### PR TITLE
feat: add logging for all requests at TRACE level

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,13 @@
+TODO: add more info here.
+
+To run unit tests:
+
+```
+dotnet test tests/Unit/Momento.Sdk.Tests
+```
+
+To run integration tests:
+
+```
+dotnet test tests/Integration/Momento.Sdk.Tests
+```

--- a/src/Momento.Sdk/Internal/LoggingUtils.cs
+++ b/src/Momento.Sdk/Internal/LoggingUtils.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using Google.Protobuf;
+using Microsoft.Extensions.Logging;
+
+namespace Momento.Sdk.Internal
+{
+    /// <summary>
+    /// Utils for logging debug information about Momento requests and responses
+    /// </summary>
+    public static class LoggingUtils
+    {
+        /// <summary>
+        /// Logs a message at TRACE level that indicates that a request is about to be executed.
+        /// </summary>
+        /// <param name="_logger"></param>
+        /// <param name="requestType"></param>
+        /// <param name="cacheName"></param>
+        /// <param name="key"></param>
+        /// <param name="value"></param>
+        /// <param name="ttl"></param>
+        public static void LogTraceExecutingRequest(this ILogger _logger, string requestType, string cacheName, ByteString key, ByteString? value, TimeSpan? ttl)
+        {
+            if (_logger.IsEnabled(LogLevel.Trace)) {
+                var readableKey = ReadableByteString(key);
+                var readableValue = ReadableByteString(value);
+                _logger.LogTrace("Executing '{}' request: cacheName: {}; key: {}; value: {}; ttl: {}", requestType, cacheName, readableKey, readableValue, ttl);
+            }
+        }
+
+        /// <summary>
+        /// Logs a message at TRACE level that indicates that a request resulted in an error.
+        /// </summary>
+        /// <typeparam name="TError"></typeparam>
+        /// <param name="_logger"></param>
+        /// <param name="requestType"></param>
+        /// <param name="cacheName"></param>
+        /// <param name="key"></param>
+        /// <param name="value"></param>
+        /// <param name="ttl"></param>
+        /// <param name="error"></param>
+        /// <returns></returns>
+        public static TError LogTraceRequestError<TError>(this ILogger _logger, string requestType, string cacheName, ByteString key, ByteString? value, TimeSpan? ttl, TError error)
+        {
+            if (_logger.IsEnabled(LogLevel.Trace))
+            {
+                var readableKey = ReadableByteString(key);
+                var readableValue = ReadableByteString(value);
+                _logger.LogTrace("An error occurred while executing a '{}' request: cacheName: {}; key: {}; value: {}; ttl: {}; error: {}", requestType, cacheName, readableKey, readableValue, ttl, error);
+            }
+            return error;
+        }
+
+        /// <summary>
+        /// /// Logs a message at TRACE level that indicates that a request resulted in a success.
+        /// </summary>
+        /// <typeparam name="TSuccess"></typeparam>
+        /// <param name="_logger"></param>
+        /// <param name="requestType"></param>
+        /// <param name="cacheName"></param>
+        /// <param name="key"></param>
+        /// <param name="value"></param>
+        /// <param name="ttl"></param>
+        /// <param name="success"></param>
+        /// <returns></returns>
+        public static TSuccess LogTraceRequestSuccess<TSuccess>(this ILogger _logger, string requestType, string cacheName, ByteString key, ByteString? value, TimeSpan? ttl, TSuccess success)
+        {
+
+            if (_logger.IsEnabled(LogLevel.Trace))
+            {
+                var readableKey = ReadableByteString(key);
+                var readableValue = ReadableByteString(value);
+                _logger.LogTrace("Successfully executed '{}' request: cacheName: {}; key: {}; value: {}; ttl: {}; success: {}", requestType, cacheName, readableKey, readableValue, ttl, success);
+            }
+            return success;
+        }
+
+        private static string ReadableByteString(ByteString? input)
+        {
+            if (input == null)
+            {
+                return "(null)";
+            }
+            var readable = input.ToStringUtf8();
+            if (readable.Length <= 20)
+            {
+                return readable;
+            }
+            return readable.Substring(0, 20) + "...";
+        }
+    }
+}
+

--- a/tests/Integration/Momento.Sdk.Tests/Momento.Sdk.Tests.Integration.csproj
+++ b/tests/Integration/Momento.Sdk.Tests/Momento.Sdk.Tests.Integration.csproj
@@ -18,9 +18,13 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Momento.Sdk\Momento.Sdk.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Remove="Microsoft.Extensions.Logging.Console" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This commit adds logging for all requests; it will be visible
if your Microsoft.Extensions.LoggerFactory configuration
logs at TRACE level for the Momento SDK namespaces.

After this goes in I will do a similar thing in the incubating repo.