### PR TITLE
chore: use sourcelink

### DIFF
--- a/src/Momento.Sdk/Momento.Sdk.csproj
+++ b/src/Momento.Sdk/Momento.Sdk.csproj
@@ -11,6 +11,8 @@
 		<IncludeSource>true</IncludeSource>
 		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
 		<IncludeSymbols>true</IncludeSymbols>
+		<!-- Publish the repository URL in the built .nupkg -->
+		<PublishRepositoryUrl>true</PublishRepositoryUrl>
 		<!-- TODO: Address public-facing documentation -->
 		<NoWarn>1591</NoWarn>
 
@@ -35,6 +37,10 @@
 		<PackageReference Include="Grpc.Net.Client" Version="2.40.0" />
 		<PackageReference Include="Grpc.Core" Version="2.41.1" />
 		<PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+		<PackageReference Include="Microsoft.SourceLink.Github" Version="1.1.1">
+		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		  <PrivateAssets>all</PrivateAssets>
+		</PackageReference>
 		<PackageReference Include="Momento.Protos" Version="0.31.0" />
 		<PackageReference Include="JWT" Version="8.4.2" />
 		<PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.16.0" />


### PR DESCRIPTION
SourceLink is an official supported mechanism to link source code to a
NuGet package. See: https://github.com/dotnet/sourcelink