### PR TITLE
feat: Rename `Exception` to `InnerException`

### DIFF
--- a/src/Momento.Sdk/Responses/CacheDeleteResponse.cs
+++ b/src/Momento.Sdk/Responses/CacheDeleteResponse.cs
@@ -35,8 +35,8 @@ public abstract class CacheDeleteResponse
             _error = error;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="Exception"]/*' />
-        public SdkException Exception
+        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="InnerException"]/*' />
+        public SdkException InnerException
         {
             get => _error;
         }

--- a/src/Momento.Sdk/Responses/CacheGetResponse.cs
+++ b/src/Momento.Sdk/Responses/CacheGetResponse.cs
@@ -93,8 +93,8 @@ public abstract class CacheGetResponse
             _error = error;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="Exception"]/*' />
-        public SdkException Exception
+        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="InnerException"]/*' />
+        public SdkException InnerException
         {
             get => _error;
         }

--- a/src/Momento.Sdk/Responses/CacheSetResponse.cs
+++ b/src/Momento.Sdk/Responses/CacheSetResponse.cs
@@ -36,8 +36,8 @@ public abstract class CacheSetResponse
             _error = error;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="Exception"]/*' />
-        public SdkException Exception
+        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="InnerException"]/*' />
+        public SdkException InnerException
         {
             get => _error;
         }

--- a/src/Momento.Sdk/Responses/CreateCacheResponse.cs
+++ b/src/Momento.Sdk/Responses/CreateCacheResponse.cs
@@ -42,8 +42,8 @@ public abstract class CreateCacheResponse
             _error = error;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="Exception"]/*' />
-        public SdkException Exception
+        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="InnerException"]/*' />
+        public SdkException InnerException
         {
             get => _error;
         }

--- a/src/Momento.Sdk/Responses/DeleteCacheResponse.cs
+++ b/src/Momento.Sdk/Responses/DeleteCacheResponse.cs
@@ -36,8 +36,8 @@ public abstract class DeleteCacheResponse
             _error = error;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="Exception"]/*' />
-        public SdkException Exception
+        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="InnerException"]/*' />
+        public SdkException InnerException
         {
             get => _error;
         }

--- a/src/Momento.Sdk/Responses/ListCachesResponse.cs
+++ b/src/Momento.Sdk/Responses/ListCachesResponse.cs
@@ -75,8 +75,8 @@ public abstract class ListCachesResponse
             _error = error;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="Exception"]/*' />
-        public SdkException Exception
+        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="InnerException"]/*' />
+        public SdkException InnerException
         {
             get => _error;
         }

--- a/src/Momento.Sdk/docs.xml
+++ b/src/Momento.Sdk/docs.xml
@@ -33,7 +33,7 @@
         </code>
       </summary>
     </prop>
-    <prop name="Exception">
+    <prop name="InnerException">
       <summary>
         The <c>SdkException</c> object used to construct the response.
       </summary>

--- a/tests/Integration/Momento.Sdk.Tests/SimpleCacheControlTest.cs
+++ b/tests/Integration/Momento.Sdk.Tests/SimpleCacheControlTest.cs
@@ -43,7 +43,7 @@ public class SimpleCacheControlTest
         DeleteCacheResponse deleteResponse = await client.DeleteCacheAsync(null!);
         Assert.True(deleteResponse is DeleteCacheResponse.Error);
         DeleteCacheResponse.Error errorResponse = (DeleteCacheResponse.Error)deleteResponse;
-        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, errorResponse.Exception.ErrorCode);
+        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, errorResponse.InnerException.ErrorCode);
     }
 
     [Fact]
@@ -52,7 +52,7 @@ public class SimpleCacheControlTest
         DeleteCacheResponse response = await client.DeleteCacheAsync("non-existent cache");
         Assert.True(response is DeleteCacheResponse.Error);
         var errorResponse = (DeleteCacheResponse.Error)response;
-        Assert.Equal(MomentoErrorCode.NOT_FOUND_ERROR, errorResponse.Exception.ErrorCode);
+        Assert.Equal(MomentoErrorCode.NOT_FOUND_ERROR, errorResponse.InnerException.ErrorCode);
     }
 
     [Fact]
@@ -61,7 +61,7 @@ public class SimpleCacheControlTest
         CreateCacheResponse response = await client.CreateCacheAsync(null!);
         Assert.True(response is CreateCacheResponse.Error);
         CreateCacheResponse.Error errorResponse = (CreateCacheResponse.Error)response;
-        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, errorResponse.Exception.ErrorCode);
+        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, errorResponse.InnerException.ErrorCode);
     }
 
     // Tests: creating a cache, listing a cache, and deleting a cache.


### PR DESCRIPTION
This commit changes the name of the `Exception` object on our
Error classes to `InnerException`.  This seems like the pattern
that is used in the existing C# exception object model for
cases like ours, where you don't usually expect the caller to
dig into the nested error details but you want to make it possible
for them to do so.
