### PR TITLE
chore: make class casts asserts in tests

### DIFF
--- a/tests/Integration/Momento.Sdk.Tests/SimpleCacheControlTest.cs
+++ b/tests/Integration/Momento.Sdk.Tests/SimpleCacheControlTest.cs
@@ -32,10 +32,10 @@ public class SimpleCacheControlTest
     [Fact]
     public async Task DeleteCacheAsync_NullCache_InvalidArgumentError()
     {
-        DeleteCacheResponse response = await client.DeleteCacheAsync(null!);
-        Assert.True(response is DeleteCacheResponse.Error);
-        DeleteCacheResponse.Error errResp = (DeleteCacheResponse.Error)response;
-        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, errResp.Exception.ErrorCode);
+        DeleteCacheResponse deleteResponse = await client.DeleteCacheAsync(null!);
+        Assert.True(deleteResponse is DeleteCacheResponse.Error);
+        DeleteCacheResponse.Error errorResponse = (DeleteCacheResponse.Error)deleteResponse;
+        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, errorResponse.Exception.ErrorCode);
     }
 
     [Fact]
@@ -43,8 +43,8 @@ public class SimpleCacheControlTest
     {
         DeleteCacheResponse response = await client.DeleteCacheAsync("non-existent cache");
         Assert.True(response is DeleteCacheResponse.Error);
-        DeleteCacheResponse.Error errResp = (DeleteCacheResponse.Error)response;
-        Assert.Equal(MomentoErrorCode.NOT_FOUND_ERROR, errResp.Exception.ErrorCode);
+        var errorResponse = (DeleteCacheResponse.Error)response;
+        Assert.Equal(MomentoErrorCode.NOT_FOUND_ERROR, errorResponse.Exception.ErrorCode);
     }
 
     [Fact]
@@ -52,8 +52,8 @@ public class SimpleCacheControlTest
     {
         CreateCacheResponse response = await client.CreateCacheAsync(null!);
         Assert.True(response is CreateCacheResponse.Error);
-        CreateCacheResponse.Error errResp = (CreateCacheResponse.Error)response;
-        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, errResp.Exception.ErrorCode);
+        CreateCacheResponse.Error errorResponse = (CreateCacheResponse.Error)response;
+        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, errorResponse.Exception.ErrorCode);
     }
 
     // Tests: creating a cache, listing a cache, and deleting a cache.

--- a/tests/Integration/Momento.Sdk.Tests/SimpleCacheControlTest.cs
+++ b/tests/Integration/Momento.Sdk.Tests/SimpleCacheControlTest.cs
@@ -32,26 +32,27 @@ public class SimpleCacheControlTest
     [Fact]
     public async Task DeleteCacheAsync_NullCache_InvalidArgumentError()
     {
-        DeleteCacheResponse resp = await client.DeleteCacheAsync(null!);
-        DeleteCacheResponse.Error errResp = (DeleteCacheResponse.Error)resp;
+        DeleteCacheResponse response = await client.DeleteCacheAsync(null!);
+        Assert.True(response is DeleteCacheResponse.Error);
+        DeleteCacheResponse.Error errResp = (DeleteCacheResponse.Error)response;
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, errResp.Exception.ErrorCode);
     }
 
     [Fact]
     public async Task DeleteCacheAsync_CacheDoesntExist_NotFoundException()
     {
-        // Assert.Throws<NotFoundException>(() => client.DeleteCache("non-existent cache"));
-        DeleteCacheResponse resp = await client.DeleteCacheAsync("non-existent cache");
-        Assert.True(resp is DeleteCacheResponse.Error);
-        DeleteCacheResponse.Error errResp = (DeleteCacheResponse.Error)resp;
+        DeleteCacheResponse response = await client.DeleteCacheAsync("non-existent cache");
+        Assert.True(response is DeleteCacheResponse.Error);
+        DeleteCacheResponse.Error errResp = (DeleteCacheResponse.Error)response;
         Assert.Equal(MomentoErrorCode.NOT_FOUND_ERROR, errResp.Exception.ErrorCode);
     }
 
     [Fact]
     public async Task CreateCacheAsync_NullCache_InvalidArgumentError()
     {
-        CreateCacheResponse resp = await client.CreateCacheAsync(null!);
-        CreateCacheResponse.Error errResp = (CreateCacheResponse.Error)resp;
+        CreateCacheResponse response = await client.CreateCacheAsync(null!);
+        Assert.True(response is CreateCacheResponse.Error);
+        CreateCacheResponse.Error errResp = (CreateCacheResponse.Error)response;
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, errResp.Exception.ErrorCode);
     }
 
@@ -65,20 +66,18 @@ public class SimpleCacheControlTest
 
         // Test cache exists
         ListCachesResponse result = await client.ListCachesAsync();
-        if (result is ListCachesResponse.Success successResult)
-        {
-            List<CacheInfo> caches = successResult.Caches;
-            Assert.Contains(new CacheInfo(cacheName), caches);
-        }
+        Assert.True(result is ListCachesResponse.Success);
+        var successResult = (ListCachesResponse.Success)result;
+        List<CacheInfo> caches = successResult.Caches;
+        Assert.Contains(new CacheInfo(cacheName), caches);
 
         // Test deleting cache
         await client.DeleteCacheAsync(cacheName);
         result = await client.ListCachesAsync();
-        if (result is ListCachesResponse.Success successResult2)
-        {
-            var caches = successResult2.Caches;
-            Assert.DoesNotContain(new CacheInfo(cacheName), caches);
-        }
+        Assert.True(result is ListCachesResponse.Success);
+        var successResult2 = (ListCachesResponse.Success)result;
+        var caches2 = successResult2.Caches;
+        Assert.DoesNotContain(new CacheInfo(cacheName), caches2);
     }
 
     [Fact]
@@ -100,18 +99,17 @@ public class SimpleCacheControlTest
         ListCachesResponse result = await client.ListCachesAsync();
         while (true)
         {
-            if (result is ListCachesResponse.Success successResult)
+            Assert.True(result is ListCachesResponse.Success);
+            var successResult = (ListCachesResponse.Success)result;
+            foreach (CacheInfo cache in successResult.Caches)
             {
-                foreach (CacheInfo cache in successResult.Caches)
-                {
-                    retrievedCaches.Add(cache.Name);
-                }
-                if (successResult.NextPageToken == null)
-                {
-                    break;
-                }
-                result = await client.ListCachesAsync(successResult.NextPageToken);
+                retrievedCaches.Add(cache.Name);
             }
+            if (successResult.NextPageToken == null)
+            {
+                break;
+            }
+            result = await client.ListCachesAsync(successResult.NextPageToken);
         }
 
 

--- a/tests/Integration/Momento.Sdk.Tests/SimpleCacheDataTest.cs
+++ b/tests/Integration/Momento.Sdk.Tests/SimpleCacheDataTest.cs
@@ -1,7 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using Momento.Sdk.Config;
+﻿using System.Threading.Tasks;
 
 namespace Momento.Sdk.Tests;
 
@@ -90,18 +87,24 @@ public class SimpleCacheDataTest
     [Fact]
     public async Task SetAsync_KeyIsStringValueIsString_HappyPath()
     {
+        // Set without TTL
         string key = Utils.NewGuidString();
         string value = Utils.NewGuidString();
-        await client.SetAsync(cacheName, key, value);
+        var setResponse = await client.SetAsync(cacheName, key, value);
+        Assert.True(setResponse is CacheSetResponse.Success);
+
         CacheGetResponse response = await client.GetAsync(cacheName, key);
         Assert.True(response is CacheGetResponse.Hit);
         var goodResponse = (CacheGetResponse.Hit)response;
         string? setValue = goodResponse.String();
         Assert.Equal(value, setValue);
 
+        // Set with TTL
         key = Utils.NewGuidString();
         value = Utils.NewGuidString();
-        await client.SetAsync(cacheName, key, value, ttlSeconds: 15);
+        setResponse = await client.SetAsync(cacheName, key, value, ttlSeconds: 15);
+        Assert.True(setResponse is CacheSetResponse.Success);
+
         response = await client.GetAsync(cacheName, key);
         Assert.True(response is CacheGetResponse.Hit);
         goodResponse = (CacheGetResponse.Hit)response;
@@ -128,6 +131,7 @@ public class SimpleCacheDataTest
         CacheSetResponse response = await client.SetAsync(cacheName, key, value);
         Assert.True(response is CacheSetResponse.Error);
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheSetResponse.Error)response).ErrorCode);
+
         response = await client.SetAsync(cacheName, key, value, DefaultTtlSeconds);
         Assert.True(response is CacheSetResponse.Error);
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheSetResponse.Error)response).ErrorCode);
@@ -137,17 +141,23 @@ public class SimpleCacheDataTest
     [Fact]
     public async Task SetAsync_KeyIsStringValueIsByteArray_HappyPath()
     {
+        // Set without TTL
         string key = Utils.NewGuidString();
         byte[] value = Utils.NewGuidByteArray();
-        await client.SetAsync(cacheName, key, value);
+        var setResponse = await client.SetAsync(cacheName, key, value);
+        Assert.True(setResponse is CacheSetResponse.Success);
+
         CacheGetResponse response = await client.GetAsync(cacheName, key);
         var goodResponse = (CacheGetResponse.Hit)response;
         byte[]? setValue = goodResponse.ByteArray;
         Assert.Equal(value, setValue);
 
+        // Set with TTL
         key = Utils.NewGuidString();
         value = Utils.NewGuidByteArray();
-        await client.SetAsync(cacheName, key, value, ttlSeconds: 15);
+        setResponse = await client.SetAsync(cacheName, key, value, ttlSeconds: 15);
+        Assert.True(setResponse is CacheSetResponse.Success);
+
         response = await client.GetAsync(cacheName, key);
         var anotherGoodResponse = (CacheGetResponse.Hit)response;
         byte[]? anotherSetValue = anotherGoodResponse.ByteArray;
@@ -182,7 +192,8 @@ public class SimpleCacheDataTest
         // Set a key to then delete
         byte[] key = new byte[] { 0x01, 0x02, 0x03, 0x04 };
         byte[] value = new byte[] { 0x05, 0x06, 0x07, 0x08 };
-        await client.SetAsync(cacheName, key, value, ttlSeconds: 60);
+        var setResponse = await client.SetAsync(cacheName, key, value, ttlSeconds: 60);
+        Assert.True(setResponse is CacheSetResponse.Success);
         CacheGetResponse getResponse = await client.GetAsync(cacheName, key);
         Assert.True(getResponse is CacheGetResponse.Hit);
 

--- a/tests/Integration/Momento.Sdk.Tests/SimpleCacheDataTest.cs
+++ b/tests/Integration/Momento.Sdk.Tests/SimpleCacheDataTest.cs
@@ -28,9 +28,12 @@ public class SimpleCacheDataTest
     public async Task SetAsync_NullChecksByteArrayByteArray_ThrowsException(string cacheName, byte[] key, byte[] value)
     {
         CacheSetResponse response = await client.SetAsync(cacheName, key, value);
+        Assert.True(response is CacheSetResponse.Error);
         var errorResponse = (CacheSetResponse.Error)response;
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, errorResponse.ErrorCode);
+
         response = await client.SetAsync(cacheName, key, value, DefaultTtlSeconds);
+        Assert.True(response is CacheSetResponse.Error);
         errorResponse = (CacheSetResponse.Error)response;
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, errorResponse.ErrorCode);
     }
@@ -43,6 +46,7 @@ public class SimpleCacheDataTest
         byte[] value = Utils.NewGuidByteArray();
         await client.SetAsync(cacheName, key, value);
         CacheGetResponse response = await client.GetAsync(cacheName, key);
+        Assert.True(response is CacheGetResponse.Hit);
         var goodResponse = (CacheGetResponse.Hit)response;
         byte[]? setValue = goodResponse.ByteArray;
         Assert.Equal(value, setValue);
@@ -51,6 +55,7 @@ public class SimpleCacheDataTest
         value = Utils.NewGuidByteArray();
         await client.SetAsync(cacheName, key, value, ttlSeconds: 15);
         response = await client.GetAsync(cacheName, key);
+        Assert.True(response is CacheGetResponse.Hit);
         goodResponse = (CacheGetResponse.Hit)response;
         setValue = goodResponse.ByteArray;
         Assert.Equal(value, setValue);
@@ -62,6 +67,7 @@ public class SimpleCacheDataTest
     public async Task GetAsync_NullChecksByteArray_ThrowsException(string cacheName, byte[] key)
     {
         CacheGetResponse response = await client.GetAsync(cacheName, key);
+        Assert.True(response is CacheGetResponse.Error);
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheGetResponse.Error)response).ErrorCode);
     }
 
@@ -72,8 +78,11 @@ public class SimpleCacheDataTest
     public async Task SetAsync_NullChecksStringString_ThrowsException(string cacheName, string key, string value)
     {
         CacheSetResponse response = await client.SetAsync(cacheName, key, value);
+        Assert.True(response is CacheSetResponse.Error);
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheSetResponse.Error)response).ErrorCode);
+
         response = await client.SetAsync(cacheName, key, value, DefaultTtlSeconds);
+        Assert.True(response is CacheSetResponse.Error);
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheSetResponse.Error)response).ErrorCode);
     }
 
@@ -85,6 +94,7 @@ public class SimpleCacheDataTest
         string value = Utils.NewGuidString();
         await client.SetAsync(cacheName, key, value);
         CacheGetResponse response = await client.GetAsync(cacheName, key);
+        Assert.True(response is CacheGetResponse.Hit);
         var goodResponse = (CacheGetResponse.Hit)response;
         string? setValue = goodResponse.String();
         Assert.Equal(value, setValue);
@@ -93,6 +103,7 @@ public class SimpleCacheDataTest
         value = Utils.NewGuidString();
         await client.SetAsync(cacheName, key, value, ttlSeconds: 15);
         response = await client.GetAsync(cacheName, key);
+        Assert.True(response is CacheGetResponse.Hit);
         goodResponse = (CacheGetResponse.Hit)response;
         setValue = goodResponse.String();
         Assert.Equal(value, setValue);
@@ -104,6 +115,7 @@ public class SimpleCacheDataTest
     public async Task GetAsync_NullChecksString_ThrowsException(string cacheName, string key)
     {
         CacheGetResponse response = await client.GetAsync(cacheName, key);
+        Assert.True(response is CacheGetResponse.Error);
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheGetResponse.Error)response).ErrorCode);
     }
 
@@ -114,8 +126,10 @@ public class SimpleCacheDataTest
     public async Task SetAsync_NullChecksStringByteArray_ThrowsException(string cacheName, string key, byte[] value)
     {
         CacheSetResponse response = await client.SetAsync(cacheName, key, value);
+        Assert.True(response is CacheSetResponse.Error);
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheSetResponse.Error)response).ErrorCode);
         response = await client.SetAsync(cacheName, key, value, DefaultTtlSeconds);
+        Assert.True(response is CacheSetResponse.Error);
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheSetResponse.Error)response).ErrorCode);
     }
 
@@ -145,7 +159,8 @@ public class SimpleCacheDataTest
     {
         string key = Utils.NewGuidString();
         string value = Utils.NewGuidString();
-        await client.SetAsync(cacheName, key, value, 1);
+        var setResponse = await client.SetAsync(cacheName, key, value, 1);
+        Assert.True(setResponse is CacheSetResponse.Success);
         await Task.Delay(3000);
         CacheGetResponse result = await client.GetAsync(cacheName, key);
         Assert.True(result is CacheGetResponse.Miss);
@@ -157,6 +172,7 @@ public class SimpleCacheDataTest
     public async Task DeleteAsync_NullChecksByte_ThrowsException(string cacheName, byte[] key)
     {
         CacheDeleteResponse result = await client.DeleteAsync(cacheName, key);
+        Assert.True(result is CacheDeleteResponse.Error);
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDeleteResponse.Error)result).ErrorCode);
     }
 
@@ -171,7 +187,8 @@ public class SimpleCacheDataTest
         Assert.True(getResponse is CacheGetResponse.Hit);
 
         // Delete
-        await client.DeleteAsync(cacheName, key);
+        var deleteResponse = await client.DeleteAsync(cacheName, key);
+        Assert.True(deleteResponse is CacheDeleteResponse.Success);
 
         // Check deleted
         getResponse = await client.GetAsync(cacheName, key);
@@ -184,6 +201,7 @@ public class SimpleCacheDataTest
     public async Task DeleteAsync_NullChecksString_ThrowsException(string cacheName, string key)
     {
         CacheDeleteResponse response = await client.DeleteAsync(cacheName, key);
+        Assert.True(response is CacheDeleteResponse.Error);
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDeleteResponse.Error)response).ErrorCode);
     }
 
@@ -193,7 +211,8 @@ public class SimpleCacheDataTest
         // Set a key to then delete
         string key = Utils.NewGuidString();
         string value = Utils.NewGuidString();
-        await client.SetAsync(cacheName, key, value, ttlSeconds: 60);
+        var setResponse = await client.SetAsync(cacheName, key, value, ttlSeconds: 60);
+        Assert.True(setResponse is CacheSetResponse.Success);
         CacheGetResponse getResponse = await client.GetAsync(cacheName, key);
         Assert.True(getResponse is CacheGetResponse.Hit);
 


### PR DESCRIPTION
This PR explicitly tests class type assertions. Previously these were implicit, which makes failures harder to identify in the test runner results.

Closes #266 