### PR TITLE
chore: dry exception handling

### DIFF
--- a/src/Momento.Sdk/Exceptions/CacheExceptionMapper.cs
+++ b/src/Momento.Sdk/Exceptions/CacheExceptionMapper.cs
@@ -5,13 +5,13 @@ using Microsoft.Extensions.Logging;
 
 namespace Momento.Sdk.Exceptions;
 
-    /// <summary>
-    /// This class maps low-level exceptions that occur during
-    /// <see cref="Momento.Sdk.SimpleCacheClient" /> requests to
-    /// Momento <see cref="Momento.Sdk.Exceptions.SdkException" />
-    /// exceptions. The <c>SdkException</c> is returned to the caller
-    /// as part of an <c>Error</c> response object.
-    /// </summary>
+/// <summary>
+/// This class maps low-level exceptions that occur during
+/// <see cref="Momento.Sdk.SimpleCacheClient" /> requests to
+/// Momento <see cref="Momento.Sdk.Exceptions.SdkException" />
+/// exceptions. The <c>SdkException</c> is returned to the caller
+/// as part of an <c>Error</c> response object.
+/// </summary>
 public class CacheExceptionMapper
 {
     private const string INTERNAL_SERVER_ERROR_MESSAGE = "Unexpected exception occurred while trying to fulfill the request.";
@@ -36,7 +36,7 @@ public class CacheExceptionMapper
     /// Convert a low-level exception to a Momento
     /// <see cref="Momento.Sdk.Exceptions.SdkException" />.
     /// </summary>
-    public SdkException Convert(Exception e)
+    public SdkException Convert(Exception e, Metadata? transportMetadata = null)
     {
         _logger.LogDebug("Mapping exception to SdkException: {}", e);
 
@@ -57,7 +57,7 @@ public class CacheExceptionMapper
         if (unwrappedException is RpcException ex)
         {
             MomentoErrorTransportDetails transportDetails = new MomentoErrorTransportDetails(
-                new MomentoGrpcErrorDetails(ex.StatusCode, ex.Message, null)
+                new MomentoGrpcErrorDetails(ex.StatusCode, ex.Message, transportMetadata)
             );
 
             switch (ex.StatusCode)

--- a/src/Momento.Sdk/Internal/ScsDataClient.cs
+++ b/src/Momento.Sdk/Internal/ScsDataClient.cs
@@ -108,18 +108,14 @@ internal sealed class ScsDataClient : ScsDataClientBase
     private async Task<CacheSetResponse> SendSetAsync(string cacheName, ByteString key, ByteString value, TimeSpan? ttl = null)
     {
         _SetRequest request = new _SetRequest() { CacheBody = value, CacheKey = key, TtlMilliseconds = TtlToMilliseconds(ttl) };
+        var metadata = MetadataWithCache(cacheName);
         try
         {
-            await this.grpcManager.Client.SetAsync(request, new CallOptions(headers: MetadataWithCache(cacheName), deadline: CalculateDeadline()));
+            await this.grpcManager.Client.SetAsync(request, new CallOptions(headers: metadata, deadline: CalculateDeadline()));
         }
         catch (Exception e)
         {
-            var exc = _exceptionMapper.Convert(e);
-            if (exc.TransportDetails != null)
-            {
-                exc.TransportDetails.Grpc.Metadata = MetadataWithCache(cacheName);
-            }
-            return new CacheSetResponse.Error(exc);
+            return new CacheSetResponse.Error(_exceptionMapper.Convert(e, metadata));
         }
         return new CacheSetResponse.Success();
     }
@@ -128,18 +124,14 @@ internal sealed class ScsDataClient : ScsDataClientBase
     {
         _GetRequest request = new _GetRequest() { CacheKey = key };
         _GetResponse response;
+        var metadata = MetadataWithCache(cacheName);
         try
         {
-            response = await this.grpcManager.Client.GetAsync(request, new CallOptions(headers: MetadataWithCache(cacheName), deadline: CalculateDeadline()));
+            response = await this.grpcManager.Client.GetAsync(request, new CallOptions(headers: metadata, deadline: CalculateDeadline()));
         }
         catch (Exception e)
         {
-            var exc = _exceptionMapper.Convert(e);
-            if (exc.TransportDetails != null)
-            {
-                exc.TransportDetails.Grpc.Metadata = MetadataWithCache(cacheName);
-            }
-            return new CacheGetResponse.Error(exc);
+            return new CacheGetResponse.Error(_exceptionMapper.Convert(e, metadata));
         }
 
         if (response.Result == ECacheResult.Miss)
@@ -152,18 +144,14 @@ internal sealed class ScsDataClient : ScsDataClientBase
     private async Task<CacheDeleteResponse> SendDeleteAsync(string cacheName, ByteString key)
     {
         _DeleteRequest request = new _DeleteRequest() { CacheKey = key };
+        var metadata = MetadataWithCache(cacheName);
         try
         {
-            await this.grpcManager.Client.DeleteAsync(request, new CallOptions(headers: MetadataWithCache(cacheName), deadline: CalculateDeadline()));
+            await this.grpcManager.Client.DeleteAsync(request, new CallOptions(headers: metadata, deadline: CalculateDeadline()));
         }
         catch (Exception e)
         {
-            var exc = _exceptionMapper.Convert(e);
-            if (exc.TransportDetails != null)
-            {
-                exc.TransportDetails.Grpc.Metadata = MetadataWithCache(cacheName);
-            }
-            return new CacheDeleteResponse.Error(exc);
+            return new CacheDeleteResponse.Error(_exceptionMapper.Convert(e, metadata));
         }
         return new CacheDeleteResponse.Success();
     }


### PR DESCRIPTION
This PR moves attaching the transport metadata to the exception
converter, where the transport details are created. This reduces
duplicated code in the data client.
