### PR TITLE
fix: re-work logging config

### DIFF
--- a/src/Momento.Sdk/Config/Configuration.cs
+++ b/src/Momento.Sdk/Config/Configuration.cs
@@ -1,5 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Momento.Sdk.Config.Middleware;
 using Momento.Sdk.Config.Retry;
 using Momento.Sdk.Config.Transport;
@@ -8,36 +10,47 @@ namespace Momento.Sdk.Config;
 
 public class Configuration : IConfiguration
 {
+    public ILoggerFactory LoggerFactory { get; }
     public IRetryStrategy RetryStrategy { get; }
     public IList<IMiddleware> Middlewares { get; }
     public ITransportStrategy TransportStrategy { get; }
 
-    public Configuration(IRetryStrategy retryStrategy, ITransportStrategy transportStrategy)
-        : this(retryStrategy, new List<IMiddleware>(), transportStrategy)
+    public Configuration(IRetryStrategy retryStrategy, ITransportStrategy transportStrategy, ILoggerFactory? loggerFactory = null)
+        : this(retryStrategy, new List<IMiddleware>(), transportStrategy, loggerFactory)
     {
 
     }
 
-    public Configuration(IRetryStrategy retryStrategy, IList<IMiddleware> middlewares, ITransportStrategy transportStrategy)
+    public Configuration(IRetryStrategy retryStrategy, IList<IMiddleware> middlewares, ITransportStrategy transportStrategy, ILoggerFactory? loggerFactory = null)
     {
-        this.RetryStrategy = retryStrategy;
-        this.Middlewares = middlewares;
+        this.LoggerFactory = loggerFactory ?? NullLoggerFactory.Instance;
+
+        var retryStrategyWithLogger = retryStrategy.LoggerFactory != null ? retryStrategy : retryStrategy.WithLoggerFactory(loggerFactory!);
+        var middlewaresWithLogger = middlewares.Select(m => m.LoggerFactory != null ? m : m.WithLoggerFactory(loggerFactory!)).ToList();
+
+        this.RetryStrategy = retryStrategyWithLogger;
+        this.Middlewares = middlewaresWithLogger;
         this.TransportStrategy = transportStrategy;
+    }
+
+    public IConfiguration WithLoggerFactory(ILoggerFactory loggerFactory)
+    {
+        return new Configuration(RetryStrategy, Middlewares, TransportStrategy, loggerFactory);
     }
 
     public IConfiguration WithRetryStrategy(IRetryStrategy retryStrategy)
     {
-        return new Configuration(retryStrategy, Middlewares, TransportStrategy);
+        return new Configuration(retryStrategy, Middlewares, TransportStrategy, LoggerFactory);
     }
 
     public IConfiguration WithMiddlewares(IList<IMiddleware> middlewares)
     {
-        return new Configuration(RetryStrategy, middlewares, TransportStrategy);
+        return new Configuration(RetryStrategy, middlewares, TransportStrategy, LoggerFactory);
     }
 
     public IConfiguration WithTransportStrategy(ITransportStrategy transportStrategy)
     {
-        return new Configuration(RetryStrategy, Middlewares, transportStrategy);
+        return new Configuration(RetryStrategy, Middlewares, transportStrategy, LoggerFactory);
     }
 
     public Configuration WithAdditionalMiddlewares(IList<IMiddleware> additionalMiddlewares)
@@ -45,7 +58,8 @@ public class Configuration : IConfiguration
         return new(
             retryStrategy: RetryStrategy,
             middlewares: Middlewares.Concat(additionalMiddlewares).ToList(),
-            transportStrategy: TransportStrategy
+            transportStrategy: TransportStrategy,
+            loggerFactory: LoggerFactory
         );
     }
 
@@ -54,7 +68,13 @@ public class Configuration : IConfiguration
         return new(
             retryStrategy: RetryStrategy,
             middlewares: Middlewares,
-            transportStrategy: TransportStrategy.WithClientTimeoutMillis(clientTimeoutMillis)
+            transportStrategy: TransportStrategy.WithClientTimeoutMillis(clientTimeoutMillis),
+            loggerFactory: LoggerFactory
         );
+    }
+
+    IConfiguration IConfiguration.WithClientTimeoutMillis(uint clientTimeoutMillis)
+    {
+        return WithClientTimeoutMillis(clientTimeoutMillis);
     }
 }

--- a/src/Momento.Sdk/Config/Configurations.cs
+++ b/src/Momento.Sdk/Config/Configurations.cs
@@ -27,7 +27,8 @@ public class Configurations
                 IRetryStrategy retryStrategy = new FixedCountRetryStrategy(maxAttempts: 3);
                 ITransportStrategy transportStrategy = new StaticTransportStrategy(
                     maxConcurrentRequests: 200,
-                    grpcConfig: new StaticGrpcConfiguration(deadlineMilliseconds: 5000));
+                    grpcConfig: new StaticGrpcConfiguration(deadlineMilliseconds: 5000)
+                );
                 return new Laptop(retryStrategy, transportStrategy);
             }
         }

--- a/src/Momento.Sdk/Config/IConfiguration.cs
+++ b/src/Momento.Sdk/Config/IConfiguration.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Microsoft.Extensions.Logging;
 using Momento.Sdk.Config.Middleware;
 using Momento.Sdk.Config.Retry;
 using Momento.Sdk.Config.Transport;
@@ -11,11 +12,16 @@ namespace Momento.Sdk.Config;
 /// </summary>
 public interface IConfiguration
 {
+    public ILoggerFactory LoggerFactory { get; }
+
     public IRetryStrategy RetryStrategy { get; }
     public IList<IMiddleware> Middlewares { get; }
     public ITransportStrategy TransportStrategy { get; }
 
+    public IConfiguration WithLoggerFactory(ILoggerFactory loggerFactory);
     public IConfiguration WithRetryStrategy(IRetryStrategy retryStrategy);
     public IConfiguration WithMiddlewares(IList<IMiddleware> middlewares);
     public IConfiguration WithTransportStrategy(ITransportStrategy transportStrategy);
+
+    public IConfiguration WithClientTimeoutMillis(uint clientTimeoutMillis);
 }

--- a/src/Momento.Sdk/Config/Middleware/IMiddleware.cs
+++ b/src/Momento.Sdk/Config/Middleware/IMiddleware.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading.Tasks;
 using Grpc.Core;
 using Grpc.Core.Interceptors;
+using Microsoft.Extensions.Logging;
 using Momento.Sdk.Config.Retry;
 
 namespace Momento.Sdk.Config.Middleware;
@@ -35,6 +36,10 @@ public record struct MiddlewareResponseState<TResponse>(
 /// </summary>
 public interface IMiddleware
 {
+    public ILoggerFactory LoggerFactory { get; }
+
+    public IMiddleware WithLoggerFactory(ILoggerFactory loggerFactory);
+
     /// <summary>
     /// Called as a wrapper around each request; can be used to time the request and collect metrics etc.
     /// </summary>

--- a/src/Momento.Sdk/Config/Middleware/LoggingMiddleware.cs
+++ b/src/Momento.Sdk/Config/Middleware/LoggingMiddleware.cs
@@ -12,11 +12,24 @@ namespace Momento.Sdk.Config.Middleware
     /// </summary>
     public class LoggingMiddleware : IMiddleware
     {
+        public ILoggerFactory LoggerFactory { get; }
+
         private readonly ILogger _logger;
 
         public LoggingMiddleware(ILoggerFactory loggerFactory)
         {
+            LoggerFactory = loggerFactory;
             _logger = loggerFactory.CreateLogger<LoggingMiddleware>();
+        }
+
+        public LoggingMiddleware WithLoggerFactory(ILoggerFactory loggerFactory)
+        {
+            return new(loggerFactory);
+        }
+
+        IMiddleware IMiddleware.WithLoggerFactory(ILoggerFactory loggerFactory)
+        {
+            return WithLoggerFactory(loggerFactory);
         }
 
         public async Task<MiddlewareResponseState<TResponse>> WrapRequest<TRequest, TResponse>(

--- a/src/Momento.Sdk/Config/Middleware/PassThroughMiddleware.cs
+++ b/src/Momento.Sdk/Config/Middleware/PassThroughMiddleware.cs
@@ -2,14 +2,33 @@ using System;
 using System.Threading.Tasks;
 using Grpc.Core;
 using Grpc.Core.Interceptors;
+using Microsoft.Extensions.Logging;
 using Momento.Sdk.Config.Retry;
 
 namespace Momento.Sdk.Config.Middleware;
 
 public class PassThroughMiddleware : IMiddleware
 {
+    public ILoggerFactory LoggerFactory { get; }
+
+    public PassThroughMiddleware(ILoggerFactory loggerFactory)
+    {
+        LoggerFactory = loggerFactory;
+    }
+
+    public PassThroughMiddleware WithLoggerFactory(ILoggerFactory loggerFactory)
+    {
+        return new(loggerFactory);
+    }
+
+    IMiddleware IMiddleware.WithLoggerFactory(ILoggerFactory loggerFactory)
+    {
+        return WithLoggerFactory(loggerFactory);
+    }
+
     public Task<MiddlewareResponseState<TResponse>> WrapRequest<TRequest, TResponse>(TRequest request, CallOptions callOptions, Func<TRequest, CallOptions, Task<MiddlewareResponseState<TResponse>>> continuation)
     {
         return continuation(request, callOptions);
     }
+
 }

--- a/src/Momento.Sdk/Config/Retry/FixedCountRetryStrategy.cs
+++ b/src/Momento.Sdk/Config/Retry/FixedCountRetryStrategy.cs
@@ -1,17 +1,32 @@
+using Microsoft.Extensions.Logging;
+
 namespace Momento.Sdk.Config.Retry;
 
 public class FixedCountRetryStrategy : IRetryStrategy
 {
+    public ILoggerFactory? LoggerFactory { get; }
     public int MaxAttempts { get; }
+
     //FixedCountRetryStrategy(retryableStatusCodes = DEFAULT_RETRYABLE_STATUS_CODES, maxAttempts = 3),
-    public FixedCountRetryStrategy(int maxAttempts)
+    public FixedCountRetryStrategy(int maxAttempts, ILoggerFactory? loggerFactory = null)
     {
+        LoggerFactory = loggerFactory;
         MaxAttempts = maxAttempts;
+    }
+
+    public FixedCountRetryStrategy WithLoggerFactory(ILoggerFactory loggerFactory)
+    {
+        return new(MaxAttempts, loggerFactory);
+    }
+
+    IRetryStrategy IRetryStrategy.WithLoggerFactory(ILoggerFactory loggerFactory)
+    {
+        return WithLoggerFactory(loggerFactory);
     }
 
     public FixedCountRetryStrategy WithMaxAttempts(int maxAttempts)
     {
-        return new(maxAttempts);
+        return new(maxAttempts, LoggerFactory);
     }
 
     public int? DetermineWhenToRetryRequest(IGrpcResponse grpcResponse, IGrpcRequest grpcRequest, int attemptNumber)

--- a/src/Momento.Sdk/Config/Retry/IRetryStrategy.cs
+++ b/src/Momento.Sdk/Config/Retry/IRetryStrategy.cs
@@ -1,3 +1,5 @@
+using Microsoft.Extensions.Logging;
+
 namespace Momento.Sdk.Config.Retry;
 
 /// <summary>
@@ -5,6 +7,9 @@ namespace Momento.Sdk.Config.Retry;
 /// </summary>
 public interface IRetryStrategy
 {
+    public ILoggerFactory? LoggerFactory { get; }
+
+
     /// <summary>
     /// Calculates whether or not to retry a request based on the type of request and number of attempts.
     /// </summary>
@@ -13,4 +18,6 @@ public interface IRetryStrategy
     /// <param name="attemptNumber"></param>
     /// <returns>Returns number of milliseconds after which the request should be retried, or <see langword="null"/> if the request should not be retried.</returns>
     public int? DetermineWhenToRetryRequest(IGrpcResponse grpcResponse, IGrpcRequest grpcRequest, int attemptNumber);
+
+    public IRetryStrategy WithLoggerFactory(ILoggerFactory loggerFactory);
 }

--- a/src/Momento.Sdk/Config/Transport/ITransportStrategy.cs
+++ b/src/Momento.Sdk/Config/Transport/ITransportStrategy.cs
@@ -1,3 +1,5 @@
+using Microsoft.Extensions.Logging;
+
 namespace Momento.Sdk.Config.Transport;
 
 /// <summary>
@@ -8,6 +10,7 @@ public interface ITransportStrategy
     public int MaxConcurrentRequests { get; }
     public IGrpcConfiguration GrpcConfig { get; }
 
+    public ITransportStrategy WithLoggerFactory(ILoggerFactory loggerFactory);
     public ITransportStrategy WithMaxConcurrentRequests(int maxConcurrentRequests);
     public ITransportStrategy WithGrpcConfig(IGrpcConfiguration grpcConfig);
     public ITransportStrategy WithClientTimeoutMillis(uint clientTimeoutMillis);

--- a/src/Momento.Sdk/Config/Transport/StaticTransportStrategy.cs
+++ b/src/Momento.Sdk/Config/Transport/StaticTransportStrategy.cs
@@ -1,5 +1,6 @@
 using System;
 using Grpc.Net.Client;
+using Microsoft.Extensions.Logging;
 
 namespace Momento.Sdk.Config.Transport;
 
@@ -32,27 +33,40 @@ public class StaticGrpcConfiguration : IGrpcConfiguration
 
 public class StaticTransportStrategy : ITransportStrategy
 {
+    public ILoggerFactory? LoggerFactory { get; }
     public int MaxConcurrentRequests { get; }
     public IGrpcConfiguration GrpcConfig { get; }
 
-    public StaticTransportStrategy(int maxConcurrentRequests, IGrpcConfiguration grpcConfig)
+    public StaticTransportStrategy(int maxConcurrentRequests, IGrpcConfiguration grpcConfig, ILoggerFactory? loggerFactory = null)
     {
+        LoggerFactory = loggerFactory;
         MaxConcurrentRequests = maxConcurrentRequests;
         GrpcConfig = grpcConfig;
     }
 
+    public StaticTransportStrategy WithLoggerFactory(ILoggerFactory loggerFactory)
+    {
+        return new(MaxConcurrentRequests, GrpcConfig, loggerFactory);
+    }
+
+    ITransportStrategy ITransportStrategy.WithLoggerFactory(ILoggerFactory loggerFactory)
+    {
+        return WithLoggerFactory(loggerFactory);
+    }
+
     public ITransportStrategy WithMaxConcurrentRequests(int maxConcurrentRequests)
     {
-        return new StaticTransportStrategy(maxConcurrentRequests, GrpcConfig);
+        return new StaticTransportStrategy(maxConcurrentRequests, GrpcConfig, LoggerFactory);
     }
 
     public ITransportStrategy WithGrpcConfig(IGrpcConfiguration grpcConfig)
     {
-        return new StaticTransportStrategy(MaxConcurrentRequests, grpcConfig);
+        return new StaticTransportStrategy(MaxConcurrentRequests, grpcConfig, LoggerFactory);
     }
 
     public ITransportStrategy WithClientTimeoutMillis(uint clientTimeoutMillis)
     {
-        return new StaticTransportStrategy(MaxConcurrentRequests, GrpcConfig.WithDeadlineMilliseconds(clientTimeoutMillis));
+        return new StaticTransportStrategy(MaxConcurrentRequests, GrpcConfig.WithDeadlineMilliseconds(clientTimeoutMillis), LoggerFactory);
     }
+
 }

--- a/src/Momento.Sdk/Internal/Middleware/MaxConcurrentRequestsMiddleware.cs
+++ b/src/Momento.Sdk/Internal/Middleware/MaxConcurrentRequestsMiddleware.cs
@@ -1,5 +1,7 @@
 ﻿using Google.Protobuf.WellKnownTypes;
 using Grpc.Core;
+using Microsoft.Extensions.Logging;
+using Momento.Sdk.Config;
 using Momento.Sdk.Config.Middleware;
 using System;
 using System.Drawing;
@@ -34,11 +36,27 @@ namespace Momento.Sdk.Internal.Middleware
     // latencies by quite a bit.
     public class MaxConcurrentRequestsMiddleware : IMiddleware
     {
+        public ILoggerFactory LoggerFactory { get; }
+        private readonly int _maxConcurrentRequests;
         private readonly FairAsyncSemaphore _semaphore;
 
-        public MaxConcurrentRequestsMiddleware(int maxConcurrentRequests)
+        public MaxConcurrentRequestsMiddleware(ILoggerFactory loggerFactory, int maxConcurrentRequests)
         {
+            LoggerFactory = loggerFactory;
+            _maxConcurrentRequests = maxConcurrentRequests;
             _semaphore = new FairAsyncSemaphore(maxConcurrentRequests);
+        }
+
+        
+
+        public MaxConcurrentRequestsMiddleware WithLoggerFactory(ILoggerFactory loggerFactory)
+        {
+            return new(loggerFactory, _maxConcurrentRequests);
+        }
+
+        IMiddleware IMiddleware.WithLoggerFactory(ILoggerFactory loggerFactory)
+        {
+            return WithLoggerFactory(loggerFactory);
         }
 
         public async Task<MiddlewareResponseState<TResponse>> WrapRequest<TRequest, TResponse>(TRequest request, CallOptions callOptions, Func<TRequest, CallOptions, Task<MiddlewareResponseState<TResponse>>> continuation)
@@ -56,6 +74,8 @@ namespace Momento.Sdk.Internal.Middleware
                 _semaphore.Release();
             }
         }
+
+
     }
 }
 

--- a/src/Momento.Sdk/Internal/ScsDataClient.cs
+++ b/src/Momento.Sdk/Internal/ScsDataClient.cs
@@ -20,12 +20,12 @@ public class ScsDataClientBase : IDisposable
     protected readonly uint dataClientOperationTimeoutMilliseconds;
     protected readonly ILogger _logger;
 
-    public ScsDataClientBase(IConfiguration config, string authToken, string endpoint, uint defaultTtlSeconds, ILoggerFactory loggerFactory)
+    public ScsDataClientBase(IConfiguration config, string authToken, string endpoint, uint defaultTtlSeconds)
     {
-        this.grpcManager = new(config, authToken, endpoint, loggerFactory);
+        this.grpcManager = new(config, authToken, endpoint);
         this.defaultTtlSeconds = defaultTtlSeconds;
         this.dataClientOperationTimeoutMilliseconds = config.TransportStrategy.GrpcConfig.DeadlineMilliseconds;
-        this._logger = loggerFactory.CreateLogger<ScsDataClient>();
+        this._logger = config.LoggerFactory.CreateLogger<ScsDataClient>();
     }
 
     protected Metadata MetadataWithCache(string cacheName)
@@ -55,8 +55,8 @@ public class ScsDataClientBase : IDisposable
 
 internal sealed class ScsDataClient : ScsDataClientBase
 {
-    public ScsDataClient(IConfiguration config, string authToken, string endpoint, uint defaultTtlSeconds, ILoggerFactory loggerFactory)
-        : base(config, authToken, endpoint, defaultTtlSeconds, loggerFactory)
+    public ScsDataClient(IConfiguration config, string authToken, string endpoint, uint defaultTtlSeconds)
+        : base(config, authToken, endpoint, defaultTtlSeconds)
     {
 
     }

--- a/src/Momento.Sdk/SimpleCacheClient.cs
+++ b/src/Momento.Sdk/SimpleCacheClient.cs
@@ -29,15 +29,14 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// <param name="config">Configuration to use for the transport, retries, middlewares. See <see cref="Configurations"/> for out-of-the-box configuration choices, eg <see cref="Configurations.Laptop.Latest"/></param>
     /// <param name="authProvider">Momento auth provider.</param>
     /// <param name="defaultTtlSeconds">Default time to live for the item in cache.</param>
-    /// <param name="loggerFactory">Logger factory to create loggers for contained instances.</param>
-    public SimpleCacheClient(IConfiguration config, ICredentialProvider authProvider, uint defaultTtlSeconds, ILoggerFactory? loggerFactory = null)
+    public SimpleCacheClient(IConfiguration config, ICredentialProvider authProvider, uint defaultTtlSeconds)
     {
         this.config = config;
-        var _loggerFactory = loggerFactory ?? NullLoggerFactory.Instance;
+        var _loggerFactory = config.LoggerFactory;
         this._logger = _loggerFactory.CreateLogger<SimpleCacheClient>();
         ValidateRequestTimeout(config.TransportStrategy.GrpcConfig.DeadlineMilliseconds);
         this.controlClient = new(authProvider.AuthToken, authProvider.ControlEndpoint, _loggerFactory);
-        this.dataClient = new(config, authProvider.AuthToken, authProvider.CacheEndpoint, defaultTtlSeconds, _loggerFactory);
+        this.dataClient = new(config, authProvider.AuthToken, authProvider.CacheEndpoint, defaultTtlSeconds);
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
This commit does some re-working on how we expose and curry the
logging config (ILoggerFactory).

The motivation for this PR is that many (most?) Middlewares and
Retry Strategies will need access to the logging config, and it
is very cumbersome to try to pass it in as a constructor arg
to every single one of those.  Especially in the pre-built configs,
which currently do not even have direct access to the ILoggerFactory.

To address this we move the ILoggerFactory to be a first-class
member of the IConfiguration itself.  We also alter the constructors
for the Configuration class such that it will loop over all of the
Middlewares and the RetryStrategy and set the ILoggerFactory on them
if they do not already have one.

This ensures that customers only ever need to explictly pass the
ILoggerFactory to at most one of the constructors (the Configuration),
but we will have access to it from all of the Middlewares and other
objects that are encapsulated within the Configuration.
