### PR TITLE
chore: add string auth provider

### DIFF
--- a/src/Momento.Sdk/Auth/StringMomentoTokenProvider.cs
+++ b/src/Momento.Sdk/Auth/StringMomentoTokenProvider.cs
@@ -2,12 +2,11 @@ namespace Momento.Sdk.Auth;
 
 using System;
 using Momento.Sdk.Exceptions;
-using Momento.Sdk.Internal;
 
 /// <summary>
-/// Reads and parses a JWT token stored as an environment variable.
+/// Reads and parses a JWT token stored as a string.
 /// </summary>
-public class EnvMomentoTokenProvider : ICredentialProvider
+public class StringMomentoTokenProvider : ICredentialProvider
 {
     /// <inheritdoc />
     public string AuthToken { get; private set; }
@@ -17,15 +16,15 @@ public class EnvMomentoTokenProvider : ICredentialProvider
     public string CacheEndpoint { get; private set; }
 
     /// <summary>
-    /// Reads and parses a JWT token stored as an environment variable.
+    /// Reads and parses a JWT token from a string.
     /// </summary>
-    /// <param name="name">Name of the environment variable that contains the JWT token.</param>
-    public EnvMomentoTokenProvider(string name)
+    /// <param name="token">The JWT token.</param>
+    public StringMomentoTokenProvider(string token)
     {
-        AuthToken = Environment.GetEnvironmentVariable(name);
+        AuthToken = token;
         if (String.IsNullOrEmpty(AuthToken))
         {
-            throw new InvalidArgumentException($"Environment variable '{name}' is empty or null.");
+            throw new InvalidArgumentException($"String '{token}' is empty or null.");
         }
 
         var claims = AuthUtils.TryDecodeAuthToken(AuthToken);

--- a/src/Momento.Sdk/Auth/Utils.cs
+++ b/src/Momento.Sdk/Auth/Utils.cs
@@ -1,0 +1,19 @@
+using Momento.Sdk.Exceptions;
+using Momento.Sdk.Internal;
+
+namespace Momento.Sdk.Auth;
+
+internal static class AuthUtils
+{
+    public static Claims TryDecodeAuthToken(string authToken)
+    {
+        try
+        {
+            return JwtUtils.DecodeJwt(authToken);
+        }
+        catch (InvalidArgumentException)
+        {
+            throw new InvalidArgumentException("The supplied Momento authToken is not valid.");
+        }
+    }
+}

--- a/src/Momento.Sdk/Config/IConfiguration.cs
+++ b/src/Momento.Sdk/Config/IConfiguration.cs
@@ -53,7 +53,7 @@ public interface IConfiguration
     /// <summary>
     /// Creates a new instance of the Configuration object, updated to use the specified client timeout.
     /// </summary>
-    /// <param name="clientTimeoutMillis">The amount of time to wait before cancelling the request.</param>
+    /// <param name="clientTimeout">The amount of time to wait before cancelling the request.</param>
     /// <returns>Configuration object with custom client timeout provided</returns>
     public IConfiguration WithClientTimeout(TimeSpan clientTimeout);
 }

--- a/tests/Unit/Momento.Sdk.Tests/Auth/StringMomentoTokenProviderTest.cs
+++ b/tests/Unit/Momento.Sdk.Tests/Auth/StringMomentoTokenProviderTest.cs
@@ -1,0 +1,17 @@
+using Momento.Sdk.Auth;
+using Momento.Sdk.Exceptions;
+using Xunit;
+
+namespace Momento.Sdk.Tests;
+
+public class StringMomentoTokenProviderTest
+{
+    [Fact]
+    public void StringMomentoTokenProvider_EmptyOrNull_ThrowsException()
+    {
+        Assert.Throws<InvalidArgumentException>(
+            () => new StringMomentoTokenProvider("eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJpbnRlZ3JhdGlvbiJ9.ZOgkTs")
+        );
+        Assert.Throws<InvalidArgumentException>(() => new StringMomentoTokenProvider(null!));
+    }
+}


### PR DESCRIPTION
Adds a new auth provider to read from a string passed in. This is used in examples when prompting for an auth token at the command line.