### PR TITLE
chore: remove pre-built config aliases

### DIFF
--- a/src/Momento.Sdk/Config/Configurations.cs
+++ b/src/Momento.Sdk/Config/Configurations.cs
@@ -94,11 +94,4 @@ public class Configurations
             }
         }
     }
-
-    /// <inheritDoc cref="Laptop" />
-    public static readonly IConfiguration DevConfig = Laptop.Latest;
-    /// <inheritDoc cref="InRegion.Default" />
-    public static readonly IConfiguration ProdConfig = InRegion.Default.Latest;
-    /// <inheritDoc cref="InRegion.LowLatency" />    
-    public static readonly IConfiguration ProdLowLatencyConfig = InRegion.LowLatency.Latest;
 }


### PR DESCRIPTION
In the dogfood test, these aliases were reported more confusing than helpful. Thus we are removing them.

Closes #219