### PR TITLE
feat: retry data structure commands

### DIFF
--- a/src/Momento.Sdk/Internal/DataGrpcManager.cs
+++ b/src/Momento.Sdk/Internal/DataGrpcManager.cs
@@ -35,7 +35,6 @@ public interface IDataClient
     public Task<_ListFetchResponse> ListFetchAsync(_ListFetchRequest request, CallOptions callOptions);
     public Task<_ListRemoveResponse> ListRemoveAsync(_ListRemoveRequest request, CallOptions callOptions);
     public Task<_ListLengthResponse> ListLengthAsync(_ListLengthRequest request, CallOptions callOptions);
-    public Task<_ListEraseResponse> ListEraseAsync(_ListEraseRequest request, CallOptions callOptions);
     public Task<_ListConcatenateFrontResponse> ListConcatenateFrontAsync(_ListConcatenateFrontRequest request, CallOptions callOptions);
     public Task<_ListConcatenateBackResponse> ListConcatenateBackAsync(_ListConcatenateBackRequest request, CallOptions callOptions);
 }
@@ -165,12 +164,6 @@ public class DataClientWithMiddleware : IDataClient
     public async Task<_ListLengthResponse> ListLengthAsync(_ListLengthRequest request, CallOptions callOptions)
     {
         var wrapped = await _middlewares.WrapRequest(request, callOptions, (r, o) => _generatedClient.ListLengthAsync(r, o));
-        return await wrapped.ResponseAsync;
-    }
-
-    public async Task<_ListEraseResponse> ListEraseAsync(_ListEraseRequest request, CallOptions callOptions)
-    {
-        var wrapped = await _middlewares.WrapRequest(request, callOptions, (r, o) => _generatedClient.ListEraseAsync(r, o));
         return await wrapped.ResponseAsync;
     }
 

--- a/src/Momento.Sdk/Internal/Retry/DefaultRetryEligibilityStrategy.cs
+++ b/src/Momento.Sdk/Internal/Retry/DefaultRetryEligibilityStrategy.cs
@@ -55,6 +55,12 @@ namespace Momento.Sdk.Internal.Retry
             // not idempotent: typeof(_ListPopFrontRequest),
             // not idempotent: typeof(_ListPopBackRequest),
             typeof(_ListFetchRequest),
+            /*
+             *  Warning: in the future, this may not be idempotent
+             *  Currently it supports removing all occurrences of a value.
+             *  In the future, we may also add "the first/last N occurrences of a value".
+             *  In the latter case it is not idempotent.
+             */
             typeof(_ListRemoveRequest),
             typeof(_ListLengthRequest),
             // not idempotent: typeof(_ListConcatenateFrontRequest),

--- a/src/Momento.Sdk/Internal/Retry/DefaultRetryEligibilityStrategy.cs
+++ b/src/Momento.Sdk/Internal/Retry/DefaultRetryEligibilityStrategy.cs
@@ -40,7 +40,25 @@ namespace Momento.Sdk.Internal.Retry
         private readonly HashSet<Type> _retryableRequestTypes = new HashSet<Type>
         {
             typeof(_SetRequest),
-            typeof(_GetRequest)
+            typeof(_GetRequest),
+            typeof(_DeleteRequest),
+            typeof(_DictionarySetRequest),
+            // not idempotent: typeof(_DictionaryIncrementRequest),
+            typeof(_DictionaryGetRequest),
+            typeof(_DictionaryFetchRequest),
+            typeof(_DictionaryDeleteRequest),
+            typeof(_SetUnionRequest),
+            typeof(_SetDifferenceRequest),
+            typeof(_SetFetchRequest),
+            // not idempotent: typeof(_ListPushFrontRequest),
+            // not idempotent: typeof(_ListPushBackRequest),
+            // not idempotent: typeof(_ListPopFrontRequest),
+            // not idempotent: typeof(_ListPopBackRequest),
+            typeof(_ListFetchRequest),
+            typeof(_ListRemoveRequest),
+            typeof(_ListLengthRequest),
+            // not idempotent: typeof(_ListConcatenateFrontRequest),
+            // not idempotent: typeof(_ListConcatenateBackRequest)
         };
 
         private readonly ILogger _logger;


### PR DESCRIPTION
Adds support to retry idempotent data structure operations. The only
commands at this point that are not idempotent are (i) ones that add or
delete from a list positionally, and (ii) increment.

closes https://github.com/momentohq/client-sdk-dotnet-incubating/issues/55