### PR TITLE
fix: move failed precondition to correct location

### DIFF
--- a/src/Momento.Sdk/Exceptions/CacheExceptionMapper.cs
+++ b/src/Momento.Sdk/Exceptions/CacheExceptionMapper.cs
@@ -20,10 +20,11 @@ class CacheExceptionMapper
             {
                 case StatusCode.InvalidArgument:
                 case StatusCode.OutOfRange:
-                case StatusCode.FailedPrecondition:
-                    return new FailedPreconditionException(ex.Message);
                 case StatusCode.Unimplemented:
                     return new BadRequestException(ex.Message);
+
+                case StatusCode.FailedPrecondition:
+                    return new FailedPreconditionException(ex.Message);
 
                 case StatusCode.PermissionDenied:
                     return new PermissionDeniedException(ex.Message);


### PR DESCRIPTION
The failed precondition switch statement was not taking into account the switch statement fall through behavior. In the previous location, we would raise `FailedPrecondition` for `InvalidArgument` or `OutOfRange` gRPC status codes, which is not what we want.