### PR TITLE
chore: response pattern matching doc comments

### DIFF
--- a/src/Momento.Sdk/ISimpleCacheClient.cs
+++ b/src/Momento.Sdk/ISimpleCacheClient.cs
@@ -15,21 +15,69 @@ public interface ISimpleCacheClient : IDisposable
     /// Creates a cache if it doesn't exist.
     /// </summary>
     /// <param name="cacheName">Name of the cache to be created.</param>
-    /// <returns>Task representing the result of the create cache operation</returns>
+    /// <returns>
+    /// Task representing the result of the create cache operation. This result
+    /// is resolved to a type-safe object of one of
+    /// the following subtypes:
+    /// <list type="bullet">
+    /// <item><description>CreateCacheResponse.Success</description></item>
+    /// <item><description>CreateCacheResponse.Error</description></item>
+    /// </list>
+    /// Pattern matching can be used to operate on the appropriate subtype.
+    /// For example:
+    /// <code>
+    /// if (response is CreateCacheResponse.Error errorResponse)
+    /// {
+    ///     // handle error as appropriate
+    /// }
+    /// </code>
+    /// </returns>
     public Task<CreateCacheResponse> CreateCacheAsync(string cacheName);
 
     /// <summary>
     /// Deletes a cache and all of the items within it.
     /// </summary>
     /// <param name="cacheName">Name of the cache to be deleted.</param>
-    /// <returns>Task representing the result of the delete cache operation.</returns>
+    /// <returns>
+    /// Task representing the result of the delete cache operation. The
+    /// response object is resolved to a type-safe object of one of
+    /// the following subtypes:
+    /// <list type="bullet">
+    /// <item><description>DeleteCacheResponse.Success</description></item>
+    /// <item><description>DeleteCacheResponse.Error</description></item>
+    /// </list>
+    /// Pattern matching can be used to operate on the appropriate subtype.
+    /// For example:
+    /// <code>
+    /// if (response is DeleteCacheResponse.Error errorResponse)
+    /// {
+    ///     // handle error as appropriate
+    /// }
+    /// </code>
+    ///</returns>
     public Task<DeleteCacheResponse> DeleteCacheAsync(string cacheName);
 
     /// <summary>
     /// List all caches.
     /// </summary>
     /// <param name="nextPageToken">A token to specify where to start paginating. This is the NextToken from a previous response.</param>
-    /// <returns>Task representing the result of the list cache operation.</returns>
+    /// <returns>
+    /// Task representing the result of the list cache operation. The
+    /// response object is resolved to a type-safe object of one of
+    /// the following subtypes:
+    /// <list type="bullet">
+    /// <item><description>ListCachesResponse.Success</description></item>
+    /// <item><description>ListCachesResponse.Error</description></item>
+    /// </list>
+    /// Pattern matching can be used to operate on the appropriate subtype.
+    /// For example:
+    /// <code>
+    /// if (response is ListCachesResponse.Error errorResponse)
+    /// {
+    ///     // handle error as appropriate
+    /// }
+    /// </code>
+    /// </returns>
     public Task<ListCachesResponse> ListCachesAsync(string? nextPageToken = null);
 
     /// <summary>
@@ -39,7 +87,23 @@ public interface ISimpleCacheClient : IDisposable
     /// <param name="key">The key to set.</param>
     /// <param name="value">The value to be stored.</param>
     /// <param name="ttlSeconds">TTL for the item in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.</param>
-    /// <returns>Task object representing the result of the set operation.</returns>
+    /// <returns>
+    /// Task object representing the result of the set operation. The
+    /// response object is resolved to a type-safe object of one of
+    /// the following subtypes:
+    /// <list type="bullet">
+    /// <item><description>CacheSetResponse.Success</description></item>
+    /// <item><description>CacheSetResponse.Error</description></item>
+    /// </list>
+    /// Pattern matching can be used to operate on the appropriate subtype.
+    /// For example:
+    /// <code>
+    /// if (response is CacheSetResponse.Error errorResponse)
+    /// {
+    ///     // handle error as appropriate
+    /// }
+    /// </code>
+    /// </returns>
     public Task<CacheSetResponse> SetAsync(string cacheName, byte[] key, byte[] value, uint? ttlSeconds = null);
 
     /// <summary>
@@ -47,7 +111,27 @@ public interface ISimpleCacheClient : IDisposable
     /// </summary>
     /// <param name="cacheName">Name of the cache to perform the lookup in.</param>
     /// <param name="key">The key to lookup.</param>
-    /// <returns>Task object containing the status of the get operation and the associated value.</returns>
+    /// <returns>
+    /// Task object containing the status of the get operation and the associated value. The
+    /// response object is resolved to a type-safe object of one of
+    /// the following subtypes:
+    /// <list type="bullet">
+    /// <item><description>CacheGetResponse.Hit</description></item>
+    /// <item><description>CacheGetResponse.Miss</description></item>
+    /// <item><description>CacheGetResponse.Error</description></item>
+    /// </list>
+    /// Pattern matching can be used to operate on the appropriate subtype.
+    /// For example:
+    /// <code>
+    /// if (response is CacheGetResponse.Hit hitResponse)
+    /// {
+    ///     return hitResponse.String();
+    /// } else if (response is CacheGetResponse.Error errorResponse)
+    /// {
+    ///     // handle error as appropriate
+    /// }
+    /// </code>
+    /// </returns>
     public Task<CacheGetResponse> GetAsync(string cacheName, byte[] key);
 
     /// <summary>
@@ -55,7 +139,23 @@ public interface ISimpleCacheClient : IDisposable
     /// </summary>
     /// <param name="cacheName">Name of the cache to delete the key from.</param>
     /// <param name="key">The key to delete.</param>
-    /// <returns>Task object representing the result of the delete operation.</returns>
+    /// <returns>
+    /// Task object representing the result of the delete operation. The
+    /// response object is resolved to a type-safe object of one of
+    /// the following subtypes:
+    /// <list type="bullet">
+    /// <item><description>CacheDeleteResponse.Success</description></item>
+    /// <item><description>CacheDeleteResponse.Error</description></item>
+    /// </list>
+    /// Pattern matching can be used to operate on the appropriate subtype.
+    /// For example:
+    /// <code>
+    /// if (response is CacheDeleteResponse.Error errorResponse)
+    /// {
+    ///     // handle error as appropriate
+    /// }
+    /// </code>
+    /// </returns>
     public Task<CacheDeleteResponse> DeleteAsync(string cacheName, byte[] key);
 
     /// <inheritdoc cref="SetAsync(string, byte[], byte[], uint?)"/>

--- a/src/Momento.Sdk/Responses/CacheDeleteResponse.cs
+++ b/src/Momento.Sdk/Responses/CacheDeleteResponse.cs
@@ -2,10 +2,29 @@
 
 using Momento.Sdk.Exceptions;
 
+/// <summary>
+/// Parent response type for a cache delete request. The
+/// response object is resolved to a type-safe object of one of
+/// the following subtypes:
+/// <list type="bullet">
+/// <item><description>CacheDeleteResponse.Success</description></item>
+/// <item><description>CacheDeleteResponse.Error</description></item>
+/// </list>
+/// Pattern matching can be used to operate on the appropriate subtype.
+/// For example:
+/// <code>
+/// if (response is CacheDeleteResponse.Error errorResponse)
+/// {
+///     // handle error as appropriate
+/// }
+/// </code>
+/// </summary>
 public abstract class CacheDeleteResponse
 {
+    /// <include file="../docs.xml" path='docs/class[@name="Success"]/description/*' />
     public class Success : CacheDeleteResponse { }
 
+    /// <include file="../docs.xml" path='docs/class[@name="Error"]/description/*' />
     public class Error : CacheDeleteResponse
     {
         private readonly SdkException _error;
@@ -14,16 +33,19 @@ public abstract class CacheDeleteResponse
             _error = error;
         }
 
+        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="Exception"]/*' />
         public SdkException Exception
         {
             get => _error;
         }
 
+        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="ErrorCode"]/*' />
         public MomentoErrorCode ErrorCode
         {
             get => _error.ErrorCode;
         }
 
+        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="Message"]/*' />
         public string Message
         {
             get => $"{_error.MessageWrapper}: {_error.Message}";

--- a/src/Momento.Sdk/Responses/CacheGetResponse.cs
+++ b/src/Momento.Sdk/Responses/CacheGetResponse.cs
@@ -3,8 +3,32 @@ using Momento.Protos.CacheClient;
 using Momento.Sdk.Exceptions;
 namespace Momento.Sdk.Responses;
 
+/// <summary>
+/// Parent response type for a cache get request. The
+/// response object is resolved to a type-safe object of one of
+/// the following subtypes:
+/// <list type="bullet">
+/// <item><description>CacheGetResponse.Hit</description></item>
+/// <item><description>CacheGetResponse.Miss</description></item>
+/// <item><description>CacheGetResponse.Error</description></item>
+/// </list>
+/// Pattern matching can be used to operate on the appropriate subtype.
+/// For example:
+/// <code>
+/// if (response is CacheGetResponse.Hit hitResponse)
+/// {
+///     return hitResponse.String();
+/// } else if (response is CacheGetResponse.Error errorResponse)
+/// {
+///     // handle error as appropriate
+/// }
+/// </code>
+/// </summary>
 public abstract class CacheGetResponse
 {
+    /// <summary>
+    /// Class <c>Hit</c> contains the results of a cache hit.
+    ///</summary>
     public class Hit : CacheGetResponse
     {
         protected readonly ByteString value;
@@ -14,11 +38,17 @@ public abstract class CacheGetResponse
             this.value = response.CacheBody;
         }
 
+        /// <summary>
+        /// Value from the cache as a byte array.
+        /// </summary>
         public byte[] ByteArray
         {
             get => value.ToByteArray();
         }
 
+        /// <summary>
+        /// Value from the cache as a string.
+        /// </summary>
         public string String() => value.ToStringUtf8();
 
         public override string ToString()
@@ -27,11 +57,15 @@ public abstract class CacheGetResponse
         }
     }
 
+    /// <summary>
+    /// Class <c>Miss</c> contains the results of a cache miss.
+    ///</summary>
     public class Miss : CacheGetResponse
     {
         public Miss() { }
     }
 
+    /// <include file="../docs.xml" path='docs/class[@name="Error"]/description/*' />
     public class Error : CacheGetResponse
     {
         private readonly SdkException _error;
@@ -40,16 +74,19 @@ public abstract class CacheGetResponse
             _error = error;
         }
 
+        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="Exception"]/*' />
         public SdkException Exception
         {
             get => _error;
         }
 
+         /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="ErrorCode"]/*' />
         public MomentoErrorCode ErrorCode
         {
             get => _error.ErrorCode;
         }
 
+         /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="Message"]/*' />
         public string Message
         {
             get => $"{_error.MessageWrapper}: {_error.Message}";

--- a/src/Momento.Sdk/Responses/CacheSetResponse.cs
+++ b/src/Momento.Sdk/Responses/CacheSetResponse.cs
@@ -2,11 +2,30 @@
 
 using Momento.Sdk.Exceptions;
 
+/// <summary>
+/// Parent response type for a cache set request. The
+/// response object is resolved to a type-safe object of one of
+/// the following subtypes:
+/// <list type="bullet">
+/// <item><description>CacheSetResponse.Success</description></item>
+/// <item><description>CacheSetResponse.Error</description></item>
+/// </list>
+/// Pattern matching can be used to operate on the appropriate subtype.
+/// For example:
+/// <code>
+/// if (response is CacheSetResponse.Error errorResponse)
+/// {
+///     // handle error as appropriate
+/// }
+/// </code>
+/// </summary>
 public abstract class CacheSetResponse
 {
 
+    /// <include file="../docs.xml" path='docs/class[@name="Success"]/description/*' />
     public class Success : CacheSetResponse { }
 
+    /// <include file="../docs.xml" path='docs/class[@name="Error"]/description/*' />
     public class Error : CacheSetResponse
     {
         private readonly SdkException _error;
@@ -15,16 +34,19 @@ public abstract class CacheSetResponse
             _error = error;
         }
 
+        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="Exception"]/*' />
         public SdkException Exception
         {
             get => _error;
         }
 
+        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="ErrorCode"]/*' />
         public MomentoErrorCode ErrorCode
         {
             get => _error.ErrorCode;
         }
 
+        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="Message"]/*' />
         public string Message
         {
             get => $"{_error.MessageWrapper}: {_error.Message}";

--- a/src/Momento.Sdk/Responses/CreateCacheResponse.cs
+++ b/src/Momento.Sdk/Responses/CreateCacheResponse.cs
@@ -2,6 +2,23 @@
 
 using Momento.Sdk.Exceptions;
 
+/// <summary>
+/// Parent response type for a create cache request. The
+/// response object is resolved to a type-safe object of one of
+/// the following subtypes:
+/// <list type="bullet">
+/// <item><description>CreateCacheResponse.Success</description></item>
+/// <item><description>CreateCacheResponse.Error</description></item>
+/// </list>
+/// Pattern matching can be used to operate on the appropriate subtype.
+/// For example:
+/// <code>
+/// if (response is CreateCacheResponse.Error errorResponse)
+/// {
+///     // handle error as appropriate
+/// }
+/// </code>
+/// </summary>
 public abstract class CreateCacheResponse
 {
 
@@ -17,16 +34,19 @@ public abstract class CreateCacheResponse
             _error = error;
         }
 
+        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="Exception"]/*' />
         public SdkException Exception
         {
             get => _error;
         }
 
+        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="ErrorCode"]/*' />
         public MomentoErrorCode ErrorCode
         {
             get => _error.ErrorCode;
         }
 
+        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="Message"]/*' />
         public string Message
         {
             get => $"{_error.MessageWrapper}: {_error.Message}";

--- a/src/Momento.Sdk/Responses/DeleteCacheResponse.cs
+++ b/src/Momento.Sdk/Responses/DeleteCacheResponse.cs
@@ -2,11 +2,30 @@
 
 using Momento.Sdk.Exceptions;
 
+/// <summary>
+/// Parent response type for a delete cache request. The
+/// response object is resolved to a type-safe object of one of
+/// the following subtypes:
+/// <list type="bullet">
+/// <item><description>DeleteCacheResponse.Success</description></item>
+/// <item><description>DeleteCacheResponse.Error</description></item>
+/// </list>
+/// Pattern matching can be used to operate on the appropriate subtype.
+/// For example:
+/// <code>
+/// if (response is DeleteCacheResponse.Error errorResponse)
+/// {
+///     // handle error as appropriate
+/// }
+/// </code>
+/// </summary>
 public abstract class DeleteCacheResponse
 {
 
+    /// <include file="../docs.xml" path='docs/class[@name="Success"]/description/*' />
     public class Success : DeleteCacheResponse { }
 
+    /// <include file="../docs.xml" path='docs/class[@name="Error"]/description/*' />
     public class Error : DeleteCacheResponse
     {
         private readonly SdkException _error;
@@ -15,16 +34,19 @@ public abstract class DeleteCacheResponse
             _error = error;
         }
 
+        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="Exception"]/*' />
         public SdkException Exception
         {
             get => _error;
         }
 
+        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="ErrorCode"]/*' />
         public MomentoErrorCode ErrorCode
         {
             get => _error.ErrorCode;
         }
 
+        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="Message"]/*' />
         public string Message
         {
             get => $"{_error.MessageWrapper}: {_error.Message}";

--- a/src/Momento.Sdk/Responses/ListCachesResponse.cs
+++ b/src/Momento.Sdk/Responses/ListCachesResponse.cs
@@ -5,8 +5,26 @@ using Momento.Sdk.Exceptions;
 
 namespace Momento.Sdk.Responses;
 
+/// <summary>
+/// Parent response type for a list caches request. The
+/// response object is resolved to a type-safe object of one of
+/// the following subtypes:
+/// <list type="bullet">
+/// <item><description>ListCachesResponse.Success</description></item>
+/// <item><description>ListCachesResponse.Error</description></item>
+/// </list>
+/// Pattern matching can be used to operate on the appropriate subtype.
+/// For example:
+/// <code>
+/// if (response is ListCachesResponse.Error errorResponse)
+/// {
+///     // handle error as appropriate
+/// }
+/// </code>
+/// </summary>
 public abstract class ListCachesResponse
 {
+    /// <include file="../docs.xml" path='docs/class[@name="Success"]/description/*' />
     public class Success : ListCachesResponse
     {
         public List<CacheInfo> Caches { get; }
@@ -34,6 +52,7 @@ public abstract class ListCachesResponse
 
     }
 
+    /// <include file="../docs.xml" path='docs/class[@name="Error"]/description/*' />
     public class Error : ListCachesResponse
     {
         private readonly SdkException _error;
@@ -42,16 +61,19 @@ public abstract class ListCachesResponse
             _error = error;
         }
 
+        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="Exception"]/*' />
         public SdkException Exception
         {
             get => _error;
         }
 
+        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="ErrorCode"]/*' />
         public MomentoErrorCode ErrorCode
         {
             get => _error.ErrorCode;
         }
 
+        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="Message"]/*' />
         public string Message
         {
             get => $"{_error.MessageWrapper}: {_error.Message}";

--- a/src/Momento.Sdk/docs.xml
+++ b/src/Momento.Sdk/docs.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0"?>
+<docs>
+  <class name="Error">
+    <description>
+      <summary>
+        Class <c>Error</c> contains information about an error
+        returned from the request:
+        <list type="bullet">
+          <item>
+            <term>ErrorCode: </term>
+            <description>
+              <c>Momento.Sdk.Exceptions.MomentoErrorCode</c> value for the error.
+            </description>
+          </item>
+          <item>
+            <term>Message: </term>
+            <description>
+              A detailed error message. 
+            </description>
+        </list>
+      </summary>
+    </description>
+    <prop name="ErrorCode">
+      <summary>
+        The <c>Momento.Sdk.Exceptions.MomentoErrorCode</c> value for the
+        <c>Error</c> object. Example:<br/>
+        <code>
+          if (errorResponse.ErrorCode == MomentoErrorCode.TIMEOUT_ERROR)
+          {
+            // handle timeout error
+          }
+        </code>
+      </summary>
+    </prop>
+    <prop name="Exception">
+      <summary>
+        The <c>SdkException</c> object used to construct the response.
+      </summary>
+    </prop>
+    <prop name="Message">
+      <summary>
+        An explanation of conditions that caused and potential
+        ways to resolve the error.
+      </summary>
+    </prop>
+  </class>
+  <class name="Success">
+    <description>
+      <summary>
+        Class <c>Success</c> indicates that the request that generated
+        it was successful.
+      </summary>
+    </description>
+  </class>
+</docs>


### PR DESCRIPTION
Some of these comments may need to be copied into `SimpleCacheClient.cs`, but if that work is determined to be necessary it'll be done in a separate PR.