### PR TITLE
fix: re-enable warning and address 20 warnings

### DIFF
--- a/src/Momento.Sdk/Auth/EnvMomentoTokenProvider.cs
+++ b/src/Momento.Sdk/Auth/EnvMomentoTokenProvider.cs
@@ -4,10 +4,22 @@ using System;
 using Momento.Sdk.Exceptions;
 using Momento.Sdk.Internal;
 
+/// <summary>
+/// Reads and parses a JWT token stored as an environment variable.
+/// </summary>
 public class EnvMomentoTokenProvider : ICredentialProvider
 {
+    /// <summary>
+    /// JWT provided by user
+    /// </summary>
     public string AuthToken { get; private set; }
-    public string ControlEndpoint {get; private set; }
+    /// <summary>
+    /// Control endpoint extracted from JWT
+    /// </summary>
+    public string ControlEndpoint { get; private set; }
+    /// <summary>
+    /// Cache endpoint extracted from JWT
+    /// </summary>
     public string CacheEndpoint { get; private set; }
 
     /// <summary>
@@ -16,16 +28,19 @@ public class EnvMomentoTokenProvider : ICredentialProvider
     /// <param name="name">Name of the environment variable that contains the JWT token.</param>
     public EnvMomentoTokenProvider(string name)
     {
-        AuthToken =  Environment.GetEnvironmentVariable(name);
+        AuthToken = Environment.GetEnvironmentVariable(name);
         if (String.IsNullOrEmpty(AuthToken))
         {
             throw new InvalidArgumentException($"Environment variable '{name}' is empty or null.");
         }
 
         Claims claims;
-        try {
+        try
+        {
             claims = JwtUtils.DecodeJwt(AuthToken);
-        } catch (InvalidArgumentException) {
+        }
+        catch (InvalidArgumentException)
+        {
             throw new InvalidArgumentException("The supplied Momento authToken is not valid.");
         }
         ControlEndpoint = claims.ControlEndpoint;

--- a/src/Momento.Sdk/Auth/ICredentialProvider.cs
+++ b/src/Momento.Sdk/Auth/ICredentialProvider.cs
@@ -12,11 +12,11 @@ public interface ICredentialProvider
     /// </summary>
     string AuthToken { get; }
     /// <summary>
-    /// Control endpoint extracted from JWT
+    /// Control endpoint
     /// </summary>
     string ControlEndpoint { get; }
     /// <summary>
-    /// Cache endpoint extracted from JWT
+    /// Cache endpoint
     /// </summary>
     string CacheEndpoint { get; }
 }

--- a/src/Momento.Sdk/Auth/ICredentialProvider.cs
+++ b/src/Momento.Sdk/Auth/ICredentialProvider.cs
@@ -2,9 +2,21 @@ namespace Momento.Sdk.Auth;
 
 using System.Collections.Generic;
 
+/// <summary>
+/// Interface for credentials
+/// </summary>
 public interface ICredentialProvider
 {
+    /// <summary>
+    /// JWT provided by user
+    /// </summary>
     string AuthToken { get; }
-    string ControlEndpoint {get; }
+    /// <summary>
+    /// Control endpoint extracted from JWT
+    /// </summary>
+    string ControlEndpoint { get; }
+    /// <summary>
+    /// Cache endpoint extracted from JWT
+    /// </summary>
     string CacheEndpoint { get; }
 }

--- a/src/Momento.Sdk/Config/Configuration.cs
+++ b/src/Momento.Sdk/Config/Configuration.cs
@@ -6,18 +6,33 @@ using Momento.Sdk.Config.Transport;
 
 namespace Momento.Sdk.Config;
 
+/// <inheritdoc cref="Momento.Sdk.Config.IConfiguration" />
 public class Configuration : IConfiguration
 {
+    /// <inheritdoc cref="Momento.Sdk.Config.Retry.IRetryStrategy" />
     public IRetryStrategy RetryStrategy { get; }
+    /// <inheritdoc cref="Momento.Sdk.Config.Middleware.IMiddleware" />
     public IList<IMiddleware> Middlewares { get; }
+    /// <inheritdoc cref="Momento.Sdk.Config.Transport.ITransportStrategy" />
     public ITransportStrategy TransportStrategy { get; }
 
+    /// <summary>
+    /// <inheritdoc cref="Momento.Sdk.Config.IConfiguration" />
+    /// </summary>
+    /// <param name="retryStrategy">Defines a contract for how and when to retry a request</param>
+    /// <param name="transportStrategy">This is responsible for configuring network tunables.</param>
     public Configuration(IRetryStrategy retryStrategy, ITransportStrategy transportStrategy)
         : this(retryStrategy, new List<IMiddleware>(), transportStrategy)
     {
 
     }
 
+    /// <summary>
+    /// <inheritdoc cref="Momento.Sdk.Config.IConfiguration" />
+    /// </summary>
+    /// <param name="retryStrategy">Defines a contract for how and when to retry a request</param>
+    /// <param name="middlewares">The Middleware interface allows the Configuration to provide a higher-order function that wraps all requests.</param>
+    /// <param name="transportStrategy">This is responsible for configuring network tunables.</param>
     public Configuration(IRetryStrategy retryStrategy, IList<IMiddleware> middlewares, ITransportStrategy transportStrategy)
     {
         this.RetryStrategy = retryStrategy;
@@ -25,21 +40,41 @@ public class Configuration : IConfiguration
         this.TransportStrategy = transportStrategy;
     }
 
+    /// <summary>
+    ///  Configures retry strategy
+    /// </summary>
+    /// <param name="retryStrategy">Defines a contract for how and when to retry a request</param>
+    /// <returns>Configuration object with custom retry strategy provided</returns>
     public IConfiguration WithRetryStrategy(IRetryStrategy retryStrategy)
     {
         return new Configuration(retryStrategy, Middlewares, TransportStrategy);
     }
 
+    /// <summary>
+    ///  Configures middlewares
+    /// </summary>
+    /// <param name="middlewares">The Middleware interface allows the Configuration to provide a higher-order function that wraps all requests.</param>
+    /// <returns>Configuration object with custom middlewares provided</returns>
     public IConfiguration WithMiddlewares(IList<IMiddleware> middlewares)
     {
         return new Configuration(RetryStrategy, middlewares, TransportStrategy);
     }
 
+    /// <summary>
+    ///  Configures transport trategy
+    /// </summary>
+    /// <param name="transportStrategy">This is responsible for configuring network tunables.</param>
+    /// <returns>Configuration object with custom transport strategy provided</returns>
     public IConfiguration WithTransportStrategy(ITransportStrategy transportStrategy)
     {
         return new Configuration(RetryStrategy, Middlewares, transportStrategy);
     }
 
+    /// <summary>
+    ///  Configures middlewares
+    /// </summary>
+    /// <param name="additionalMiddlewares">The Middleware interface allows the Configuration to provide a higher-order function that wraps all requests.</param>
+    /// <returns>Configuration object with custom middlewares provided</returns>
     public Configuration WithAdditionalMiddlewares(IList<IMiddleware> additionalMiddlewares)
     {
         return new(
@@ -49,6 +84,11 @@ public class Configuration : IConfiguration
         );
     }
 
+    /// <summary>
+    ///  Configures client timeout for transport strategy
+    /// </summary>
+    /// <param name="clientTimeoutMillis">Client timeout in milliseconds.</param>
+    /// <returns>Configuration object with client timeout provided</returns>
     public Configuration WithClientTimeoutMillis(uint clientTimeoutMillis)
     {
         return new(

--- a/src/Momento.Sdk/Config/Configurations.cs
+++ b/src/Momento.Sdk/Config/Configurations.cs
@@ -5,6 +5,9 @@ using Momento.Sdk.Config.Transport;
 
 namespace Momento.Sdk.Config;
 
+/// <summary>
+/// Provide pre-build configurations.
+/// </summary>
 public class Configurations
 {
     /// <summary>

--- a/src/Momento.Sdk/Momento.Sdk.csproj
+++ b/src/Momento.Sdk/Momento.Sdk.csproj
@@ -13,8 +13,6 @@
 		<IncludeSymbols>true</IncludeSymbols>
 		<!-- Publish the repository URL in the built .nupkg -->
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
-		<!-- TODO: Address public-facing documentation -->
-		<NoWarn>1591</NoWarn>
 
 		<!-- Package metadata -->
 		<PackageId>Momento.Sdk</PackageId>
@@ -57,4 +55,14 @@
 	    <PrivateAssets>all</PrivateAssets>
 	  </PackageReference>
 	</ItemGroup>
+	<ProjectExtensions>
+	  <MonoDevelop>
+	    <Properties>
+	      <Policies>
+	        <TextStylePolicy TabWidth="4" IndentWidth="4" RemoveTrailingWhitespace="True" NoTabsAfterNonTabs="False" EolMarker="Native" FileWidth="80" TabsToSpaces="True" scope="application/xml" />
+	        <XmlFormattingPolicy scope="application/xml" />
+	      </Policies>
+	    </Properties>
+	  </MonoDevelop>
+	</ProjectExtensions>
 </Project>


### PR DESCRIPTION
This pr address the first 20 warnings of 165 warning we have for documentation.
Relevant ticket: https://github.com/momentohq/client-sdk-dotnet/issues/223