### PR TITLE
chore: add internal grpc stubs for new List APIs

### DIFF
--- a/src/Momento.Sdk/Internal/DataGrpcManager.cs
+++ b/src/Momento.Sdk/Internal/DataGrpcManager.cs
@@ -36,6 +36,8 @@ public interface IDataClient
     public Task<_ListRemoveResponse> ListRemoveAsync(_ListRemoveRequest request, CallOptions callOptions);
     public Task<_ListLengthResponse> ListLengthAsync(_ListLengthRequest request, CallOptions callOptions);
     public Task<_ListEraseResponse> ListEraseAsync(_ListEraseRequest request, CallOptions callOptions);
+    public Task<_ListConcatenateFrontResponse> ListConcatenateFrontAsync(_ListConcatenateFrontRequest request, CallOptions callOptions);
+    public Task<_ListConcatenateBackResponse> ListConcatenateBackAsync(_ListConcatenateBackRequest request, CallOptions callOptions);
 }
 
 
@@ -169,6 +171,18 @@ public class DataClientWithMiddleware : IDataClient
     public async Task<_ListEraseResponse> ListEraseAsync(_ListEraseRequest request, CallOptions callOptions)
     {
         var wrapped = await _middlewares.WrapRequest(request, callOptions, (r, o) => _generatedClient.ListEraseAsync(r, o));
+        return await wrapped.ResponseAsync;
+    }
+
+    public async Task<_ListConcatenateFrontResponse> ListConcatenateFrontAsync(_ListConcatenateFrontRequest request, CallOptions callOptions)
+    {
+        var wrapped = await _middlewares.WrapRequest(request, callOptions, (r, o) => _generatedClient.ListConcatenateFrontAsync(r, o));
+        return await wrapped.ResponseAsync;
+    }
+
+    public async Task<_ListConcatenateBackResponse> ListConcatenateBackAsync(_ListConcatenateBackRequest request, CallOptions callOptions)
+    {
+        var wrapped = await _middlewares.WrapRequest(request, callOptions, (r, o) => _generatedClient.ListConcatenateBackAsync(r, o));
         return await wrapped.ResponseAsync;
     }
 }


### PR DESCRIPTION
Follow-up PR to add internal stubs so that `client-sdk-dotnet-incubating` can consume and extend the new API stubs.
