### PR TITLE
chore: truncate long CacheGetResponse.Hit string representations

### DIFF
--- a/src/Momento.Sdk/Internal/ExtensionMethods/ByteArrayExtensions.cs
+++ b/src/Momento.Sdk/Internal/ExtensionMethods/ByteArrayExtensions.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Text;
+
+namespace Momento.Sdk.Internal.ExtensionMethods;
+
+/// <summary>
+/// Defines extension methods to support pretty printing.
+/// </summary>
+public static class ByteArrayExtensions
+{
+    /// <summary>
+    /// Converts the byte array to a hex string.
+    /// </summary>
+    /// <param name="byteArray">The byte array to convert.</param>
+    /// <returns>The pretty hex string.</returns>
+    public static string ToPrettyHexString(this byte[] byteArray)
+    {
+        return BitConverter.ToString(byteArray);
+    }
+}
+
+

--- a/src/Momento.Sdk/Internal/ExtensionMethods/DictionaryExtensions.cs
+++ b/src/Momento.Sdk/Internal/ExtensionMethods/DictionaryExtensions.cs
@@ -1,0 +1,58 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Momento.Sdk.Internal.ExtensionMethods;
+
+/// <summary>
+/// Defines extension methods to operate on dictionaries with
+/// byte array keys and values.
+/// </summary>
+public static class ByteArrayDictionaryExtensions
+{
+    /// <summary>
+    /// DWIM equality implementation for dictionaries, cf <see href="https://docs.microsoft.com/en-us/dotnet/api/system.collections.generic.hashset-1.setequals?view=net-6.0">SetEquals</see>.
+    ///
+    ///
+    /// Tests whether the dictionaries contain the same content as opposed to the same
+    /// references.
+    /// </summary>
+    /// <param name="dictionary">LHS to compare</param>
+    /// <param name="other">RHS to compare</param>
+    /// <returns><see langword="true"/> if the dictionaries contain the same content.</returns>
+    public static bool DictionaryEquals(this Dictionary<byte[], byte[]> dictionary, Dictionary<byte[], byte[]> other)
+    {
+        if (dictionary == null && other == null)
+        {
+            return true;
+        }
+        else if (dictionary == null || other == null)
+        {
+            return false;
+        }
+        else if (dictionary.Count != other.Count)
+        {
+            return false;
+        }
+
+        var keySet = new HashSet<byte[]>(dictionary.Keys, Utils.ByteArrayComparer);
+        return other.All(kv => keySet.Contains(kv.Key) && dictionary[kv.Key].SequenceEqual(kv.Value));
+    }
+}
+
+
+/// <summary>
+/// Defines extension methods to operate on dictionaries with
+/// string keys and values.
+/// </summary>
+public static class StringStringDictionaryExtensions
+{
+    /// <summary>
+    /// Make a shallow copy of a dictionary.
+    /// </summary>
+    /// <param name="dictionary">The dictionary to copy.</param>
+    /// <returns>A new dictionary container with the same contents.</returns>
+    public static IDictionary<string, string> Clone(this IDictionary<string, string> dictionary)
+    {
+        return new Dictionary<string, string>(dictionary);
+    }
+}

--- a/src/Momento.Sdk/Internal/ExtensionMethods/ListExtensions.cs
+++ b/src/Momento.Sdk/Internal/ExtensionMethods/ListExtensions.cs
@@ -1,0 +1,39 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Momento.Sdk.Internal.ExtensionMethods;
+
+/// <summary>
+/// Defines extension methods to operate on lists containing
+/// byte arrays.
+/// </summary>
+public static class ByteArrayListExtensions
+{
+    /// <summary>
+    /// DWIM equality implementation for lists, cf <see href="https://docs.microsoft.com/en-us/dotnet/api/system.collections.generic.hashset-1.setequals?view=net-6.0">SetEquals</see>.
+    ///
+    ///
+    /// Tests whether the lists contain the same content as opposed to the same
+    /// references.
+    /// </summary>
+    /// <param name="list">LHS to compare</param>
+    /// <param name="other">RHS to compare</param>
+    /// <returns><see langword="true"/> if the lists contain the same content.</returns>
+    public static bool ListEquals(this List<byte[]> list, List<byte[]> other)
+    {
+        if (list == null && other == null)
+        {
+            return true;
+        }
+        else if (list == null || other == null)
+        {
+            return false;
+        }
+        else if (list.Count != other.Count)
+        {
+            return false;
+        }
+
+        return Enumerable.Range(0, list.Count).All(index => list[index].SequenceEqual(other[index]));
+    }
+}

--- a/src/Momento.Sdk/Internal/ExtensionMethods/StringExtensions.cs
+++ b/src/Momento.Sdk/Internal/ExtensionMethods/StringExtensions.cs
@@ -29,9 +29,12 @@ public static class StringExtensions
         }
 
         var firstHalf = totalLength / 2 - fillValue.Length / 2;
-        if (totalLength % 2 == 0)
+
+        // Even length and odd sized fillvalue means the output will have the same number of characters
+        // on either side of the fillValue. 
+        if (totalLength % 2 == 0 && fillValue.Length % 2 == 1)
         {
-            firstHalf -= (fillValue.Length % 2);
+            firstHalf--;
         }
 
         var sb = new StringBuilder();

--- a/src/Momento.Sdk/Internal/ExtensionMethods/StringExtensions.cs
+++ b/src/Momento.Sdk/Internal/ExtensionMethods/StringExtensions.cs
@@ -41,5 +41,3 @@ public static class StringExtensions
         return sb.ToString();
     }
 }
-
-

--- a/src/Momento.Sdk/Internal/ExtensionMethods/StringExtensions.cs
+++ b/src/Momento.Sdk/Internal/ExtensionMethods/StringExtensions.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Text;
+
+namespace Momento.Sdk.Internal.ExtensionMethods;
+
+/// <summary>
+/// Defines extension methods to support pretty printing.
+/// </summary>
+public static class StringExtensions
+{
+    /// <summary>
+    /// Truncates a string to a max length, eliding with a fill value.
+    /// </summary>
+    /// <param name="str">The string to truncate.</param>
+    /// <param name="totalLength">Maximum allowed input length.</param>
+    /// <param name="fillValue">The string to use to elide the input when it exceeds the max length.</param>
+    /// <returns>The original string if not too long, else the truncated string.</returns>
+    /// <exception cref="ArgumentException"></exception>
+    public static string Truncate(this string str, int totalLength = 20, string fillValue = "...")
+    {
+        if (str.Length <= totalLength)
+        {
+            return str;
+        }
+
+        if (fillValue.Length >= totalLength)
+        {
+            throw new ArgumentException($"fillValue was larger than totalLength: {fillValue} vs {totalLength}");
+        }
+
+        var firstHalf = totalLength / 2 - fillValue.Length / 2;
+        if (totalLength % 2 == 0)
+        {
+            firstHalf -= (fillValue.Length % 2);
+        }
+
+        var sb = new StringBuilder();
+        sb.Append(str.Substring(0, firstHalf));
+        sb.Append(fillValue);
+        sb.Append(str.Substring(str.Length - (totalLength - firstHalf - fillValue.Length)));
+        return sb.ToString();
+    }
+}
+
+

--- a/src/Momento.Sdk/Internal/ExtensionMethods/ToByteStringExtensions.cs
+++ b/src/Momento.Sdk/Internal/ExtensionMethods/ToByteStringExtensions.cs
@@ -1,0 +1,68 @@
+using System.Collections.Generic;
+using System.Linq;
+using Google.Protobuf;
+
+namespace Momento.Sdk.Internal.ExtensionMethods;
+
+/// <summary>
+/// Defines extension methods to support the conversion of data to
+/// various forms of ByteString.
+/// </summary>
+public static class ToByteStringExtensions
+{
+    /// <summary>
+    /// Convert a byte array to a <see cref="ByteString"/>
+    /// </summary>
+    /// <param name="byteArray">The byte array to convert.</param>
+    /// <returns>The byte array as a <see cref="ByteString"/></returns>
+    public static ByteString ToByteString(this byte[] byteArray)
+    {
+        return ByteString.CopyFrom(byteArray);
+    }
+
+    /// <summary>
+    /// Convert a UTF-8 string to a <see cref="ByteString"/>.
+    /// </summary>
+    /// <param name="str">The string to convert.</param>
+    /// <returns>The string as a <see cref="ByteString"/>.</returns>
+    public static ByteString ToByteString(this string str)
+    {
+        return ByteString.CopyFromUtf8(str);
+    }
+
+    /// <summary>
+    /// Convert a byte array to a singleton <see cref="ByteString"/> array
+    /// </summary>
+    /// <param name="byteArray">The byte array to convert.</param>
+    /// <returns>A length one array containing the converted byte array.</returns>
+    public static ByteString[] ToSingletonByteString(this byte[] byteArray)
+    {
+        return new ByteString[] { byteArray.ToByteString() };
+    }
+
+    /// <summary>
+    /// Convert a UTF-8 string to a singleton <see cref="ByteString"/> array.
+    /// </summary>
+    /// <param name="str">The string to convert.</param>
+    /// <returns>A length one array containing the converted string.</returns>
+    public static ByteString[] ToSingletonByteString(this string str)
+    {
+        return new ByteString[] { str.ToByteString() };
+    }
+
+    /// <summary>
+    /// Convert an enumerable of byte arrays to <see cref="IEnumerable{ByteString}"/>
+    /// </summary>
+    /// <param name="enumerable">The enumerable to convert.</param>
+    /// <returns>An enumerable over <see cref="ByteString"/>s.</returns>
+    public static IEnumerable<ByteString> ToEnumerableByteString(this IEnumerable<byte[]> enumerable)
+    {
+        return enumerable.Select(item => item.ToByteString());
+    }
+
+    /// <inheritdoc cref="ToEnumerableByteString(IEnumerable{byte[]})"/>
+    public static IEnumerable<ByteString> ToEnumerableByteString(this IEnumerable<string> enumerable)
+    {
+        return enumerable.Select(item => item.ToByteString());
+    }
+}

--- a/src/Momento.Sdk/Internal/Utils.cs
+++ b/src/Momento.Sdk/Internal/Utils.cs
@@ -3,294 +3,138 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using Google.Protobuf;
 
-namespace Momento.Sdk.Internal
+namespace Momento.Sdk.Internal;
+
+/// <summary>
+/// Ad-hoc utility methods.
+/// </summary>
+public static class Utils
 {
     /// <summary>
-    /// Ad-hoc utility methods.
+    /// Make a globally unique ID as a string.
     /// </summary>
-    public static class Utils
+    /// <returns>A GUID as a string.</returns>
+    public static string NewGuidString() => Guid.NewGuid().ToString();
+
+    /// <summary>
+    /// Make a globally unique ID as a byte array.
+    /// </summary>
+    /// <returns>A GUID as a byte array.</returns>
+    public static byte[] NewGuidByteArray() => Guid.NewGuid().ToByteArray();
+
+    /// <summary>
+    /// Convert a UTF-8 encoded string to a byte array.
+    /// </summary>
+    /// <param name="s">The string to convert.</param>
+    /// <returns>The string as a byte array.</returns>
+    public static byte[] Utf8ToByteArray(string s) => Encoding.UTF8.GetBytes(s);
+
+    /// <summary>
+    /// Throw an exception if the argument is <see langword="null"/>.
+    /// </summary>
+    /// <param name="argument">The instance to check for <see langword="null"/>.</param>
+    /// <param name="paramName">The name of the object to propagate to the exception.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="argument"/> is <see langword="null"/>.</exception>
+    public static void ArgumentNotNull(object? argument, string paramName)
     {
-        /// <summary>
-        /// Make a globally unique ID as a string.
-        /// </summary>
-        /// <returns>A GUID as a string.</returns>
-        public static string NewGuidString() => Guid.NewGuid().ToString();
-
-        /// <summary>
-        /// Make a globally unique ID as a byte array.
-        /// </summary>
-        /// <returns>A GUID as a byte array.</returns>
-        public static byte[] NewGuidByteArray() => Guid.NewGuid().ToByteArray();
-
-        /// <summary>
-        /// Convert a UTF-8 encoded string to a byte array.
-        /// </summary>
-        /// <param name="s">The string to convert.</param>
-        /// <returns>The string as a byte array.</returns>
-        public static byte[] Utf8ToByteArray(string s) => Encoding.UTF8.GetBytes(s);
-
-        /// <summary>
-        /// Throw an exception if the argument is <see langword="null"/>.
-        /// </summary>
-        /// <param name="argument">The instance to check for <see langword="null"/>.</param>
-        /// <param name="paramName">The name of the object to propagate to the exception.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="argument"/> is <see langword="null"/>.</exception>
-        public static void ArgumentNotNull(object? argument, string paramName)
+        if (argument == null)
         {
-            if (argument == null)
-            {
-                throw new ArgumentNullException(paramName);
-            }
+            throw new ArgumentNullException(paramName);
         }
-
-        /// <summary>
-        /// Throw an exception if any of the keys or values is <see langword="null"/>.
-        /// </summary>
-        /// <typeparam name="TKey">Key type.</typeparam>
-        /// <typeparam name="TValue">Value type.</typeparam>
-        /// <param name="argument">Enumerable to check for <see langword="null"/> keys/values.</param>
-        /// <param name="paramName">Name of the enumerable to propagate to the exception.</param>
-        /// <exception cref="ArgumentNullException">Any of <paramref name="argument"/> keys or values is <see langword="null"/>.</exception>
-        public static void KeysAndValuesNotNull<TKey, TValue>(IEnumerable<KeyValuePair<TKey, TValue>> argument, string paramName)
-        {
-            if (argument.Any(kv => kv.Key == null || kv.Value == null))
-            {
-                throw new ArgumentNullException(paramName, "Each key and value must be non-null");
-            }
-        }
-
-        /// <summary>
-        /// Throw an exception if any of the elements of the enumerable is <see langword="null"/>.
-        /// </summary>
-        /// <typeparam name="T">Enumerable element type.</typeparam>
-        /// <param name="argument">Enumerable to check for <see langword="null"/> elements.</param>
-        /// <param name="paramName">Name of the eumerable to propagate to the exception.</param>
-        /// <exception cref="ArgumentNullException">Any of <paramref name="argument"/> elements is <see langword="null"/>.</exception>
-        public static void ElementsNotNull<T>(IEnumerable<T> argument, string paramName)
-        {
-            if (argument.Any(value => value == null))
-            {
-                throw new ArgumentNullException(paramName, "Each value must be non-null");
-            }
-        }
-
-        /// <summary>
-        /// Throw an exception if the time span is zero or negative.
-        /// </summary>
-        /// <param name="argument">The time span to test.</param>
-        /// <param name="paramName">Name of the time span to propagate to the exception.</param>
-        /// <exception cref="ArgumentOutOfRangeException"><paramref name="argument"/> is zero or negative.</exception>
-        public static void ArgumentStrictlyPositive(TimeSpan? argument, string paramName)
-        {
-            if (argument is null)
-            {
-                return;
-            }
-
-            if (argument <= TimeSpan.Zero)
-            {
-                throw new ArgumentOutOfRangeException(paramName, "TimeSpan must be strictly positive.");
-            }
-        }
-
-        /// <summary>
-        /// Throw an exception if the value is zero or negative.
-        /// </summary>
-        /// <param name="argument">The value to test.</param>
-        /// <param name="paramName">Name of the value to propagate to the exception.</param>
-        /// <exception cref="ArgumentOutOfRangeException"><paramref name="argument"/> is zero or negative.</exception>
-        public static void ArgumentStrictlyPositive(int? argument, string paramName)
-        {
-            if (argument is null)
-            {
-                return;
-            }
-
-            if (argument <= 0)
-            {
-                throw new ArgumentOutOfRangeException(paramName, "TimeSpan must be strictly positive.");
-            }
-        }
-
-        /// <summary>
-        /// Defines methods to support comparing containers of reference items by their
-        /// contents (structure) instead of by reference.
-        /// </summary>
-        public class StructuralEqualityComparer<T> : IEqualityComparer<T>
-        {
-            /// <inheritdoc />
-            public bool Equals(T x, T y)
-            {
-                return StructuralComparisons.StructuralEqualityComparer.Equals(x, y);
-            }
-
-            /// <inheritdoc />
-            public int GetHashCode(T obj)
-            {
-                return StructuralComparisons.StructuralEqualityComparer.GetHashCode(obj);
-            }
-        }
-
-        /// <summary>
-        /// Comprarer to use in byte array containers (Set, Dictionary, List)
-        /// so comparisons operate on byte-array content instead of reference.
-        /// </summary>
-        public static StructuralEqualityComparer<byte[]> ByteArrayComparer = new();
     }
 
-    namespace ExtensionMethods
+    /// <summary>
+    /// Throw an exception if any of the keys or values is <see langword="null"/>.
+    /// </summary>
+    /// <typeparam name="TKey">Key type.</typeparam>
+    /// <typeparam name="TValue">Value type.</typeparam>
+    /// <param name="argument">Enumerable to check for <see langword="null"/> keys/values.</param>
+    /// <param name="paramName">Name of the enumerable to propagate to the exception.</param>
+    /// <exception cref="ArgumentNullException">Any of <paramref name="argument"/> keys or values is <see langword="null"/>.</exception>
+    public static void KeysAndValuesNotNull<TKey, TValue>(IEnumerable<KeyValuePair<TKey, TValue>> argument, string paramName)
     {
-        /// <summary>
-        /// Defines extension methods to support the conversion of data to
-        /// various forms of ByteString.
-        /// </summary>
-        public static class ToByteStringExtensions
+        if (argument.Any(kv => kv.Key == null || kv.Value == null))
         {
-            /// <summary>
-            /// Convert a byte array to a <see cref="ByteString"/>
-            /// </summary>
-            /// <param name="byteArray">The byte array to convert.</param>
-            /// <returns>The byte array as a <see cref="ByteString"/></returns>
-            public static ByteString ToByteString(this byte[] byteArray)
-            {
-                return ByteString.CopyFrom(byteArray);
-            }
-
-            /// <summary>
-            /// Convert a UTF-8 string to a <see cref="ByteString"/>.
-            /// </summary>
-            /// <param name="str">The string to convert.</param>
-            /// <returns>The string as a <see cref="ByteString"/>.</returns>
-            public static ByteString ToByteString(this string str)
-            {
-                return ByteString.CopyFromUtf8(str);
-            }
-
-            /// <summary>
-            /// Convert a byte array to a singleton <see cref="ByteString"/> array
-            /// </summary>
-            /// <param name="byteArray">The byte array to convert.</param>
-            /// <returns>A length one array containing the converted byte array.</returns>
-            public static ByteString[] ToSingletonByteString(this byte[] byteArray)
-            {
-                return new ByteString[] { byteArray.ToByteString() };
-            }
-
-            /// <summary>
-            /// Convert a UTF-8 string to a singleton <see cref="ByteString"/> array.
-            /// </summary>
-            /// <param name="str">The string to convert.</param>
-            /// <returns>A length one array containing the converted string.</returns>
-            public static ByteString[] ToSingletonByteString(this string str)
-            {
-                return new ByteString[] { str.ToByteString() };
-            }
-
-            /// <summary>
-            /// Convert an enumerable of byte arrays to <see cref="IEnumerable{ByteString}"/>
-            /// </summary>
-            /// <param name="enumerable">The enumerable to convert.</param>
-            /// <returns>An enumerable over <see cref="ByteString"/>s.</returns>
-            public static IEnumerable<ByteString> ToEnumerableByteString(this IEnumerable<byte[]> enumerable)
-            {
-                return enumerable.Select(item => item.ToByteString());
-            }
-
-            /// <inheritdoc cref="ToEnumerableByteString(IEnumerable{byte[]})"/>
-            public static IEnumerable<ByteString> ToEnumerableByteString(this IEnumerable<string> enumerable)
-            {
-                return enumerable.Select(item => item.ToByteString());
-            }
-        }
-
-        /// <summary>
-        /// Defines extension methods to operate on dictionaries with
-        /// byte array keys and values.
-        /// </summary>
-        public static class ByteArrayDictionaryExtensions
-        {
-            /// <summary>
-            /// DWIM equality implementation for dictionaries, cf <see href="https://docs.microsoft.com/en-us/dotnet/api/system.collections.generic.hashset-1.setequals?view=net-6.0">SetEquals</see>.
-            ///
-            ///
-            /// Tests whether the dictionaries contain the same content as opposed to the same
-            /// references.
-            /// </summary>
-            /// <param name="dictionary">LHS to compare</param>
-            /// <param name="other">RHS to compare</param>
-            /// <returns><see langword="true"/> if the dictionaries contain the same content.</returns>
-            public static bool DictionaryEquals(this Dictionary<byte[], byte[]> dictionary, Dictionary<byte[], byte[]> other)
-            {
-                if (dictionary == null && other == null)
-                {
-                    return true;
-                }
-                else if (dictionary == null || other == null)
-                {
-                    return false;
-                }
-                else if (dictionary.Count != other.Count)
-                {
-                    return false;
-                }
-
-                var keySet = new HashSet<byte[]>(dictionary.Keys, Utils.ByteArrayComparer);
-                return other.All(kv => keySet.Contains(kv.Key) && dictionary[kv.Key].SequenceEqual(kv.Value));
-            }
-        }
-
-        /// <summary>
-        /// Defines extension methods to operate on lists containing
-        /// byte arrays.
-        /// </summary>
-        public static class ByteArrayListExtensions
-        {
-            /// <summary>
-            /// DWIM equality implementation for lists, cf <see href="https://docs.microsoft.com/en-us/dotnet/api/system.collections.generic.hashset-1.setequals?view=net-6.0">SetEquals</see>.
-            ///
-            ///
-            /// Tests whether the lists contain the same content as opposed to the same
-            /// references.
-            /// </summary>
-            /// <param name="list">LHS to compare</param>
-            /// <param name="other">RHS to compare</param>
-            /// <returns><see langword="true"/> if the lists contain the same content.</returns>
-            public static bool ListEquals(this List<byte[]> list, List<byte[]> other)
-            {
-                if (list == null && other == null)
-                {
-                    return true;
-                }
-                else if (list == null || other == null)
-                {
-                    return false;
-                }
-                else if (list.Count != other.Count)
-                {
-                    return false;
-                }
-
-                return Enumerable.Range(0, list.Count).All(index => list[index].SequenceEqual(other[index]));
-            }
-        }
-
-        /// <summary>
-        /// Defines extension methods to operate on dictionaries with
-        /// string keys and values.
-        /// </summary>
-       public static class StringStringDictionaryExtensions
-        {
-            /// <summary>
-            /// Make a shallow copy of a dictionary.
-            /// </summary>
-            /// <param name="dictionary">The dictionary to copy.</param>
-            /// <returns>A new dictionary container with the same contents.</returns>
-            public static IDictionary<string, string> Clone(this IDictionary<string, string> dictionary)
-            {
-                return new Dictionary<string, string>(dictionary);
-            }
+            throw new ArgumentNullException(paramName, "Each key and value must be non-null");
         }
     }
+
+    /// <summary>
+    /// Throw an exception if any of the elements of the enumerable is <see langword="null"/>.
+    /// </summary>
+    /// <typeparam name="T">Enumerable element type.</typeparam>
+    /// <param name="argument">Enumerable to check for <see langword="null"/> elements.</param>
+    /// <param name="paramName">Name of the eumerable to propagate to the exception.</param>
+    /// <exception cref="ArgumentNullException">Any of <paramref name="argument"/> elements is <see langword="null"/>.</exception>
+    public static void ElementsNotNull<T>(IEnumerable<T> argument, string paramName)
+    {
+        if (argument.Any(value => value == null))
+        {
+            throw new ArgumentNullException(paramName, "Each value must be non-null");
+        }
+    }
+
+    /// <summary>
+    /// Throw an exception if the time span is zero or negative.
+    /// </summary>
+    /// <param name="argument">The time span to test.</param>
+    /// <param name="paramName">Name of the time span to propagate to the exception.</param>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="argument"/> is zero or negative.</exception>
+    public static void ArgumentStrictlyPositive(TimeSpan? argument, string paramName)
+    {
+        if (argument is null)
+        {
+            return;
+        }
+
+        if (argument <= TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(paramName, "TimeSpan must be strictly positive.");
+        }
+    }
+
+    /// <summary>
+    /// Throw an exception if the value is zero or negative.
+    /// </summary>
+    /// <param name="argument">The value to test.</param>
+    /// <param name="paramName">Name of the value to propagate to the exception.</param>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="argument"/> is zero or negative.</exception>
+    public static void ArgumentStrictlyPositive(int? argument, string paramName)
+    {
+        if (argument is null)
+        {
+            return;
+        }
+
+        if (argument <= 0)
+        {
+            throw new ArgumentOutOfRangeException(paramName, "TimeSpan must be strictly positive.");
+        }
+    }
+
+    /// <summary>
+    /// Defines methods to support comparing containers of reference items by their
+    /// contents (structure) instead of by reference.
+    /// </summary>
+    public class StructuralEqualityComparer<T> : IEqualityComparer<T>
+    {
+        /// <inheritdoc />
+        public bool Equals(T x, T y)
+        {
+            return StructuralComparisons.StructuralEqualityComparer.Equals(x, y);
+        }
+
+        /// <inheritdoc />
+        public int GetHashCode(T obj)
+        {
+            return StructuralComparisons.StructuralEqualityComparer.GetHashCode(obj);
+        }
+    }
+
+    /// <summary>
+    /// Comprarer to use in byte array containers (Set, Dictionary, List)
+    /// so comparisons operate on byte-array content instead of reference.
+    /// </summary>
+    public static StructuralEqualityComparer<byte[]> ByteArrayComparer = new();
 }

--- a/src/Momento.Sdk/Responses/CacheGetResponse.cs
+++ b/src/Momento.Sdk/Responses/CacheGetResponse.cs
@@ -1,6 +1,8 @@
 ﻿using Google.Protobuf;
 using Momento.Protos.CacheClient;
 using Momento.Sdk.Exceptions;
+using Momento.Sdk.Internal.ExtensionMethods;
+
 namespace Momento.Sdk.Responses;
 
 /// <summary>
@@ -67,7 +69,7 @@ public abstract class CacheGetResponse
         /// <inheritdoc />
         public override string ToString()
         {
-            return $"{base.ToString()}: {this.ValueString}";
+            return $"{base.ToString()}: ValueString: \"{this.ValueString.Truncate()}\" ValueByteArray: \"{ValueByteArray.ToPrettyHexString().Truncate()}\"";
         }
     }
 
@@ -99,13 +101,13 @@ public abstract class CacheGetResponse
             get => _error;
         }
 
-         /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="ErrorCode"]/*' />
+        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="ErrorCode"]/*' />
         public MomentoErrorCode ErrorCode
         {
             get => _error.ErrorCode;
         }
 
-         /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="Message"]/*' />
+        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="Message"]/*' />
         public string Message
         {
             get => $"{_error.MessageWrapper}: {_error.Message}";

--- a/tests/Unit/Momento.Sdk.Tests/Internal/ExtensionMethods/ByteArrayExtensionsTest.cs
+++ b/tests/Unit/Momento.Sdk.Tests/Internal/ExtensionMethods/ByteArrayExtensionsTest.cs
@@ -1,0 +1,16 @@
+using System;
+using Momento.Sdk.Internal.ExtensionMethods;
+using Xunit;
+
+public class ByteArrayExtensionsTest
+{
+    [Fact]
+    public void ToPrettyHexString_HappyPath()
+    {
+        var actual = new byte[] { 0x00, 0x01 }.ToPrettyHexString();
+        Assert.Equal("00-01", actual);
+
+        actual = new byte[] { 0xFF, 0xAB }.ToPrettyHexString();
+        Assert.Equal("FF-AB", actual);
+    }
+}

--- a/tests/Unit/Momento.Sdk.Tests/Internal/ExtensionMethods/StringExtensionsTest.cs
+++ b/tests/Unit/Momento.Sdk.Tests/Internal/ExtensionMethods/StringExtensionsTest.cs
@@ -14,6 +14,8 @@ public class StringExtensionsTest
     [InlineData("hello", 20, "...", "hello")]
     [InlineData("hello", 4, "...", "...o")]
     [InlineData("hellos", 5, "...", "h...s")]
+    [InlineData("hellos", 4, "..", "h..s")]
+    [InlineData("hellos", 5, "..", "h..os")]
     [InlineData("hello world", 10, "...", "hel...orld")]
     public void Truncate_StringSmall_ReturnsIdentical(string input, int totalLength, string fillValue, string expected)
     {

--- a/tests/Unit/Momento.Sdk.Tests/Internal/ExtensionMethods/StringExtensionsTest.cs
+++ b/tests/Unit/Momento.Sdk.Tests/Internal/ExtensionMethods/StringExtensionsTest.cs
@@ -1,0 +1,24 @@
+using System;
+using Momento.Sdk.Internal.ExtensionMethods;
+using Xunit;
+
+public class StringExtensionsTest
+{
+    [Fact]
+    public void Truncate_InvalidArguments_ThrowsException()
+    {
+        Assert.Throws<ArgumentException>(() => "hello".Truncate(totalLength: 2, fillValue: "..."));
+    }
+
+    [Theory]
+    [InlineData("hello", 20, "...", "hello")]
+    [InlineData("hello", 4, "...", "...o")]
+    [InlineData("hellos", 5, "...", "h...s")]
+    [InlineData("hello world", 10, "...", "hel...orld")]
+    public void Truncate_StringSmall_ReturnsIdentical(string input, int totalLength, string fillValue, string expected)
+    {
+        var truncated = input.Truncate(totalLength, fillValue);
+        Assert.Equal(expected, truncated);
+        Assert.True(truncated.Length <= totalLength);
+    }
+}

--- a/tests/Unit/Momento.Sdk.Tests/Responses/CacheGetResponseTest.cs
+++ b/tests/Unit/Momento.Sdk.Tests/Responses/CacheGetResponseTest.cs
@@ -16,4 +16,17 @@ public class CacheGetResponseTest
         CacheGetResponse.Hit responseHit = new CacheGetResponse.Hit(serverResponseHit);
         Assert.Equal(cacheBody, responseHit.ValueString);
     }
+
+    [Theory]
+    [InlineData("test body", "Momento.Sdk.Responses.CacheGetResponse+Hit: ValueString: \"test body\" ValueByteArray: \"74-65-73...-6F-64-79\"")]
+    [InlineData("this is a very long string and will be truncated", "Momento.Sdk.Responses.CacheGetResponse+Hit: ValueString: \"this is ...truncated\" ValueByteArray: \"74-68-69...-74-65-64\"")]
+    public void ToString_Truncates_HappyPath(string input, string expected)
+    {
+        ByteString body = ByteString.CopyFromUtf8(input);
+        _GetResponse serverResponseHit = new _GetResponse() { CacheBody = body, Result = ECacheResult.Hit };
+        CacheGetResponse.Hit responseHit = new CacheGetResponse.Hit(serverResponseHit);
+
+        var asString = responseHit.ToString();
+        Assert.Equal(expected, asString);
+    }
 }


### PR DESCRIPTION
This adds extension methods to both pretty print byte arrays and truncate strings. With these extension methods we trim the string representation of `CacheGetResponse.Hit`.

Closes #314 