### PR TITLE
feat: simplify logging configuration

### DIFF
--- a/src/Momento.Sdk/Config/Configuration.cs
+++ b/src/Momento.Sdk/Config/Configuration.cs
@@ -26,8 +26,8 @@ public class Configuration : IConfiguration
     /// <param name="retryStrategy">Defines a contract for how and when to retry a request</param>
     /// <param name="transportStrategy">This is responsible for configuring network tunables.</param>
     /// <param name="loggerFactory">This is responsible for configuraing logging.</param>
-    public Configuration(IRetryStrategy retryStrategy, ITransportStrategy transportStrategy, ILoggerFactory? loggerFactory = null)
-        : this(retryStrategy, new List<IMiddleware>(), transportStrategy, loggerFactory)
+    public Configuration(ILoggerFactory loggerFactory, IRetryStrategy retryStrategy, ITransportStrategy transportStrategy)
+        : this(loggerFactory, retryStrategy, new List<IMiddleware>(), transportStrategy)
     {
 
     }
@@ -39,27 +39,12 @@ public class Configuration : IConfiguration
     /// <param name="middlewares">The Middleware interface allows the Configuration to provide a higher-order function that wraps all requests.</param>
     /// <param name="transportStrategy">This is responsible for configuring network tunables.</param>
     /// <param name="loggerFactory">This is responsible for configuraing logging.</param>
-    public Configuration(IRetryStrategy retryStrategy, IList<IMiddleware> middlewares, ITransportStrategy transportStrategy, ILoggerFactory? loggerFactory = null)
-
+    public Configuration(ILoggerFactory loggerFactory, IRetryStrategy retryStrategy, IList<IMiddleware> middlewares, ITransportStrategy transportStrategy)
     {
-        this.LoggerFactory = loggerFactory ?? NullLoggerFactory.Instance;
-
-        var retryStrategyWithLogger = retryStrategy.LoggerFactory != null ? retryStrategy : retryStrategy.WithLoggerFactory(loggerFactory!);
-        var middlewaresWithLogger = middlewares.Select(m => m.LoggerFactory != null ? m : m.WithLoggerFactory(loggerFactory!)).ToList();
-
-        this.RetryStrategy = retryStrategyWithLogger;
-        this.Middlewares = middlewaresWithLogger;
+        this.LoggerFactory = loggerFactory;
+        this.RetryStrategy = retryStrategy;
+        this.Middlewares = middlewares;
         this.TransportStrategy = transportStrategy;
-    }
-
-    /// <summary>
-    ///  Configures logging
-    /// </summary>
-    /// <param name="loggerFactory">This is responsible for configuraing logging.</param>
-    /// <returns>Configuration object with custom logging provided</returns>
-    public IConfiguration WithLoggerFactory(ILoggerFactory loggerFactory)
-    {
-        return new Configuration(RetryStrategy, Middlewares, TransportStrategy, loggerFactory);
     }
 
     /// <summary>
@@ -69,7 +54,7 @@ public class Configuration : IConfiguration
     /// <returns>Configuration object with custom retry strategy provided</returns>
     public IConfiguration WithRetryStrategy(IRetryStrategy retryStrategy)
     {
-        return new Configuration(retryStrategy, Middlewares, TransportStrategy, LoggerFactory);
+        return new Configuration(LoggerFactory, retryStrategy, Middlewares, TransportStrategy);
     }
 
     /// <summary>
@@ -79,7 +64,7 @@ public class Configuration : IConfiguration
     /// <returns>Configuration object with custom middlewares provided</returns>
     public IConfiguration WithMiddlewares(IList<IMiddleware> middlewares)
     {
-        return new Configuration(RetryStrategy, middlewares, TransportStrategy, LoggerFactory);
+        return new Configuration(LoggerFactory, RetryStrategy, middlewares, TransportStrategy);
     }
 
     /// <summary>
@@ -89,7 +74,7 @@ public class Configuration : IConfiguration
     /// <returns>Configuration object with custom transport strategy provided</returns>
     public IConfiguration WithTransportStrategy(ITransportStrategy transportStrategy)
     {
-        return new Configuration(RetryStrategy, Middlewares, transportStrategy, LoggerFactory);
+        return new Configuration(LoggerFactory, RetryStrategy, Middlewares, transportStrategy);
     }
 
     /// <summary>

--- a/src/Momento.Sdk/Config/Configurations.cs
+++ b/src/Momento.Sdk/Config/Configurations.cs
@@ -1,4 +1,6 @@
 using System.Collections.Generic;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Momento.Sdk.Config.Middleware;
 using Momento.Sdk.Config.Retry;
 using Momento.Sdk.Config.Transport;
@@ -16,24 +18,21 @@ public class Configurations
     /// </summary>
     public class Laptop : Configuration
     {
-        private Laptop(IRetryStrategy retryStrategy, ITransportStrategy transportStrategy)
-            : base(retryStrategy, transportStrategy)
+        private Laptop(ILoggerFactory loggerFactory, IRetryStrategy retryStrategy, ITransportStrategy transportStrategy)
+            : base(loggerFactory, retryStrategy, transportStrategy)
         {
 
         }
 
-        public static Laptop Latest
+        public static Laptop Latest(ILoggerFactory? loggerFactory = null)
         {
-            get
-            {
-                /*retryableStatusCodes = DEFAULT_RETRYABLE_STATUS_CODES,*/
-                IRetryStrategy retryStrategy = new FixedCountRetryStrategy(maxAttempts: 3);
-                ITransportStrategy transportStrategy = new StaticTransportStrategy(
-                    maxConcurrentRequests: 200,
-                    grpcConfig: new StaticGrpcConfiguration(deadlineMilliseconds: 5000)
-                );
-                return new Laptop(retryStrategy, transportStrategy);
-            }
+            var finalLoggerFactory = loggerFactory ?? NullLoggerFactory.Instance;
+            IRetryStrategy retryStrategy = new FixedCountRetryStrategy(finalLoggerFactory, maxAttempts: 3);
+            ITransportStrategy transportStrategy = new StaticTransportStrategy(
+                maxConcurrentRequests: 200,
+                grpcConfig: new StaticGrpcConfiguration(deadlineMilliseconds: 5000)
+            );
+            return new Laptop(finalLoggerFactory, retryStrategy, transportStrategy);
         }
     }
 
@@ -48,24 +47,21 @@ public class Configurations
         /// </summary>
         public class Default : Configuration
         {
-            private Default(IRetryStrategy retryStrategy, ITransportStrategy transportStrategy)
-                : base(retryStrategy, transportStrategy)
+            private Default(ILoggerFactory loggerFactory, IRetryStrategy retryStrategy, ITransportStrategy transportStrategy)
+                : base(loggerFactory, retryStrategy, transportStrategy)
             {
 
             }
 
-            public static Default Latest
+            public static Default Latest(ILoggerFactory? loggerFactory = null)
             {
-                get
-                {
-                    /*retryableStatusCodes = DEFAULT_RETRYABLE_STATUS_CODES,*/
-                    IRetryStrategy retryStrategy = new FixedCountRetryStrategy(maxAttempts: 3);
-                    ITransportStrategy transportStrategy = new StaticTransportStrategy(
-                        maxConcurrentRequests: 200,
-                        // TODO: tune the timeout value
-                        grpcConfig: new StaticGrpcConfiguration(deadlineMilliseconds: 1000));
-                    return new Default(retryStrategy, transportStrategy);
-                }
+                var finalLoggerFactory = loggerFactory ?? NullLoggerFactory.Instance;
+                IRetryStrategy retryStrategy = new FixedCountRetryStrategy(finalLoggerFactory, maxAttempts: 3);
+                ITransportStrategy transportStrategy = new StaticTransportStrategy(
+                    maxConcurrentRequests: 200,
+                    // TODO: tune the timeout value
+                    grpcConfig: new StaticGrpcConfiguration(deadlineMilliseconds: 1000));
+                return new Default(finalLoggerFactory, retryStrategy, transportStrategy);
             }
         }
 
@@ -76,25 +72,22 @@ public class Configurations
         /// </summary>
         public class LowLatency : Configuration
         {
-            private LowLatency(IRetryStrategy retryStrategy, ITransportStrategy transportStrategy)
-                : base(retryStrategy, transportStrategy)
+            private LowLatency(ILoggerFactory loggerFactory, IRetryStrategy retryStrategy, ITransportStrategy transportStrategy)
+                : base(loggerFactory, retryStrategy, transportStrategy)
             {
 
             }
 
-            public static LowLatency Latest
+            public static LowLatency Latest(ILoggerFactory? loggerFactory = null)
             {
-                get
-                {
-                    /*retryableStatusCodes = DEFAULT_RETRYABLE_STATUS_CODES,*/
-                    IRetryStrategy retryStrategy = new FixedCountRetryStrategy(maxAttempts: 3);
-                    ITransportStrategy transportStrategy = new StaticTransportStrategy(
-                        maxConcurrentRequests: 20,
-                        // TODO: tune the timeout value
-                        grpcConfig: new StaticGrpcConfiguration(deadlineMilliseconds: 1000)
-                    );
-                    return new LowLatency(retryStrategy, transportStrategy);
-                }
+                var finalLoggerFactory = loggerFactory ?? NullLoggerFactory.Instance;
+                IRetryStrategy retryStrategy = new FixedCountRetryStrategy(finalLoggerFactory, maxAttempts: 3);
+                ITransportStrategy transportStrategy = new StaticTransportStrategy(
+                    maxConcurrentRequests: 20,
+                    // TODO: tune the timeout value
+                    grpcConfig: new StaticGrpcConfiguration(deadlineMilliseconds: 1000)
+                );
+                return new LowLatency(finalLoggerFactory, retryStrategy, transportStrategy);
             }
         }
     }

--- a/src/Momento.Sdk/Config/IConfiguration.cs
+++ b/src/Momento.Sdk/Config/IConfiguration.cs
@@ -18,7 +18,6 @@ public interface IConfiguration
     public IList<IMiddleware> Middlewares { get; }
     public ITransportStrategy TransportStrategy { get; }
 
-    public IConfiguration WithLoggerFactory(ILoggerFactory loggerFactory);
     public IConfiguration WithRetryStrategy(IRetryStrategy retryStrategy);
     public IConfiguration WithMiddlewares(IList<IMiddleware> middlewares);
     public IConfiguration WithTransportStrategy(ITransportStrategy transportStrategy);

--- a/src/Momento.Sdk/Config/Middleware/IMiddleware.cs
+++ b/src/Momento.Sdk/Config/Middleware/IMiddleware.cs
@@ -36,10 +36,6 @@ public record struct MiddlewareResponseState<TResponse>(
 /// </summary>
 public interface IMiddleware
 {
-    public ILoggerFactory? LoggerFactory { get; }
-
-    public IMiddleware WithLoggerFactory(ILoggerFactory loggerFactory);
-
     /// <summary>
     /// Called as a wrapper around each request; can be used to time the request and collect metrics etc.
     /// </summary>

--- a/src/Momento.Sdk/Config/Middleware/LoggingMiddleware.cs
+++ b/src/Momento.Sdk/Config/Middleware/LoggingMiddleware.cs
@@ -12,24 +12,11 @@ namespace Momento.Sdk.Config.Middleware
     /// </summary>
     public class LoggingMiddleware : IMiddleware
     {
-        public ILoggerFactory LoggerFactory { get; }
-
         private readonly ILogger _logger;
 
         public LoggingMiddleware(ILoggerFactory loggerFactory)
         {
-            LoggerFactory = loggerFactory;
             _logger = loggerFactory.CreateLogger<LoggingMiddleware>();
-        }
-
-        public LoggingMiddleware WithLoggerFactory(ILoggerFactory loggerFactory)
-        {
-            return new(loggerFactory);
-        }
-
-        IMiddleware IMiddleware.WithLoggerFactory(ILoggerFactory loggerFactory)
-        {
-            return WithLoggerFactory(loggerFactory);
         }
 
         public async Task<MiddlewareResponseState<TResponse>> WrapRequest<TRequest, TResponse>(

--- a/src/Momento.Sdk/Config/Middleware/PassThroughMiddleware.cs
+++ b/src/Momento.Sdk/Config/Middleware/PassThroughMiddleware.cs
@@ -9,21 +9,11 @@ namespace Momento.Sdk.Config.Middleware;
 
 public class PassThroughMiddleware : IMiddleware
 {
-    public ILoggerFactory LoggerFactory { get; }
+    private readonly ILogger _logger;
 
     public PassThroughMiddleware(ILoggerFactory loggerFactory)
     {
-        LoggerFactory = loggerFactory;
-    }
-
-    public PassThroughMiddleware WithLoggerFactory(ILoggerFactory loggerFactory)
-    {
-        return new(loggerFactory);
-    }
-
-    IMiddleware IMiddleware.WithLoggerFactory(ILoggerFactory loggerFactory)
-    {
-        return WithLoggerFactory(loggerFactory);
+        _logger = loggerFactory.CreateLogger<PassThroughMiddleware>();
     }
 
     public Task<MiddlewareResponseState<TResponse>> WrapRequest<TRequest, TResponse>(
@@ -32,6 +22,7 @@ public class PassThroughMiddleware : IMiddleware
         Func<TRequest, CallOptions, Task<MiddlewareResponseState<TResponse>>> continuation
     ) where TRequest : class where TResponse : class
     {
+        _logger.LogDebug("Hello from PassThroughMiddleware");
         return continuation(request, callOptions);
     }
 

--- a/src/Momento.Sdk/Config/Retry/FixedCountRetryStrategy.cs
+++ b/src/Momento.Sdk/Config/Retry/FixedCountRetryStrategy.cs
@@ -8,34 +8,23 @@ namespace Momento.Sdk.Config.Retry;
 
 public class FixedCountRetryStrategy : IRetryStrategy
 {
-    public ILoggerFactory? LoggerFactory { get; }
-
+    private ILoggerFactory _loggerFactory;
     private ILogger _logger;
     private readonly IRetryEligibilityStrategy _eligibilityStrategy;
 
     public int MaxAttempts { get; }
 
-    public FixedCountRetryStrategy(int maxAttempts, IRetryEligibilityStrategy? eligibilityStrategy = null, ILoggerFactory? loggerFactory = null)
+    public FixedCountRetryStrategy(ILoggerFactory loggerFactory, int maxAttempts, IRetryEligibilityStrategy? eligibilityStrategy = null)
     {
-        LoggerFactory = loggerFactory;
-        _logger = (loggerFactory ?? NullLoggerFactory.Instance).CreateLogger<FixedCountRetryStrategy>();
+        _loggerFactory = loggerFactory;
+        _logger = loggerFactory.CreateLogger<FixedCountRetryStrategy>();
         _eligibilityStrategy = eligibilityStrategy ?? new DefaultRetryEligibilityStrategy(loggerFactory);
         MaxAttempts = maxAttempts;
     }
 
-    public FixedCountRetryStrategy WithLoggerFactory(ILoggerFactory loggerFactory)
-    {
-        return new(MaxAttempts, _eligibilityStrategy.WithLoggerFactory(loggerFactory), loggerFactory);
-    }
-
-    IRetryStrategy IRetryStrategy.WithLoggerFactory(ILoggerFactory loggerFactory)
-    {
-        return WithLoggerFactory(loggerFactory);
-    }
-
     public FixedCountRetryStrategy WithMaxAttempts(int maxAttempts)
     {
-        return new(maxAttempts, _eligibilityStrategy, LoggerFactory);
+        return new(_loggerFactory, maxAttempts, _eligibilityStrategy);
     }
 
     public int? DetermineWhenToRetryRequest<TRequest>(Status grpcStatus, TRequest grpcRequest, int attemptNumber) where TRequest : class

--- a/src/Momento.Sdk/Config/Retry/IRetryStrategy.cs
+++ b/src/Momento.Sdk/Config/Retry/IRetryStrategy.cs
@@ -8,9 +8,6 @@ namespace Momento.Sdk.Config.Retry;
 /// </summary>
 public interface IRetryStrategy
 {
-    public ILoggerFactory? LoggerFactory { get; }
-    public IRetryStrategy WithLoggerFactory(ILoggerFactory loggerFactory);
-
     /// <summary>
     /// Calculates whether or not to retry a request based on the type of request and number of attempts.
     /// </summary>

--- a/src/Momento.Sdk/Internal/Middleware/HeaderMiddleware.cs
+++ b/src/Momento.Sdk/Internal/Middleware/HeaderMiddleware.cs
@@ -26,8 +26,6 @@ namespace Momento.Sdk.Internal.Middleware
 
     internal class HeaderMiddleware : IMiddleware
     {
-        public ILoggerFactory? LoggerFactory { get; }
-
         private readonly List<Header> _headers;
         private readonly List<Header> headersToAddEveryTime = new List<Header> { };
         private readonly List<Header> headersToAddOnce = new List<Header> { };
@@ -38,16 +36,6 @@ namespace Momento.Sdk.Internal.Middleware
             _headers = headers;
             this.headersToAddOnce = headers.Where(header => header.onceOnlyHeaders.Contains(header.Name)).ToList();
             this.headersToAddEveryTime = headers.Where(header => !header.onceOnlyHeaders.Contains(header.Name)).ToList();
-        }
-
-        public HeaderMiddleware WithLoggerFactory(ILoggerFactory loggerFactory)
-        {
-            return new(loggerFactory, _headers);
-        }
-
-        IMiddleware IMiddleware.WithLoggerFactory(ILoggerFactory loggerFactory)
-        {
-            return WithLoggerFactory(loggerFactory);
         }
 
         public async Task<MiddlewareResponseState<TResponse>> WrapRequest<TRequest, TResponse>(

--- a/src/Momento.Sdk/Internal/Middleware/MaxConcurrentRequestsMiddleware.cs
+++ b/src/Momento.Sdk/Internal/Middleware/MaxConcurrentRequestsMiddleware.cs
@@ -36,25 +36,13 @@ namespace Momento.Sdk.Internal.Middleware
     // latencies by quite a bit.
     internal class MaxConcurrentRequestsMiddleware : IMiddleware
     {
-        public ILoggerFactory LoggerFactory { get; }
         private readonly int _maxConcurrentRequests;
         private readonly FairAsyncSemaphore _semaphore;
 
         public MaxConcurrentRequestsMiddleware(ILoggerFactory loggerFactory, int maxConcurrentRequests)
         {
-            LoggerFactory = loggerFactory;
             _maxConcurrentRequests = maxConcurrentRequests;
             _semaphore = new FairAsyncSemaphore(maxConcurrentRequests);
-        }
-
-        public MaxConcurrentRequestsMiddleware WithLoggerFactory(ILoggerFactory loggerFactory)
-        {
-            return new(loggerFactory, _maxConcurrentRequests);
-        }
-
-        IMiddleware IMiddleware.WithLoggerFactory(ILoggerFactory loggerFactory)
-        {
-            return WithLoggerFactory(loggerFactory);
         }
 
         public async Task<MiddlewareResponseState<TResponse>> WrapRequest<TRequest, TResponse>(

--- a/src/Momento.Sdk/Internal/Middleware/RetryMiddleware.cs
+++ b/src/Momento.Sdk/Internal/Middleware/RetryMiddleware.cs
@@ -11,26 +11,13 @@ namespace Momento.Sdk.Config.Retry
 {
     internal class RetryMiddleware : IMiddleware
     {
-        public ILoggerFactory? LoggerFactory { get; }
-
         private readonly ILogger _logger;
         private readonly IRetryStrategy _retryStrategy;
 
         public RetryMiddleware(ILoggerFactory loggerFactory, IRetryStrategy retryStrategy)
         {
-            LoggerFactory = loggerFactory;
             _logger = loggerFactory.CreateLogger<RetryMiddleware>();
             _retryStrategy = retryStrategy;
-        }
-
-        public RetryMiddleware WithLoggerFactory(ILoggerFactory loggerFactory)
-        {
-            return new(loggerFactory, _retryStrategy);
-        }
-
-        IMiddleware IMiddleware.WithLoggerFactory(ILoggerFactory loggerFactory)
-        {
-            return WithLoggerFactory(loggerFactory);
         }
 
         public async Task<MiddlewareResponseState<TResponse>> WrapRequest<TRequest, TResponse>(

--- a/tests/Integration/Momento.Sdk.Tests/Fixtures.cs
+++ b/tests/Integration/Momento.Sdk.Tests/Fixtures.cs
@@ -21,7 +21,7 @@ public class SimpleCacheClientFixture : IDisposable
         AuthProvider = new EnvMomentoTokenProvider("TEST_AUTH_TOKEN");
         CacheName = Environment.GetEnvironmentVariable("TEST_CACHE_NAME") ??
             throw new NullReferenceException("TEST_CACHE_NAME environment variable must be set.");
-        Client = new(Configurations.Laptop.Latest, AuthProvider, defaultTtlSeconds: DefaultTtlSeconds);
+        Client = new(Configurations.Laptop.Latest(), AuthProvider, defaultTtlSeconds: DefaultTtlSeconds);
 
         try
         {


### PR DESCRIPTION
Kenny called out on a previous PR that there was some code smell in the way I was managing the logging factories for the various components of the configuration.

This commit reworks things slightly so that the user still only has to pass in the ILoggerFactory in one spot in our pre-built configs, but we now just pass that directly through to the constructors of the other things that need it.  This allows us to get rid of the getters and copy constructors that we had previously exposed.