### PR TITLE
chore: use snupkg format

### DIFF
--- a/src/Momento.Sdk/Momento.Sdk.csproj
+++ b/src/Momento.Sdk/Momento.Sdk.csproj
@@ -9,6 +9,7 @@
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<!-- Include source and debug symbols-->
 		<IncludeSource>true</IncludeSource>
+		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
 		<IncludeSymbols>true</IncludeSymbols>
 		<!-- TODO: Address public-facing documentation -->
 		<NoWarn>1591</NoWarn>


### PR DESCRIPTION
The recommended `SymbolPackageFormat` is `snupkg`. The default is
deprecated. See the note here: https://learn.microsoft.com/en-us/nuget/create-packages/symbol-packages-snupkg