### PR TITLE
fix: remove unnecessary deps (e.g. duplicate grpc dep)

### DIFF
--- a/src/Momento.Sdk/Momento.Sdk.csproj
+++ b/src/Momento.Sdk/Momento.Sdk.csproj
@@ -39,6 +39,8 @@
 	  <None Remove="Momento.Protos" />
 	  <None Remove="JWT" />
 	  <None Remove="System.IdentityModel.Tokens.Jwt" />
+	  <None Remove="Microsoft.Extensions.Logging" />
+	  <None Remove="Microsoft.SourceLink.GitHub" />
 	</ItemGroup>
 	<ItemGroup>
 	  <Folder Include="Internal\Middleware\" />
@@ -49,5 +51,10 @@
 	  <PackageReference Include="JWT" Version="9.0.3" />
 	  <PackageReference Include="System.Threading.Channels" Version="6.0.0" />
 	  <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.23.1" />
+	  <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+	  <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
+	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+	    <PrivateAssets>all</PrivateAssets>
+	  </PackageReference>
 	</ItemGroup>
 </Project>

--- a/src/Momento.Sdk/Momento.Sdk.csproj
+++ b/src/Momento.Sdk/Momento.Sdk.csproj
@@ -33,24 +33,21 @@
 		<RepositoryUrl>https://github.com/momentohq/client-sdk-dotnet</RepositoryUrl>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="Google.Protobuf" Version="3.19.0" />
-		<PackageReference Include="Grpc.Net.Client" Version="2.40.0" />
-		<PackageReference Include="Grpc.Core" Version="2.41.1" />
-		<PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
-		<PackageReference Include="Microsoft.SourceLink.Github" Version="1.1.1">
-		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		  <PrivateAssets>all</PrivateAssets>
-		</PackageReference>
-		<PackageReference Include="Momento.Protos" Version="0.31.0" />
-		<PackageReference Include="JWT" Version="8.4.2" />
-		<PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.16.0" />
-		<PackageReference Include="System.Threading.Channels" Version="6.0.0" />
-	</ItemGroup>
-	<ItemGroup>
 	  <None Remove="System.Threading.Channels" />
 	  <None Remove="Internal\Middleware\" />
+	  <None Remove="Grpc.Net.Client" />
+	  <None Remove="Momento.Protos" />
+	  <None Remove="JWT" />
+	  <None Remove="System.IdentityModel.Tokens.Jwt" />
 	</ItemGroup>
 	<ItemGroup>
 	  <Folder Include="Internal\Middleware\" />
+	</ItemGroup>
+	<ItemGroup>
+	  <PackageReference Include="Grpc.Net.Client" Version="2.49.0" />
+	  <PackageReference Include="Momento.Protos" Version="0.31.1" />
+	  <PackageReference Include="JWT" Version="9.0.3" />
+	  <PackageReference Include="System.Threading.Channels" Version="6.0.0" />
+	  <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.23.1" />
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
This commit attempts to pare down our dependency list to the
minimum requirements to compile.  Previously we had more than
one gRPC library, plus a google protobuf lib that we don't seem
to need.

This also removes the SourceLink.Github because it wasn't required
for compiling, but that is probably a mistake and should be
reverted... just posting this for discussion since I'm not familiar
with that one.
