### PR TITLE
chore: change test runner log level to info

### DIFF
--- a/tests/Integration/Momento.Sdk.Tests/Fixtures.cs
+++ b/tests/Integration/Momento.Sdk.Tests/Fixtures.cs
@@ -24,7 +24,8 @@ public class SimpleCacheClientFixture : IDisposable
         CacheName = Environment.GetEnvironmentVariable("TEST_CACHE_NAME") ??
             throw new NullReferenceException("TEST_CACHE_NAME environment variable must be set.");
         Client = new(Configurations.Laptop.Latest().WithLoggerFactory(
-                LoggerFactory.Create(builder => {
+                LoggerFactory.Create(builder =>
+                {
                     builder.AddSimpleConsole(options =>
                     {
                         options.IncludeScopes = true;
@@ -32,11 +33,11 @@ public class SimpleCacheClientFixture : IDisposable
                         options.TimestampFormat = "hh:mm:ss ";
                     });
                     builder.AddFilter("Grpc.Net.Client", LogLevel.Error);
-                    builder.SetMinimumLevel(LogLevel.Trace);
+                    builder.SetMinimumLevel(LogLevel.Information);
                 })),
                 AuthProvider, defaultTtl: DefaultTtl);
 
-        var result = Client.CreateCacheAsync(CacheName).Result;    
+        var result = Client.CreateCacheAsync(CacheName).Result;
     }
 
     public void Dispose()


### PR DESCRIPTION
Previously the test runner log level was set to trace. In the a future
PR we will allow this to be set from the command line.
