### PR TITLE
fix: handle AggregateExceptions from task continuations

### DIFF
--- a/src/Momento.Sdk/Internal/DataGrpcManager.cs
+++ b/src/Momento.Sdk/Internal/DataGrpcManager.cs
@@ -219,7 +219,9 @@ public class DataGrpcManager : IDisposable
         CallInvoker invoker = this.channel.Intercept(new HeaderInterceptor(headers));
 
         var middlewares = config.Middlewares.Concat(
-            new List<IMiddleware> { new MaxConcurrentRequestsMiddleware(config.LoggerFactory, config.TransportStrategy.MaxConcurrentRequests) }
+            new List<IMiddleware> {
+                new MaxConcurrentRequestsMiddleware(config.LoggerFactory, config.TransportStrategy.MaxConcurrentRequests)
+            }
         ).ToList();
 
         Client = new DataClientWithMiddleware(new Scs.ScsClient(invoker), middlewares);

--- a/src/Momento.Sdk/Internal/ScsControlClient.cs
+++ b/src/Momento.Sdk/Internal/ScsControlClient.cs
@@ -13,13 +13,16 @@ internal sealed class ScsControlClient : IDisposable
     private readonly ControlGrpcManager grpcManager;
     private readonly string authToken;
     private const uint DEADLINE_SECONDS = 60;
+
     private readonly ILogger _logger;
+    private readonly CacheExceptionMapper _exceptionMapper;
 
     public ScsControlClient(string authToken, string endpoint, ILoggerFactory loggerFactory)
     {
         this.grpcManager = new ControlGrpcManager(authToken, endpoint, loggerFactory);
         this.authToken = authToken;
         this._logger = loggerFactory.CreateLogger<ScsControlClient>();
+        this._exceptionMapper = new CacheExceptionMapper(loggerFactory);
     }
 
     public async Task<CreateCacheResponse> CreateCacheAsync(string cacheName)
@@ -36,7 +39,7 @@ internal sealed class ScsControlClient : IDisposable
             if (e is RpcException ex && ex.StatusCode == StatusCode.AlreadyExists) {
                 return new CreateCacheResponse.CacheAlreadyExists();
             }
-            return new CreateCacheResponse.Error(CacheExceptionMapper.Convert(e));
+            return new CreateCacheResponse.Error(_exceptionMapper.Convert(e));
         }
     }
 
@@ -51,7 +54,7 @@ internal sealed class ScsControlClient : IDisposable
         }
         catch (Exception e)
         {
-            return new DeleteCacheResponse.Error(CacheExceptionMapper.Convert(e));
+            return new DeleteCacheResponse.Error(_exceptionMapper.Convert(e));
         }
     }
 
@@ -65,7 +68,7 @@ internal sealed class ScsControlClient : IDisposable
         }
         catch (Exception e)
         {
-            return new ListCachesResponse.Error(CacheExceptionMapper.Convert(e));
+            return new ListCachesResponse.Error(_exceptionMapper.Convert(e));
         }
     }
 

--- a/src/Momento.Sdk/Internal/ScsDataClient.cs
+++ b/src/Momento.Sdk/Internal/ScsDataClient.cs
@@ -19,6 +19,7 @@ public class ScsDataClientBase : IDisposable
     protected readonly uint defaultTtlSeconds;
     protected readonly uint dataClientOperationTimeoutMilliseconds;
     protected readonly ILogger _logger;
+    protected readonly CacheExceptionMapper _exceptionMapper;
 
     public ScsDataClientBase(IConfiguration config, string authToken, string endpoint, uint defaultTtlSeconds)
     {
@@ -26,6 +27,7 @@ public class ScsDataClientBase : IDisposable
         this.defaultTtlSeconds = defaultTtlSeconds;
         this.dataClientOperationTimeoutMilliseconds = config.TransportStrategy.GrpcConfig.DeadlineMilliseconds;
         this._logger = config.LoggerFactory.CreateLogger<ScsDataClient>();
+        this._exceptionMapper = new CacheExceptionMapper(config.LoggerFactory);
     }
 
     protected Metadata MetadataWithCache(string cacheName)
@@ -105,7 +107,7 @@ internal sealed class ScsDataClient : ScsDataClientBase
         }
         catch (Exception e)
         {
-            var exc = CacheExceptionMapper.Convert(e);
+            var exc = _exceptionMapper.Convert(e);
             if (exc.TransportDetails != null)
             {
                 exc.TransportDetails.Grpc.Metadata = MetadataWithCache(cacheName);
@@ -125,7 +127,7 @@ internal sealed class ScsDataClient : ScsDataClientBase
         }
         catch (Exception e)
         {
-            var exc = CacheExceptionMapper.Convert(e);
+            var exc = _exceptionMapper.Convert(e);
             if (exc.TransportDetails != null)
             {
                 exc.TransportDetails.Grpc.Metadata = MetadataWithCache(cacheName);
@@ -149,7 +151,7 @@ internal sealed class ScsDataClient : ScsDataClientBase
         }
         catch (Exception e)
         {
-            var exc = CacheExceptionMapper.Convert(e);
+            var exc = _exceptionMapper.Convert(e);
             if (exc.TransportDetails != null)
             {
                 exc.TransportDetails.Grpc.Metadata = MetadataWithCache(cacheName);


### PR DESCRIPTION
In Middleware code, if you need to modify the response before it
makes it back out to the caller, you need to use `Task.ContinueWith`.
However, if an exception is thrown while such a Middleware is
in the stack, the exception will get wrapped in an AggregateException.

Prior to this commit our CacheExceptionMapper would treat this as
an unknown error and we would lose our desired status code mapping.
This commit unwraps AggregateExceptions before the mapping so that
the error codes will be correct.

It also adds debug logs to the exception mapper so that we can
see what's going wrong if other exception types fail to map
properly in the future.
