### PR TITLE
feat: max concurrent request middleware

### DIFF
--- a/src/Momento.Sdk/Config/Configuration.cs
+++ b/src/Momento.Sdk/Config/Configuration.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using Momento.Sdk.Config.Middleware;
 using Momento.Sdk.Config.Retry;
 using Momento.Sdk.Config.Transport;
@@ -37,5 +38,14 @@ public class Configuration : IConfiguration
     public IConfiguration WithTransportStrategy(ITransportStrategy transportStrategy)
     {
         return new Configuration(RetryStrategy, Middlewares, transportStrategy);
+    }
+
+    public Configuration WithAdditionalMiddlewares(IList<IMiddleware> additionalMiddlewares)
+    {
+        return new(
+            retryStrategy: RetryStrategy,
+            middlewares: Middlewares.Concat(additionalMiddlewares).ToList(),
+            transportStrategy: TransportStrategy
+        );
     }
 }

--- a/src/Momento.Sdk/Config/Configurations.cs
+++ b/src/Momento.Sdk/Config/Configurations.cs
@@ -28,7 +28,7 @@ public class Configurations
                 /*retryableStatusCodes = DEFAULT_RETRYABLE_STATUS_CODES,*/
                 IRetryStrategy retryStrategy = new FixedCountRetryStrategy(maxAttempts: 3);
                 ITransportStrategy transportStrategy = new StaticTransportStrategy(
-                    maxConcurrentRequests: 1,
+                    maxConcurrentRequests: 200,
                     grpcConfig: new StaticGrpcConfiguration(numChannels: 6, maxSessionMemory: 128, useLocalSubChannelPool: true, deadlineMilliseconds: DEFAULT_DEADLINE_MILLISECONDS));
                 return new Laptop(retryStrategy, transportStrategy);
             }
@@ -86,8 +86,9 @@ public class Configurations
                     /*retryableStatusCodes = DEFAULT_RETRYABLE_STATUS_CODES,*/
                     IRetryStrategy retryStrategy = new FixedCountRetryStrategy(maxAttempts: 3);
                     ITransportStrategy transportStrategy = new StaticTransportStrategy(
-                        maxConcurrentRequests: 1,
-                        grpcConfig: new StaticGrpcConfiguration(numChannels: 6, maxSessionMemory: 128, useLocalSubChannelPool: true, deadlineMilliseconds: DEFAULT_DEADLINE_MILLISECONDS));
+                        maxConcurrentRequests: 200,
+                        grpcConfig: new StaticGrpcConfiguration(numChannels: 6, maxSessionMemory: 128, useLocalSubChannelPool: true, deadlineMilliseconds: DEFAULT_DEADLINE_MILLISECONDS)
+                    );
                     return new LowLatency(retryStrategy, transportStrategy);
                 }
             }

--- a/src/Momento.Sdk/Config/Middleware/IMiddleware.cs
+++ b/src/Momento.Sdk/Config/Middleware/IMiddleware.cs
@@ -1,7 +1,33 @@
+using System;
 using System.Threading.Tasks;
+using Grpc.Core;
+using Grpc.Core.Interceptors;
 using Momento.Sdk.Config.Retry;
 
 namespace Momento.Sdk.Config.Middleware;
+
+/// <summary>
+/// Contains the state of a Response object during the life cycle of a Middleware.
+/// Middlewares may augment the Tasks herein, or call and replace the Funcs herein,
+/// to alter the response before it proceeds to the next Middleware.
+/// </summary>
+/// <typeparam name="TResponse"></typeparam>
+/// <param name="ResponseAsync">A Task that will be completed when the previous Middleware is done processing
+/// the reponse.  Middlewares may use, e.g. `.ContinueWith` to access and modify
+/// the response.</param>
+/// <param name="ResponseHeadersAsync">A Task that will be completed when the previous Middleware is done processing
+/// the reponse headers.  Middlewares may use, e.g. `.ContinueWith` to access and modify
+/// the response headers.</param>
+/// <param name="GetStatus">Returns the gRPC Status of the response.  Middlewares may override to alter
+/// the Status.</param>
+/// <param name="GetTrailers">Returns the trailers of the response.  Middlewares may override to alter
+/// the trailers.</param>
+public record struct MiddlewareResponseState<TResponse>(
+    Task<TResponse> ResponseAsync,
+    Task<Metadata> ResponseHeadersAsync,
+    Func<Status> GetStatus,
+    Func<Metadata> GetTrailers
+);
 
 /// <summary>
 /// The Middleware interface allows the Configuration to provide a higher-order function that wraps all requests.
@@ -9,15 +35,20 @@ namespace Momento.Sdk.Config.Middleware;
 /// </summary>
 public interface IMiddleware
 {
-    public delegate Task<IGrpcResponse> MiddlewareFn(IGrpcRequest request);
-
-    // TODO: this should return another delegate, ie
-    // wrapRequest(middlewareFn) -> middlewareFn
     /// <summary>
     /// Called as a wrapper around each request; can be used to time the request and collect metrics etc.
     /// </summary>
-    /// <param name="middlewareFn"></param>
+    /// <typeparam name="TRequest"></typeparam>
+    /// <typeparam name="TResponse"></typeparam>
     /// <param name="request"></param>
+    /// <param name="callOptions"></param>
+    /// <param name="continuation"></param>
     /// <returns></returns>
-    public Task<IGrpcResponse> wrapRequest(MiddlewareFn middlewareFn, IGrpcRequest request);
+    /// 
+    public Task<MiddlewareResponseState<TResponse>> WrapRequest<TRequest, TResponse>(
+        TRequest request,
+        CallOptions callOptions,
+        Func<TRequest, CallOptions, Task<MiddlewareResponseState<TResponse>>> continuation
+    );
+
 }

--- a/src/Momento.Sdk/Config/Middleware/LoggingMiddleware.cs
+++ b/src/Momento.Sdk/Config/Middleware/LoggingMiddleware.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using Grpc.Core;
+using System.Threading.Tasks;
+using Grpc.Core.Interceptors;
+
+namespace Momento.Sdk.Config.Middleware
+{
+    public class LoggingMiddleware : IMiddleware
+    {
+
+        public async Task<MiddlewareResponseState<TResponse>> WrapRequest<TRequest, TResponse>(
+            TRequest request,
+            CallOptions callOptions,
+            Func<TRequest, CallOptions, Task<MiddlewareResponseState<TResponse>>> continuation
+        )
+        {
+            Console.WriteLine($"LOGGING MIDDLEWARE WRAPPING REQUEST: {request.GetType()}");
+            var nextState = await continuation(request, callOptions);
+            Console.WriteLine($"LOGGING MIDDLEWARE WRAPPED REQUEST: {request.GetType()}");
+            return new MiddlewareResponseState<TResponse>(
+                ResponseAsync: nextState.ResponseAsync.ContinueWith(r =>
+                {
+                    Console.WriteLine($"LOGGING MIDDLEWARE RESPONSE CALLBACK: {request.GetType()}");
+                    return r.Result;
+                }),
+                ResponseHeadersAsync: nextState.ResponseHeadersAsync,
+                GetStatus: nextState.GetStatus,
+                GetTrailers: nextState.GetTrailers
+            );
+        }
+    }
+}
+

--- a/src/Momento.Sdk/Config/Middleware/PassThroughMiddleware.cs
+++ b/src/Momento.Sdk/Config/Middleware/PassThroughMiddleware.cs
@@ -1,17 +1,15 @@
+using System;
 using System.Threading.Tasks;
+using Grpc.Core;
+using Grpc.Core.Interceptors;
 using Momento.Sdk.Config.Retry;
 
 namespace Momento.Sdk.Config.Middleware;
 
 public class PassThroughMiddleware : IMiddleware
 {
-    public PassThroughMiddleware()
+    public Task<MiddlewareResponseState<TResponse>> WrapRequest<TRequest, TResponse>(TRequest request, CallOptions callOptions, Func<TRequest, CallOptions, Task<MiddlewareResponseState<TResponse>>> continuation)
     {
-
-    }
-
-    public async Task<IGrpcResponse> wrapRequest(IMiddleware.MiddlewareFn middlewareFn, IGrpcRequest request)
-    {
-        return await middlewareFn(request);
+        return continuation(request, callOptions);
     }
 }

--- a/src/Momento.Sdk/Exceptions/SdkException.cs
+++ b/src/Momento.Sdk/Exceptions/SdkException.cs
@@ -3,67 +3,68 @@ using Grpc.Core;
 
 namespace Momento.Sdk.Exceptions;
 
-public enum MomentoErrorCode {
-  /// <summary>
-  /// Invalid argument passed to Momento client
-  /// </summary>
-  INVALID_ARGUMENT_ERROR,
-  /// <summary>
-  /// Service returned an unknown response
-  /// </summary>
-  UNKNOWN_SERVICE_ERROR,
-  /// <summary>
-  /// Cache with specified name already exists
-  /// </summary>
-  ALREADY_EXISTS_ERROR,
-  /// <summary>
-  /// Cache with specified name doesn't exist
-  /// </summary>
-  NOT_FOUND_ERROR,
-  /// <summary>
-  /// An unexpected error occurred while trying to fulfill the request
-  /// </summary>
-  INTERNAL_SERVER_ERROR,
-  /// <summary>
-  /// Insufficient permissions to perform operation
-  /// </summary>
-  PERMISSION_ERROR,
-  /// <summary>
-  /// Invalid authentication credentials to connect to cache service
-  /// </summary>
-  AUTHENTICATION_ERROR,
-  /// <summary>
-  /// Request was cancelled by the server
-  /// </summary>
-  CANCELLED_ERROR,
-  /// <summary>
-  /// Request rate exceeded the limits for the account
-  /// </summary>
-  LIMIT_EXCEEDED_ERROR,
-  /// <summary>
-  /// Request was invalid
-  /// </summary>
-  BAD_REQUEST_ERROR,
-  /// <summary>
-  /// Client's configured timeout was exceeded
-  /// </summary>
-  TIMEOUT_ERROR,
-  /// <summary>
-  /// Server was unable to handle the request
-  /// </summary>
-  SERVER_UNAVAILABLE,
-  /// <summary>
-  /// A client resource (most likely memory) was exhausted
-  /// </summary>
-  CLIENT_RESOURCE_EXHAUSTED,
-  /// <summary>
-  /// System is not in a state required for the operation's execution
-  /// </summary>
-  FAILED_PRECONDITION_ERROR,
-  /// <summary>
-  /// Unknown error has occurred
-  /// </summary>
-  UNKNOWN_ERROR
+public enum MomentoErrorCode
+{
+    /// <summary>
+    /// Invalid argument passed to Momento client
+    /// </summary>
+    INVALID_ARGUMENT_ERROR,
+    /// <summary>
+    /// Service returned an unknown response
+    /// </summary>
+    UNKNOWN_SERVICE_ERROR,
+    /// <summary>
+    /// Cache with specified name already exists
+    /// </summary>
+    ALREADY_EXISTS_ERROR,
+    /// <summary>
+    /// Cache with specified name doesn't exist
+    /// </summary>
+    NOT_FOUND_ERROR,
+    /// <summary>
+    /// An unexpected error occurred while trying to fulfill the request
+    /// </summary>
+    INTERNAL_SERVER_ERROR,
+    /// <summary>
+    /// Insufficient permissions to perform operation
+    /// </summary>
+    PERMISSION_ERROR,
+    /// <summary>
+    /// Invalid authentication credentials to connect to cache service
+    /// </summary>
+    AUTHENTICATION_ERROR,
+    /// <summary>
+    /// Request was cancelled by the server
+    /// </summary>
+    CANCELLED_ERROR,
+    /// <summary>
+    /// Request rate exceeded the limits for the account
+    /// </summary>
+    LIMIT_EXCEEDED_ERROR,
+    /// <summary>
+    /// Request was invalid
+    /// </summary>
+    BAD_REQUEST_ERROR,
+    /// <summary>
+    /// Client's configured timeout was exceeded
+    /// </summary>
+    TIMEOUT_ERROR,
+    /// <summary>
+    /// Server was unable to handle the request
+    /// </summary>
+    SERVER_UNAVAILABLE,
+    /// <summary>
+    /// A client resource (most likely memory) was exhausted
+    /// </summary>
+    CLIENT_RESOURCE_EXHAUSTED,
+    /// <summary>
+    /// System is not in a state required for the operation's execution
+    /// </summary>
+    FAILED_PRECONDITION_ERROR,
+    /// <summary>
+    /// Unknown error has occurred
+    /// </summary>
+    UNKNOWN_ERROR
 }
 
 public class MomentoGrpcErrorDetails {
@@ -71,21 +72,22 @@ public class MomentoGrpcErrorDetails {
   public string Details { get; }
   public Metadata? Metadata { get; set; }
 
-  public MomentoGrpcErrorDetails(StatusCode code, string details, Metadata? metadata=null)
-  {
-    this.Code = code;
-    this.Details = details;
-    this.Metadata = metadata;
-  }
-
+    public MomentoGrpcErrorDetails(StatusCode code, string details, Metadata? metadata = null)
+    {
+        this.Code = code;
+        this.Details = details;
+        this.Metadata = metadata;
+    }
 }
 
-public class MomentoErrorTransportDetails {
-  public MomentoGrpcErrorDetails Grpc { get; }
+public class MomentoErrorTransportDetails
+{
+    public MomentoGrpcErrorDetails Grpc { get; }
 
-  public MomentoErrorTransportDetails(MomentoGrpcErrorDetails grpc) {
-    this.Grpc = grpc;
-  }
+    public MomentoErrorTransportDetails(MomentoGrpcErrorDetails grpc)
+    {
+        this.Grpc = grpc;
+    }
 }
 
 public abstract class SdkException : Exception
@@ -94,7 +96,7 @@ public abstract class SdkException : Exception
     public MomentoErrorTransportDetails? TransportDetails { get; }
     public string MessageWrapper { get; set; }
 
-    protected SdkException(MomentoErrorCode errorCode, string message, MomentoErrorTransportDetails? transportDetails=null, Exception? e=null) : base(message, e)
+    protected SdkException(MomentoErrorCode errorCode, string message, MomentoErrorTransportDetails? transportDetails = null, Exception? e = null) : base(message, e)
     {
       this.ErrorCode = errorCode;
       this.TransportDetails = transportDetails;

--- a/src/Momento.Sdk/Internal/DataGrpcManager.cs
+++ b/src/Momento.Sdk/Internal/DataGrpcManager.cs
@@ -1,19 +1,97 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using Grpc.Core;
 using Grpc.Core.Interceptors;
 using Grpc.Net.Client;
 using Microsoft.Extensions.Logging;
 using Momento.Protos.CacheClient;
-using Momento.Sdk.Internal;
+using Momento.Sdk.Config;
+using Momento.Sdk.Config.Middleware;
+using Momento.Sdk.Internal.Middleware;
 using static System.Reflection.Assembly;
+using static Grpc.Core.Interceptors.Interceptor;
 
 namespace Momento.Sdk.Internal;
+
+public interface IDataClient
+{
+    public Task<_GetResponse> GetAsync(_GetRequest request, CallOptions callOptions);
+    public Task<_SetResponse> SetAsync(_SetRequest request, CallOptions callOptions);
+    public Task<_DeleteResponse> DeleteAsync(_DeleteRequest request, CallOptions callOptions);
+}
+
+
+// Ideally we would implement our middleware based on gRPC Interceptors.  Unfortunately,
+// the their method signatures are not asynchronous. Thus, for any middleware that may
+// require asynchronous actions (such as our MaxConcurrentRequestsMiddleware), we would
+// end up blocking threads to wait for the completion of the async task, which would have
+// a big negative impact on performance. Instead, in this commit, we implement a thin
+// middleware layer of our own that uses asynchronous signatures throughout.  This has
+// the nice side effect of making the user-facing API for writing Middlewares a bit less
+// of a learning curve for anyone not super deep on gRPC internals.
+internal class DataClientWithMiddleware : IDataClient
+{
+    private readonly IList<IMiddleware> _middlewares;
+    private readonly Scs.ScsClient _generatedClient;
+
+    public DataClientWithMiddleware(Scs.ScsClient generatedClient, IList<IMiddleware> middlewares)
+    {
+        _generatedClient = generatedClient;
+        _middlewares = middlewares;
+    }
+
+    public async Task<_DeleteResponse> DeleteAsync(_DeleteRequest request, CallOptions callOptions)
+    {
+        var wrapped = await WrapWithMiddleware(request, callOptions, (r, o) => _generatedClient.DeleteAsync(r, o));
+        return await wrapped.ResponseAsync;
+    }
+
+    public async Task<_GetResponse> GetAsync(_GetRequest request, CallOptions callOptions)
+    {
+        var wrapped = await WrapWithMiddleware(request, callOptions, (r, o) => _generatedClient.GetAsync(r, o));
+        return await wrapped.ResponseAsync;
+    }
+
+    public async Task<_SetResponse> SetAsync(_SetRequest request, CallOptions callOptions)
+    {
+        var wrapped = await WrapWithMiddleware(request, callOptions, (r, o) => _generatedClient.SetAsync(r, o));
+        return await wrapped.ResponseAsync;
+    }
+
+
+    private async Task<MiddlewareResponseState<TResponse>> WrapWithMiddleware<TRequest, TResponse>(
+        TRequest request,
+        CallOptions callOptions,
+        Func<TRequest, CallOptions, AsyncUnaryCall<TResponse>> continuation
+    )
+    {
+        Func<TRequest, CallOptions, Task<MiddlewareResponseState<TResponse>>> continuationWithMiddlewareResponseState = (r, o) =>
+        {
+            var result = continuation(r, o);
+            return Task.FromResult(new MiddlewareResponseState<TResponse>(
+                ResponseAsync: result.ResponseAsync,
+                ResponseHeadersAsync: result.ResponseHeadersAsync,
+                GetStatus: result.GetStatus,
+                GetTrailers: result.GetTrailers
+            ));
+        };
+
+        var wrapped = _middlewares.Aggregate(continuationWithMiddlewareResponseState, (acc, middleware) =>
+        {
+            return (r, o) => middleware.WrapRequest(r, o, acc);
+        });
+        return await wrapped(request, callOptions);
+    }
+}
 
 public class DataGrpcManager : IDisposable
 {
     private readonly GrpcChannel channel;
-    public Scs.ScsClient Client { get; }
+
+    public readonly IDataClient Client;
 
     private readonly string version = "dotnet:" + GetAssembly(typeof(Momento.Sdk.Responses.CacheGetResponse)).GetName().Version.ToString();
     // Some System.Environment.Version remarks to be aware of
@@ -21,14 +99,19 @@ public class DataGrpcManager : IDisposable
     private readonly string runtimeVersion = "dotnet:" + System.Environment.Version;
     private readonly ILogger _logger;
 
-    internal DataGrpcManager(string authToken, string host, ILoggerFactory? loggerFactory = null)
+    internal DataGrpcManager(IConfiguration config, string authToken, string host, ILoggerFactory? loggerFactory = null)
     {
         var url = $"https://{host}";
         this.channel = GrpcChannel.ForAddress(url, new GrpcChannelOptions() { Credentials = ChannelCredentials.SecureSsl });
         List<Header> headers = new List<Header> { new Header(name: Header.AuthorizationKey, value: authToken), new Header(name: Header.AgentKey, value: version), new Header(name: Header.RuntimeVersionKey, value: runtimeVersion) };
-        CallInvoker invoker = this.channel.Intercept(new HeaderInterceptor(headers));
-        Client = new Scs.ScsClient(invoker);
         this._logger = Utils.CreateOrNullLogger<DataGrpcManager>(loggerFactory);
+        CallInvoker invoker = this.channel.Intercept(new HeaderInterceptor(headers));
+        
+        var middlewares = config.Middlewares.Concat(
+            new List<IMiddleware> { new MaxConcurrentRequestsMiddleware(config.TransportStrategy.MaxConcurrentRequests) }
+        ).ToList();
+
+        Client = new DataClientWithMiddleware(new Scs.ScsClient(invoker), middlewares);
     }
 
     public void Dispose()

--- a/src/Momento.Sdk/Internal/Middleware/FairAsyncSemaphore.cs
+++ b/src/Momento.Sdk/Internal/Middleware/FairAsyncSemaphore.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+
+namespace Momento.Sdk.Internal.Middleware
+{
+    // A very simplistic implementation of a semaphore that is based on .NET
+    // async channels.  This is used for our MaxConcurrentRequestsMiddleware.
+    // Channel read and write requests exhibit some degree
+    // of fairness, which ensures that we don't starve requests if the
+    // user exceeds the maximum number of concurrent requests.
+    internal class FairAsyncSemaphore
+    {
+        private readonly Channel<bool> _ticketChannel;
+
+        internal FairAsyncSemaphore(int numTickets)
+        {
+            _ticketChannel = Channel.CreateBounded<bool>(numTickets);
+
+            for (var i = 0; i < numTickets; i++)
+            {
+                bool success = _ticketChannel.Writer.TryWrite(true);
+                if (!success)
+                {
+                    throw new ApplicationException("Unable to initialize async channel");
+                }
+            }
+        }
+
+        public async Task WaitOne()
+        {
+            await _ticketChannel.Reader.ReadAsync();
+        }
+
+        public void Release()
+        {
+            var balanced = _ticketChannel.Writer.TryWrite(true);
+            if (!balanced)
+            {
+                throw new ApplicationException("more releases than waits! These must be 1:1");
+            }
+        }
+    }
+}
+

--- a/src/Momento.Sdk/Internal/Middleware/MaxConcurrentRequestsMiddleware.cs
+++ b/src/Momento.Sdk/Internal/Middleware/MaxConcurrentRequestsMiddleware.cs
@@ -1,0 +1,61 @@
+﻿using Google.Protobuf.WellKnownTypes;
+using Grpc.Core;
+using Momento.Sdk.Config.Middleware;
+using System;
+using System.Drawing;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace Momento.Sdk.Internal.Middleware
+{
+    //
+    // During tuning, I discovered that the.NET grpc library behaves differently
+    // than the others I'd previously tested.  Specifically, it will detect whenever
+    // your number of concurrent requests exceeds a multiple of 100 and open a new
+    // connection to the server when it does. Thus, in my loadgen scenario where I
+    // was executing 5000 concurrent requests, the library would end up opening
+    // on the order of 50 connections to the server.
+    //
+    // This behavior is undesirable for both the client and server, depending on
+    // the network bandwidth available between the two.  Specifically, in a laptop
+    // environment, throughput and latency both decrease when you exceed about 200
+    // concurrent requests, so there is no value in opening so many additional
+    // connections to the server and this could cause server-side throttling/load shedding.
+    //
+    // In later versions of .NET it appears that this behavior may be configurable:
+    // https://learn.microsoft.com/en-us/aspnet/core/grpc/performance?view=aspnetcore-6.0#connection-concurrency
+    // But in the older version that we are targeting it is not.
+    //
+    // Therefore we use an async semaphore to restrict the maximum number of
+    // concurrent requests.Setting this to 200 in the laptop environment results
+    // in far fewer connections, and throughput and latency for the happy path
+    // cases are unaffected. For the degenerate case (5000+ concurrent requests),
+    // this protects the server and actually seems to improve client-side p999
+    // latencies by quite a bit.
+    public class MaxConcurrentRequestsMiddleware : IMiddleware
+    {
+        private readonly FairAsyncSemaphore _semaphore;
+
+        public MaxConcurrentRequestsMiddleware(int maxConcurrentRequests)
+        {
+            _semaphore = new FairAsyncSemaphore(maxConcurrentRequests);
+        }
+
+        public async Task<MiddlewareResponseState<TResponse>> WrapRequest<TRequest, TResponse>(TRequest request, CallOptions callOptions, Func<TRequest, CallOptions, Task<MiddlewareResponseState<TResponse>>> continuation)
+        {
+            await _semaphore.WaitOne();
+            try
+            {
+                var result = await continuation(request, callOptions);
+                // ensure that we don't return (and release the semaphore) until the response task is complete
+                await result.ResponseAsync;
+                return result;
+            }
+            finally
+            {
+                _semaphore.Release();
+            }
+        }
+    }
+}
+

--- a/src/Momento.Sdk/Momento.Sdk.csproj
+++ b/src/Momento.Sdk/Momento.Sdk.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<!-- Build Configuration -->
-		<TargetFramework>netstandard2.0</TargetFramework>
+		<TargetFramework>netstandard2.1</TargetFramework>
 		<LangVersion>latest</LangVersion>
 		<Nullable>enable</Nullable>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -32,5 +32,13 @@
 		<PackageReference Include="Momento.Protos" Version="0.31.0" />
 		<PackageReference Include="JWT" Version="8.4.2" />
 		<PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.16.0" />
+		<PackageReference Include="System.Threading.Channels" Version="6.0.0" />
+	</ItemGroup>
+	<ItemGroup>
+	  <None Remove="System.Threading.Channels" />
+	  <None Remove="Internal\Middleware\" />
+	</ItemGroup>
+	<ItemGroup>
+	  <Folder Include="Internal\Middleware\" />
 	</ItemGroup>
 </Project>

--- a/src/Momento.Sdk/Responses/CreateCacheResponse.cs
+++ b/src/Momento.Sdk/Responses/CreateCacheResponse.cs
@@ -2,11 +2,12 @@
 
 using Momento.Sdk.Exceptions;
 
-public abstract class CreateCacheResponse {
+public abstract class CreateCacheResponse
+{
 
     public class Success : CreateCacheResponse { }
 
-    public class Error: CreateCacheResponse
+    public class Error : CreateCacheResponse
     {
         private readonly SdkException _error;
         public Error(SdkException error)
@@ -19,7 +20,8 @@ public abstract class CreateCacheResponse {
             get => _error;
         }
 
-        public MomentoErrorCode ErrorCode {
+        public MomentoErrorCode ErrorCode
+        {
             get => _error.ErrorCode;
         }
 

--- a/src/Momento.Sdk/Responses/DeleteCacheResponse.cs
+++ b/src/Momento.Sdk/Responses/DeleteCacheResponse.cs
@@ -7,7 +7,7 @@ public abstract class DeleteCacheResponse
 
     public class Success : DeleteCacheResponse { }
 
-    public class Error: DeleteCacheResponse
+    public class Error : DeleteCacheResponse
     {
         private readonly SdkException _error;
         public Error(SdkException error)

--- a/src/Momento.Sdk/SimpleCacheClient.cs
+++ b/src/Momento.Sdk/SimpleCacheClient.cs
@@ -37,8 +37,7 @@ public class SimpleCacheClient : ISimpleCacheClient
         Claims claims = JwtUtils.DecodeJwt(authToken);
 
         this.controlClient = new(authToken, claims.ControlEndpoint, loggerFactory);
-        
-        this.dataClient = new(authToken, claims.CacheEndpoint, defaultTtlSeconds, config.TransportStrategy.GrpcConfig.DeadlineMilliseconds, loggerFactory);
+        this.dataClient = new(config, authToken, claims.CacheEndpoint, defaultTtlSeconds, loggerFactory);
     }
 
     /// <inheritdoc />

--- a/tests/Integration/Momento.Sdk.Tests/SimpleCacheControlTest.cs
+++ b/tests/Integration/Momento.Sdk.Tests/SimpleCacheControlTest.cs
@@ -64,7 +64,8 @@ public class SimpleCacheControlTest
 
         // Test cache exists
         ListCachesResponse result = client.ListCaches();
-        if (result is ListCachesResponse.Success successResult) {
+        if (result is ListCachesResponse.Success successResult)
+        {
             List<CacheInfo> caches = successResult.Caches;
             Assert.Contains(new CacheInfo(cacheName), caches);
         }
@@ -72,7 +73,8 @@ public class SimpleCacheControlTest
         // Test deleting cache
         client.DeleteCache(cacheName);
         result = client.ListCaches();
-        if (result is ListCachesResponse.Success successResult2) {
+        if (result is ListCachesResponse.Success successResult2)
+        {
             var caches = successResult2.Caches;
             Assert.DoesNotContain(new CacheInfo(cacheName), caches);
         }
@@ -97,7 +99,8 @@ public class SimpleCacheControlTest
         ListCachesResponse result = client.ListCaches();
         while (true)
         {
-            if (result is ListCachesResponse.Success successResult) {
+            if (result is ListCachesResponse.Success successResult)
+            {
                 foreach (CacheInfo cache in successResult.Caches)
                 {
                     retrievedCaches.Add(cache.Name);


### PR DESCRIPTION
During tuning, I discovered that the .NET grpc library behaves differently than the others I'd previously tested w/rt connections opened to the server.  Specifically, it will detect whenever your number of concurrent requests exceeds a multiple of 100 and open a new connection to the server when it does.  Thus, in my loadgen scenario where I was executing 5000 concurrent requests, the library would end up opening on the order of 50 connections to the server.

This behavior is undesirable for both the client and server, depending on the network bandwidth available between the two.  Specifically, in a laptop environment, throughput and latency both decrease when you exceed about 200 concurrent requests, so there is no value in opening so many additional connections to the server and this could cause server-side throttling/load shedding.

In this commit we introduce a new middleware that can restrict the maximum number of concurrent requests.  Setting this to 200 in the laptop environment results in far fewer connections, and throughput and latency for the happy path cases are unaffected. For the degenerate case (5000+ concurrent requests), this protects the server and actually seems to improve client-side p999 latencies by quite a bit.

Note that as part of this commit I needed to re-work the middleware layer.  We can't rely directly on using gRPC Interceptors for this, because their method signatures are not asynchronous.  Thus, we would end up blocking threads to wait for any kind of semaphore, which would have a big negative impact on performance.  Instead, in this commit, we move the middleware layer to some code that we own ourselves so that we are able to use async method signatures.