### PR TITLE
chore: update GH workflow arg and JP `README`

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,7 +26,7 @@ jobs:
         uses: momentohq/standards-and-practices/github-actions/oss-readme-template@gh-actions-v1
         with:
           project_status: official
-          project_stability: beta
+          project_stability: stable
           project_type: sdk
           sdk_language: .NET
           usage_example_path: ./examples/MomentoUsage/Program.cs

--- a/.github/workflows/on-push-to-main-branch.yaml
+++ b/.github/workflows/on-push-to-main-branch.yaml
@@ -44,7 +44,7 @@ jobs:
         uses: momentohq/standards-and-practices/github-actions/generate-and-commit-oss-readme@gh-actions-v1
         with:
           project_status: official
-          project_stability: beta
+          project_stability: stable
           project_type: sdk
           sdk_language: .NET
           usage_example_path: ./examples/MomentoUsage/Program.cs

--- a/README.ja.md
+++ b/README.ja.md
@@ -8,10 +8,6 @@
 
 # Momento .NET Client Library
 
-:warning: Beta SDK :warning:
-
-こちらの SDK は Momento の公式 SDK ですが、API は Beta ステージです。詳細は上記の Beta ボタンをクリックしてください。
-
 Momento Serverless Cache の .NET クライアント SDK：従来のキャッシュが必要とするオペレーションオーバーヘッドが全く無く、速くて、シンプルで、従量課金のキャッシュです！
 
 ## さあ、使用開始 :running:


### PR DESCRIPTION
Updated the `on-push-to-main` workflow to take `project_stability=stable` and removed the beta warning from JP README. 