### PR TITLE
chore: LoggerFactory should only be nullable for public-facing classes

### DIFF
--- a/src/Momento.Sdk/Config/Configurations.cs
+++ b/src/Momento.Sdk/Config/Configurations.cs
@@ -7,8 +7,6 @@ namespace Momento.Sdk.Config;
 
 public class Configurations
 {
-    public static readonly uint DEFAULT_DEADLINE_MILLISECONDS = 5000;
-
     /// <summary>
     /// Laptop config provides defaults suitable for a medium-to-high-latency dev environment.  Permissive timeouts, retries, potentially
     /// a higher number of connections, etc.
@@ -29,7 +27,7 @@ public class Configurations
                 IRetryStrategy retryStrategy = new FixedCountRetryStrategy(maxAttempts: 3);
                 ITransportStrategy transportStrategy = new StaticTransportStrategy(
                     maxConcurrentRequests: 200,
-                    grpcConfig: new StaticGrpcConfiguration(numChannels: 6, maxSessionMemory: 128, useLocalSubChannelPool: true, deadlineMilliseconds: DEFAULT_DEADLINE_MILLISECONDS));
+                    grpcConfig: new StaticGrpcConfiguration(numChannels: 6, maxSessionMemory: 128, useLocalSubChannelPool: true, deadlineMilliseconds: 5000));
                 return new Laptop(retryStrategy, transportStrategy);
             }
         }
@@ -60,7 +58,8 @@ public class Configurations
                     IRetryStrategy retryStrategy = new FixedCountRetryStrategy(maxAttempts: 3);
                     ITransportStrategy transportStrategy = new StaticTransportStrategy(
                         maxConcurrentRequests: 1,
-                        grpcConfig: new StaticGrpcConfiguration(numChannels: 6, maxSessionMemory: 128, useLocalSubChannelPool: true, deadlineMilliseconds: DEFAULT_DEADLINE_MILLISECONDS));
+                        // TODO: tune the timeout value
+                        grpcConfig: new StaticGrpcConfiguration(numChannels: 6, maxSessionMemory: 128, useLocalSubChannelPool: true, deadlineMilliseconds: 1000));
                     return new Default(retryStrategy, transportStrategy);
                 }
             }
@@ -87,7 +86,8 @@ public class Configurations
                     IRetryStrategy retryStrategy = new FixedCountRetryStrategy(maxAttempts: 3);
                     ITransportStrategy transportStrategy = new StaticTransportStrategy(
                         maxConcurrentRequests: 200,
-                        grpcConfig: new StaticGrpcConfiguration(numChannels: 6, maxSessionMemory: 128, useLocalSubChannelPool: true, deadlineMilliseconds: DEFAULT_DEADLINE_MILLISECONDS)
+                        // TODO: tune the timeout value
+                        grpcConfig: new StaticGrpcConfiguration(numChannels: 6, maxSessionMemory: 128, useLocalSubChannelPool: true, deadlineMilliseconds: 1000)
                     );
                     return new LowLatency(retryStrategy, transportStrategy);
                 }

--- a/src/Momento.Sdk/Config/Middleware/LoggingMiddleware.cs
+++ b/src/Momento.Sdk/Config/Middleware/LoggingMiddleware.cs
@@ -2,11 +2,22 @@
 using Grpc.Core;
 using System.Threading.Tasks;
 using Grpc.Core.Interceptors;
+using Microsoft.Extensions.Logging;
 
 namespace Momento.Sdk.Config.Middleware
 {
+    /// <summary>
+    /// Basic middleware that logs at debug level for each request/response.  This
+    /// is mostly provided as an example of how to implement middlewares.
+    /// </summary>
     public class LoggingMiddleware : IMiddleware
     {
+        private readonly ILogger _logger;
+
+        public LoggingMiddleware(ILoggerFactory loggerFactory)
+        {
+            _logger = loggerFactory.CreateLogger<LoggingMiddleware>();
+        }
 
         public async Task<MiddlewareResponseState<TResponse>> WrapRequest<TRequest, TResponse>(
             TRequest request,
@@ -14,13 +25,12 @@ namespace Momento.Sdk.Config.Middleware
             Func<TRequest, CallOptions, Task<MiddlewareResponseState<TResponse>>> continuation
         )
         {
-            Console.WriteLine($"LOGGING MIDDLEWARE WRAPPING REQUEST: {request.GetType()}");
+            _logger.LogDebug("Executing request of type: {}", request?.GetType());
             var nextState = await continuation(request, callOptions);
-            Console.WriteLine($"LOGGING MIDDLEWARE WRAPPED REQUEST: {request.GetType()}");
             return new MiddlewareResponseState<TResponse>(
                 ResponseAsync: nextState.ResponseAsync.ContinueWith(r =>
                 {
-                    Console.WriteLine($"LOGGING MIDDLEWARE RESPONSE CALLBACK: {request.GetType()}");
+                    _logger.LogDebug("Got response for request of type: {}", request?.GetType());
                     return r.Result;
                 }),
                 ResponseHeadersAsync: nextState.ResponseHeadersAsync,

--- a/src/Momento.Sdk/Internal/ControlGrpcManager.cs
+++ b/src/Momento.Sdk/Internal/ControlGrpcManager.cs
@@ -20,14 +20,14 @@ internal sealed class ControlGrpcManager : IDisposable
     private readonly string runtimeVersion = "dotnet:" + System.Environment.Version;
     private readonly ILogger _logger;
 
-    public ControlGrpcManager(string authToken, string endpoint, ILoggerFactory? loggerFactory = null)
+    public ControlGrpcManager(string authToken, string endpoint, ILoggerFactory loggerFactory)
     {
         var uri = $"https://{endpoint}";
         this.channel = GrpcChannel.ForAddress(uri, new GrpcChannelOptions() { Credentials = ChannelCredentials.SecureSsl });
         List<Header> headers = new List<Header> { new Header(name: Header.AuthorizationKey, value: authToken), new Header(name: Header.AgentKey, value: version), new Header(name: Header.RuntimeVersionKey, value: runtimeVersion) };
         CallInvoker invoker = channel.Intercept(new HeaderInterceptor(headers));
         Client = new ScsControl.ScsControlClient(invoker);
-        this._logger = Utils.CreateOrNullLogger<ControlGrpcManager>(loggerFactory);
+        this._logger = loggerFactory.CreateLogger<ControlGrpcManager>();
     }
 
     public void Dispose()

--- a/src/Momento.Sdk/Internal/DataGrpcManager.cs
+++ b/src/Momento.Sdk/Internal/DataGrpcManager.cs
@@ -99,12 +99,12 @@ public class DataGrpcManager : IDisposable
     private readonly string runtimeVersion = "dotnet:" + System.Environment.Version;
     private readonly ILogger _logger;
 
-    internal DataGrpcManager(IConfiguration config, string authToken, string host, ILoggerFactory? loggerFactory = null)
+    internal DataGrpcManager(IConfiguration config, string authToken, string host, ILoggerFactory loggerFactory)
     {
         var url = $"https://{host}";
         this.channel = GrpcChannel.ForAddress(url, new GrpcChannelOptions() { Credentials = ChannelCredentials.SecureSsl });
         List<Header> headers = new List<Header> { new Header(name: Header.AuthorizationKey, value: authToken), new Header(name: Header.AgentKey, value: version), new Header(name: Header.RuntimeVersionKey, value: runtimeVersion) };
-        this._logger = Utils.CreateOrNullLogger<DataGrpcManager>(loggerFactory);
+        this._logger = loggerFactory.CreateLogger<DataGrpcManager>();
         CallInvoker invoker = this.channel.Intercept(new HeaderInterceptor(headers));
         
         var middlewares = config.Middlewares.Concat(

--- a/src/Momento.Sdk/Internal/ScsControlClient.cs
+++ b/src/Momento.Sdk/Internal/ScsControlClient.cs
@@ -13,11 +13,11 @@ internal sealed class ScsControlClient : IDisposable
     private const uint DEADLINE_SECONDS = 60;
     private readonly ILogger _logger;
 
-    public ScsControlClient(string authToken, string endpoint, ILoggerFactory? loggerFactory = null)
+    public ScsControlClient(string authToken, string endpoint, ILoggerFactory loggerFactory)
     {
         this.grpcManager = new ControlGrpcManager(authToken, endpoint, loggerFactory);
         this.authToken = authToken;
-        this._logger = Utils.CreateOrNullLogger<ScsControlClient>(loggerFactory);
+        this._logger = loggerFactory.CreateLogger<ScsControlClient>();
     }
 
     public CreateCacheResponse CreateCache(string cacheName)

--- a/src/Momento.Sdk/Internal/ScsDataClient.cs
+++ b/src/Momento.Sdk/Internal/ScsDataClient.cs
@@ -22,12 +22,12 @@ public class ScsDataClientBase : IDisposable
     protected readonly uint dataClientOperationTimeoutMilliseconds;
     protected readonly ILogger _logger;
 
-    public ScsDataClientBase(IConfiguration config, string authToken, string endpoint, uint defaultTtlSeconds, ILoggerFactory? loggerFactory = null)
+    public ScsDataClientBase(IConfiguration config, string authToken, string endpoint, uint defaultTtlSeconds, ILoggerFactory loggerFactory)
     {
         this.grpcManager = new(config, authToken, endpoint, loggerFactory);
         this.defaultTtlSeconds = defaultTtlSeconds;
         this.dataClientOperationTimeoutMilliseconds = config.TransportStrategy.GrpcConfig.DeadlineMilliseconds;
-        this._logger = Utils.CreateOrNullLogger<ScsDataClient>(loggerFactory);
+        this._logger = loggerFactory.CreateLogger<ScsDataClient>();
     }
 
     protected Metadata MetadataWithCache(string cacheName)
@@ -57,7 +57,7 @@ public class ScsDataClientBase : IDisposable
 
 internal sealed class ScsDataClient : ScsDataClientBase
 {
-    public ScsDataClient(IConfiguration config, string authToken, string endpoint, uint defaultTtlSeconds, ILoggerFactory? loggerFactory = null)
+    public ScsDataClient(IConfiguration config, string authToken, string endpoint, uint defaultTtlSeconds, ILoggerFactory loggerFactory)
         : base(config, authToken, endpoint, defaultTtlSeconds, loggerFactory)
     {
 

--- a/src/Momento.Sdk/Internal/Utils.cs
+++ b/src/Momento.Sdk/Internal/Utils.cs
@@ -114,17 +114,6 @@ namespace Momento.Sdk.Internal
         /// so comparisons operate on byte-array content instead of reference.
         /// </summary>
         public static StructuralEqualityComparer<byte[]> ByteArrayComparer = new();
-
-        /// <summary>
-        /// Create a logger using a provided factory or else use <see cref="NullLoggerFactory"/>.
-        /// </summary>
-        /// <typeparam name="T">The type for which the logger is scoped.</typeparam>
-        /// <param name="loggerFactory">The factory to use by default, otherwise <see cref="NullLoggerFactory.Instance"/>.</param>
-        /// <returns></returns>
-        public static ILogger<T> CreateOrNullLogger<T>(ILoggerFactory? loggerFactory = null)
-        {
-            return (loggerFactory ?? NullLoggerFactory.Instance).CreateLogger<T>();
-        }
     }
 
     namespace ExtensionMethods

--- a/src/Momento.Sdk/SimpleCacheClient.cs
+++ b/src/Momento.Sdk/SimpleCacheClient.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Momento.Sdk.Config;
 using Momento.Sdk.Exceptions;
 using Momento.Sdk.Internal;
@@ -32,12 +33,13 @@ public class SimpleCacheClient : ISimpleCacheClient
     public SimpleCacheClient(IConfiguration config, string authToken, uint defaultTtlSeconds, ILoggerFactory? loggerFactory = null)
     {
         this.config = config;
-        this._logger = Utils.CreateOrNullLogger<SimpleCacheClient>(loggerFactory);
+        var _loggerFactory = loggerFactory ?? NullLoggerFactory.Instance;
+        this._logger = _loggerFactory.CreateLogger<SimpleCacheClient>();
         ValidateRequestTimeout(config.TransportStrategy.GrpcConfig.DeadlineMilliseconds);
         Claims claims = JwtUtils.DecodeJwt(authToken);
 
-        this.controlClient = new(authToken, claims.ControlEndpoint, loggerFactory);
-        this.dataClient = new(config, authToken, claims.CacheEndpoint, defaultTtlSeconds, loggerFactory);
+        this.controlClient = new(authToken, claims.ControlEndpoint, _loggerFactory);
+        this.dataClient = new(config, authToken, claims.CacheEndpoint, defaultTtlSeconds, _loggerFactory);
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
For internal classes we want to make it a required argument, so that we don't ever mistakenly omit it.