### PR TITLE
fix: bad reference to error email action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -74,12 +74,13 @@ jobs:
           popd
         shell: bash
 
-      #      - name: Send CI failure mail
-      #        if: ${{ steps.validation.outcome == 'failure' }}
-      #        uses: ./.github/actions/error-email-action
-      #        with:
-      #          username: ${{secrets.MAIL_USERNAME}}
-      #          password: ${{secrets.MAIL_PASSWORD}}
-#      - name: Flag Job Failure
-#        if: ${{ steps.validation.outcome == 'failure' }}
-#        run: exit 1
+      - name: Send CI failure mail
+        if: ${{ steps.validation.outcome == 'failure' }}
+        uses: momentohq/standards-and-practices/github-actions/error-email-action@gh-actions-v1
+        with:
+          username: ${{secrets.MOMENTO_ROBOT_GMAIL_USERNAME}}
+          password: ${{secrets.MOMENTO_ROBOT_GMAIL_PASSWORD}}
+
+      - name: Flag Job Failure
+        if: ${{ steps.validation.outcome == 'failure' }}
+        run: exit 1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -67,7 +67,7 @@ jobs:
         id: validation
         continue-on-error: true
         run: |
-          pushd dotnet/MomentoExamples
+          pushd examples
             dotnet build MomentoApplication
             dotnet run --project MomentoApplication
             dotnet build MomentoApplicationPresignedUrl


### PR DESCRIPTION
The CI job uses a github action that sends e-mails to us on build failures.
That action was defined in the examples repo, and when I moved
the dotnet examples over to this repo I didn't bring that action
along, so there was a bad reference to it in the ci.yaml.

Now that action has been moved to standards-and-practices repo
so it can be shared across other projects.  This commit fixes
the reference to point to the standards-and-practices repo.
