### PR TITLE
chore: hopefully final touches to README

### DIFF
--- a/README.template.md
+++ b/README.template.md
@@ -35,7 +35,6 @@ else if (getResponse is CacheGetResponse.Error getError)
 
 See the [Error Handling](#error-handling) section below for more details.
 
-
 ### Installation
 
 To create a new .NET project and add the Momento client library as a dependency:

--- a/README.template.md
+++ b/README.template.md
@@ -8,6 +8,34 @@ You will need the [`dotnet` runtime and command line tools](https://dotnet.micro
 
 **IDE Notes**: You will most likely want an IDE that supports .NET development, such as [Microsoft Visual Studio](https://visualstudio.microsoft.com/vs), [JetBrains Rider](https://www.jetbrains.com/rider/), or [Microsoft Visual Studio Code](https://code.visualstudio.com/).
 
+### Examples
+
+Ready to dive right in?  Just check out the [examples](./examples/README.md) directory for complete, working examples of
+how to use the SDK.
+
+### Momento Response Types
+
+The return values of the methods on the Momento `SimpleCacheClient` class are designed to allow you to use your
+IDE to help you easily discover all the possible responses, including errors.  We use [pattern matching](https://learn.microsoft.com/en-us/dotnet/csharp/fundamentals/functional/pattern-matching) to distinguish between different types of responses,
+which means that you can get compile-time safety when interacting with the API, rather than having bugs sneak in at runtime.
+
+Here's an example:
+
+```csharp
+CacheGetResponse getResponse = await client.GetAsync(CACHE_NAME, KEY);
+if (getResponse is CacheGetResponse.Hit hitResponse)
+{
+  Console.WriteLine($"Looked up value: {hitResponse.ValueString}, Stored value: {VALUE}");
+}
+else if (getResponse is CacheGetResponse.Error getError)
+{
+  Console.WriteLine($"Error getting value: {getError.Message}");
+}
+```
+
+See the [Error Handling](#error-handling) section below for more details.
+
+
 ### Installation
 
 To create a new .NET project and add the Momento client library as a dependency:
@@ -21,8 +49,6 @@ dotnet add package Momento.Sdk
 
 ### Usage
 
-Checkout our [examples](./examples/README.md) directory for complete examples of how to use the SDK.
-
 Here is a quickstart you can use in your own project:
 
 ```csharp
@@ -31,26 +57,6 @@ Here is a quickstart you can use in your own project:
 
 Note that the above code requires an environment variable named MOMENTO_AUTH_TOKEN which must
 be set to a valid [Momento authentication token](https://docs.momentohq.com/docs/getting-started#obtain-an-auth-token).
-
-**Momento Response Types**: The Momento `SimpleCacheClient` uses response types in a way you may not be familiar with and deserves
-a word of explanation upfront. Each response object's actual type will be a subtype (e.g., `CacheGetResponse.Hit`) of the requested response type (e.g., `CacheGetResponse`) and must be resolved to the correct subtype before accessing its properties. We recommend using [pattern matching](https://learn.microsoft.com/en-us/dotnet/csharp/fundamentals/functional/pattern-matching) to resolve the response's subtype and allow us to access the appropriate properties for that type:
-
-```csharp
-CreateCacheResponse createResponse = client.CreateCacheAsync("example-cache");
-if (createResponse is CreateCacheResponse.CacheAlreadyExists)
-{
-      // this may or may not be expected; handle as appropriate.
-}
-else if (createResponse is CreateCacheResponse.Error createError)
-{
-      if (createError.ErrorCode == MomentoErrorCode.LIMIT_EXCEEDED_ERROR)
-      {
-            // we've used our quota of caches; we should contact support@momentohq.com!
-      }
-}
-```
-
-See the "Error Handling" section below for more details.
 
 ### Error Handling
 
@@ -91,8 +97,8 @@ if (getResponse is CacheGetResponse.Error errorResponse)
 }
 ```
 
-Note that, outside of SimpleCacheClient responses, exceptions can occur and should be handled as usual. For example, trying to instantiate a SimpleCacheClient with an invalid authentication token will result in an
-IllegalArgumentException being thrown.
+Note that, outside of SimpleCacheClient responses, exceptions can occur and should be handled as usual. For example, trying
+to instantiate a SimpleCacheClient with an invalid authentication token will result in an IllegalArgumentException being thrown.
 
 ### Tuning
 
@@ -110,5 +116,13 @@ you might be interested in:
 - `Configurations.InRegion.LowLatency` - This config prioritizes keeping p99.9 latencies as low as possible, potentially sacrificing
       some throughput to achieve this.  Use this configuration if the most important factor is to ensure that cache
       unavailability doesn't force unacceptably high latencies for your own application.
+
+We hope that these configurations will meet the needs of most users, but if you find them lacking in any way, please
+open a github issue, or contact us at `support@momentohq.com`.  We would love to hear about your use case so that we
+can fix or extend the pre-built configs to support it.
+
+If you do need to customize your configuration beyond what our pre-builts provide, see the
+[Advanced Configuration Guide](./docs/advanced-config.md).
+
 
 {{ ossFooter }}

--- a/README.template.md
+++ b/README.template.md
@@ -123,5 +123,4 @@ can fix or extend the pre-built configs to support it.
 If you do need to customize your configuration beyond what our pre-builts provide, see the
 [Advanced Configuration Guide](./docs/advanced-config.md).
 
-
 {{ ossFooter }}

--- a/docs/advanced-config.md
+++ b/docs/advanced-config.md
@@ -1,0 +1,60 @@
+<head>
+  <meta name="Momento .NET Client Library Documentation" content=".NET client software development kit for Momento Serverless Cache">
+</head>
+<img src="https://docs.momentohq.com/img/logo.svg" alt="logo" width="400"/>
+
+# Momento .NET Client Library: Advanced Configuration
+
+## Changing the Client Timeout
+
+If the only setting you need to change is the client-side timeout, you can do this on the pre-built configs via
+the `WithClientTimeout` method:
+
+```csharp
+new SimpleCacheClient(
+    Configurations.InRegion.Default.Latest().WithClientTimeout(TimeSpan.FromSeconds(2))
+)
+```
+
+## Custom Configurations
+
+In most cases we hope that our pre-built configurations will meet your needs.  However, if you do need to override
+any of our default settings, you can create your own configuration object that implements our `IConfiguration`
+interface.
+
+
+The easiest way to do that is to use our `Configuration` class, which takes four arguments:
+
+```csharp
+new Configuration(loggerFactory, retryStrategy, middlewares, transportStrategy)
+```
+
+You can look at the source code in [Configurations.cs](../src/Momento.Sdk/Config/Configurations.cs) to see how our
+pre-builts are constructed, which is a great starting point for custom configurations.
+
+Here's more info on each of those arguments.
+
+### loggerFactory
+
+This is an instance of the .NET `ILoggerFactory`.  This will be used to configure logging for all Momento classes that
+consume this `IConfiguration`.
+
+### retryStrategy
+
+Controls whether failed requests are retried, and how.  The interface for this argument is `IRetryStrategy`; we provide
+some simple pre-built implementations such as `FixedCountRetryStrategy`, but you may provide your own implementation of
+this interface for custom retry behavior.
+
+### middlewares
+
+Here you may provide zero or more instances of `IMiddleware`, which allow you to intercept requests and responses and
+modify them as they are processed.  This could be used for logging debug or performance information, among other
+possible use cases.  See `LoggingMiddleware` for a very simple example.
+
+### transportStrategy
+
+This configures the low-level networking settings for communicating with the Momento service.  See the `ITransportStrategy`
+interface for more details.
+
+
+

--- a/docs/advanced-config.md
+++ b/docs/advanced-config.md
@@ -12,7 +12,9 @@ the `WithClientTimeout` method:
 
 ```csharp
 new SimpleCacheClient(
-    Configurations.InRegion.Default.Latest().WithClientTimeout(TimeSpan.FromSeconds(2))
+    Configurations.InRegion.Default.Latest().WithClientTimeout(TimeSpan.FromSeconds(2)),
+    authProvider,
+    defaultTtl
 )
 ```
 


### PR DESCRIPTION
Tweaks the ordering of the README sections a bit to make the
examples more prominent and highlight the pattern matching
earlier.

Also adds an initial doc for advanced configuration.

The README template generator will need to be tweaked to
accommodate these changes but this feels like a better
structure based on the feedback we got in the bug bash.
