### PR TITLE
feat: add logger to client

### DIFF
--- a/src/Momento.Sdk/Internal/DataGrpcManager.cs
+++ b/src/Momento.Sdk/Internal/DataGrpcManager.cs
@@ -3,7 +3,9 @@ using System.Collections.Generic;
 using Grpc.Core;
 using Grpc.Core.Interceptors;
 using Grpc.Net.Client;
+using Microsoft.Extensions.Logging;
 using Momento.Protos.CacheClient;
+using Momento.Sdk.Internal;
 using static System.Reflection.Assembly;
 
 namespace Momento.Sdk.Internal;
@@ -17,14 +19,16 @@ public class DataGrpcManager : IDisposable
     // Some System.Environment.Version remarks to be aware of
     // https://learn.microsoft.com/en-us/dotnet/api/system.environment.version?view=netstandard-2.0#remarks
     private readonly string runtimeVersion = "dotnet:" + System.Environment.Version;
+    private readonly ILogger _logger;
 
-    internal DataGrpcManager(string authToken, string host)
+    internal DataGrpcManager(string authToken, string host, ILoggerFactory? loggerFactory = null)
     {
         var url = $"https://{host}";
         this.channel = GrpcChannel.ForAddress(url, new GrpcChannelOptions() { Credentials = ChannelCredentials.SecureSsl });
         List<Header> headers = new List<Header> { new Header(name: Header.AuthorizationKey, value: authToken), new Header(name: Header.AgentKey, value: version), new Header(name: Header.RuntimeVersionKey, value: runtimeVersion) };
         CallInvoker invoker = this.channel.Intercept(new HeaderInterceptor(headers));
         Client = new Scs.ScsClient(invoker);
+        this._logger = Utils.CreateOrNullLogger<DataGrpcManager>(loggerFactory);
     }
 
     public void Dispose()

--- a/src/Momento.Sdk/Internal/ScsControlClient.cs
+++ b/src/Momento.Sdk/Internal/ScsControlClient.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Microsoft.Extensions.Logging;
 using Momento.Protos.ControlClient;
 using Momento.Sdk.Exceptions;
 using Momento.Sdk.Responses;
@@ -10,11 +11,13 @@ internal sealed class ScsControlClient : IDisposable
     private readonly ControlGrpcManager grpcManager;
     private readonly string authToken;
     private const uint DEADLINE_SECONDS = 60;
+    private readonly ILogger _logger;
 
-    public ScsControlClient(string authToken, string endpoint)
+    public ScsControlClient(string authToken, string endpoint, ILoggerFactory? loggerFactory = null)
     {
-        this.grpcManager = new ControlGrpcManager(authToken, endpoint);
+        this.grpcManager = new ControlGrpcManager(authToken, endpoint, loggerFactory);
         this.authToken = authToken;
+        this._logger = Utils.CreateOrNullLogger<ScsControlClient>(loggerFactory);
     }
 
     public CreateCacheResponse CreateCache(string cacheName)

--- a/src/Momento.Sdk/Internal/Utils.cs
+++ b/src/Momento.Sdk/Internal/Utils.cs
@@ -4,6 +4,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using Google.Protobuf;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Momento.Sdk.Internal
 {
@@ -112,6 +114,17 @@ namespace Momento.Sdk.Internal
         /// so comparisons operate on byte-array content instead of reference.
         /// </summary>
         public static StructuralEqualityComparer<byte[]> ByteArrayComparer = new();
+
+        /// <summary>
+        /// Create a logger using a provided factory or else use <see cref="NullLoggerFactory"/>.
+        /// </summary>
+        /// <typeparam name="T">The type for which the logger is scoped.</typeparam>
+        /// <param name="loggerFactory">The factory to use by default, otherwise <see cref="NullLoggerFactory.Instance"/>.</param>
+        /// <returns></returns>
+        public static ILogger<T> CreateOrNullLogger<T>(ILoggerFactory? loggerFactory = null)
+        {
+            return (loggerFactory ?? NullLoggerFactory.Instance).CreateLogger<T>();
+        }
     }
 
     namespace ExtensionMethods

--- a/src/Momento.Sdk/Momento.Sdk.csproj
+++ b/src/Momento.Sdk/Momento.Sdk.csproj
@@ -28,6 +28,7 @@
 		<PackageReference Include="Google.Protobuf" Version="3.19.0" />
 		<PackageReference Include="Grpc.Net.Client" Version="2.40.0" />
 		<PackageReference Include="Grpc.Core" Version="2.41.1" />
+		<PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
 		<PackageReference Include="Momento.Protos" Version="0.31.0" />
 		<PackageReference Include="JWT" Version="8.4.2" />
 		<PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.16.0" />


### PR DESCRIPTION
This PR allows the cache client to accept a `ILoggerFactory` parameter. This is used to create loggers in the cache client itself, any contained objects, and so on.

We allow the `loggerFactory` to be `null`. In this case we use the `NullLoggerFactory` singleton to create concrete loggers. Those loggers will just perform no-ops.