### PR TITLE
fix: use semrel-from-release-branch workaround

### DIFF
--- a/.github/workflows/on-push-to-release-branch.yaml
+++ b/.github/workflows/on-push-to-release-branch.yaml
@@ -5,7 +5,32 @@ on:
     branches: [release]
 
 jobs:
-  build_csharp:
+  release:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.release.outputs.release }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set release
+        id: semrel
+        uses: go-semantic-release/action@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          allow-initial-development-versions: true
+          force-bump-patch-version: true
+          # For whatever reason, this silly tool won't let you do releases from branches
+          #  other than the default branch unless you pass this flag, which doesn't seem
+          #  to actually have anything to do with CI:
+          # https://github.com/go-semantic-release/semantic-release/blob/master/cmd/semantic-release/main.go#L173-L194
+          # https://github.com/go-semantic-release/condition-github/blob/4c8af3fc516151423fff2f77eb08bf7082570676/pkg/condition/github.go#L42-L44
+          custom-arguments: "--no-ci"
+
+      - name: Output release
+        id: release
+        run: echo "::set-output name=release::${{ steps.semrel.outputs.version }}"
+
+
+  test:
     runs-on: ubuntu-latest
     env:
       TEST_AUTH_TOKEN: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
@@ -16,7 +41,7 @@ jobs:
         uses: gerred/actions/current-time@master
         id: current-time
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: actions/setup-dotnet@v1
         with:
@@ -42,19 +67,34 @@ jobs:
           dotnet test tests/Integration/Momento.Sdk.Incubating.Tests
         shell: bash
 
-      - name: Set release
-        id: semrel
-        uses: go-semantic-release/action@v1
+  publish:
+    runs-on: ubuntu-latest
+    needs: [release, test]
+    env:
+      TEST_AUTH_TOKEN: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
+      TEST_CACHE_NAME: client-sdk-dotnet
+
+    steps:
+      - name: Get current time
+        uses: gerred/actions/current-time@master
+        id: current-time
+
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-dotnet@v1
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          allow-initial-development-versions: true
-          force-bump-patch-version: true
+          dotnet-version: "6.0.x"
+
+      - name: Build
+        run: |
+          dotnet build
+        shell: bash
 
       - name: Pack and Publish
         run: |
           set -x
           pushd src/Momento.Sdk
-            VERSION="${{ steps.semrel.outputs.version }}"
+            VERSION="${{ needs.release.outputs.version }}"
             echo "version: ${VERSION}"
             dotnet build --configuration Release
             dotnet pack -c Release -p:Version=${VERSION}


### PR DESCRIPTION
This ports the workaround to get semrel working on the release branch, as opposed to the main branch only.