### PR TITLE
chore: add middleware wrapper for `ListErase`

### DIFF
--- a/src/Momento.Sdk/Internal/DataGrpcManager.cs
+++ b/src/Momento.Sdk/Internal/DataGrpcManager.cs
@@ -35,6 +35,7 @@ public interface IDataClient
     public Task<_ListFetchResponse> ListFetchAsync(_ListFetchRequest request, CallOptions callOptions);
     public Task<_ListRemoveResponse> ListRemoveAsync(_ListRemoveRequest request, CallOptions callOptions);
     public Task<_ListLengthResponse> ListLengthAsync(_ListLengthRequest request, CallOptions callOptions);
+    public Task<_ListEraseResponse> ListEraseAsync(_ListEraseRequest request, CallOptions callOptions);
 }
 
 
@@ -162,6 +163,12 @@ public class DataClientWithMiddleware : IDataClient
     public async Task<_ListLengthResponse> ListLengthAsync(_ListLengthRequest request, CallOptions callOptions)
     {
         var wrapped = await _middlewares.WrapRequest(request, callOptions, (r, o) => _generatedClient.ListLengthAsync(r, o));
+        return await wrapped.ResponseAsync;
+    }
+
+    public async Task<_ListEraseResponse> ListEraseAsync(_ListEraseRequest request, CallOptions callOptions)
+    {
+        var wrapped = await _middlewares.WrapRequest(request, callOptions, (r, o) => _generatedClient.ListEraseAsync(r, o));
         return await wrapped.ResponseAsync;
     }
 }


### PR DESCRIPTION
In order to add the `ListDeleteAsync` command, we add a middleware wrapper for `ListErase` (which `ListDelete` reduces to).