### PR TITLE
fix: Block waitTillReady

### DIFF
--- a/Momento/MomentoCache.cs
+++ b/Momento/MomentoCache.cs
@@ -245,7 +245,7 @@ namespace MomentoSdk
         // Temporary measure. Till the metadata stream is up and running.
         private void WaitUntilReady()
         {
-            ByteString cacheKey = ByteString.CopyFromUtf8("1");
+            ByteString cacheKey = ByteString.CopyFromUtf8(Guid.NewGuid().ToString());
             GetRequest request = new GetRequest() { CacheKey = cacheKey };
             Exception lastError = new Exception();
             int backoffMillis = 50;


### PR DESCRIPTION
Previous implementation is async and hence the code doesn't really wait till the cache is ready.

This results in InternalServerExceptions on first Set.