### PR TITLE
feat: add support for configuring eager connection on client

### DIFF
--- a/src/Momento.Sdk/Auth/EnvMomentoTokenProvider.cs
+++ b/src/Momento.Sdk/Auth/EnvMomentoTokenProvider.cs
@@ -9,6 +9,8 @@ using Momento.Sdk.Internal;
 /// </summary>
 public class EnvMomentoTokenProvider : ICredentialProvider
 {
+    private readonly string envVarName;
+    
     /// <inheritdoc />
     public string AuthToken { get; private set; }
     /// <inheritdoc />
@@ -22,6 +24,8 @@ public class EnvMomentoTokenProvider : ICredentialProvider
     /// <param name="name">Name of the environment variable that contains the JWT token.</param>
     public EnvMomentoTokenProvider(string name)
     {
+        this.envVarName = name;
+        
         AuthToken = Environment.GetEnvironmentVariable(name);
         if (String.IsNullOrEmpty(AuthToken))
         {
@@ -31,5 +35,12 @@ public class EnvMomentoTokenProvider : ICredentialProvider
         var claims = AuthUtils.TryDecodeAuthToken(AuthToken);
         ControlEndpoint = claims.ControlEndpoint;
         CacheEndpoint = claims.CacheEndpoint;
+    }
+
+    public ICredentialProvider WithCacheEndpoint(string cacheEndpoint)
+    {
+        var updated = new EnvMomentoTokenProvider(this.envVarName);
+        updated.CacheEndpoint = cacheEndpoint;
+        return updated;
     }
 }

--- a/src/Momento.Sdk/Auth/EnvMomentoTokenProvider.cs
+++ b/src/Momento.Sdk/Auth/EnvMomentoTokenProvider.cs
@@ -37,6 +37,7 @@ public class EnvMomentoTokenProvider : ICredentialProvider
         CacheEndpoint = claims.CacheEndpoint;
     }
 
+    /// <inheritdoc />
     public ICredentialProvider WithCacheEndpoint(string cacheEndpoint)
     {
         var updated = new EnvMomentoTokenProvider(this.envVarName);

--- a/src/Momento.Sdk/Auth/ICredentialProvider.cs
+++ b/src/Momento.Sdk/Auth/ICredentialProvider.cs
@@ -1,7 +1,5 @@
 namespace Momento.Sdk.Auth;
 
-using System.Collections.Generic;
-
 /// <summary>
 /// Specifies the fields that are required for a Momento client to connect to and authenticate with the Momento service.
 /// </summary>
@@ -19,4 +17,11 @@ public interface ICredentialProvider
     /// The host which the Momento client will connect to the Momento data plane
     /// </summary>
     string CacheEndpoint { get; }
+
+    /// <summary>
+    /// Copy constructor to override the CacheEndpoint
+    /// </summary>
+    /// <param name="cacheEndpoint"></param>
+    /// <returns>A new ICredentialProvider with the specified cache endpoint.</returns>
+    ICredentialProvider WithCacheEndpoint(string cacheEndpoint);
 }

--- a/src/Momento.Sdk/Auth/StringMomentoTokenProvider.cs
+++ b/src/Momento.Sdk/Auth/StringMomentoTokenProvider.cs
@@ -31,4 +31,12 @@ public class StringMomentoTokenProvider : ICredentialProvider
         ControlEndpoint = claims.ControlEndpoint;
         CacheEndpoint = claims.CacheEndpoint;
     }
+    
+    /// <inheritdoc />
+    public ICredentialProvider WithCacheEndpoint(string cacheEndpoint)
+    {
+        var updated = new StringMomentoTokenProvider(this.AuthToken);
+        updated.CacheEndpoint = cacheEndpoint;
+        return updated;
+    }
 }

--- a/src/Momento.Sdk/Config/Configurations.cs
+++ b/src/Momento.Sdk/Config/Configurations.cs
@@ -30,7 +30,7 @@ public class Configurations
         /// </summary>
         /// <param name="loggerFactory"></param>
         /// <returns></returns>
-        public static Laptop Latest(ILoggerFactory? loggerFactory = null)
+        public static IConfiguration Latest(ILoggerFactory? loggerFactory = null)
         {
             var finalLoggerFactory = loggerFactory ?? NullLoggerFactory.Instance;
             IRetryStrategy retryStrategy = new FixedCountRetryStrategy(finalLoggerFactory, maxAttempts: 3);
@@ -65,7 +65,7 @@ public class Configurations
             /// </summary>
             /// <param name="loggerFactory"></param>
             /// <returns></returns>
-            public static Default Latest(ILoggerFactory? loggerFactory = null)
+            public static IConfiguration Latest(ILoggerFactory? loggerFactory = null)
             {
                 var finalLoggerFactory = loggerFactory ?? NullLoggerFactory.Instance;
                 IRetryStrategy retryStrategy = new FixedCountRetryStrategy(finalLoggerFactory, maxAttempts: 3);
@@ -96,7 +96,7 @@ public class Configurations
             /// </summary>
             /// <param name="loggerFactory"></param>
             /// <returns></returns>
-            public static LowLatency Latest(ILoggerFactory? loggerFactory = null)
+            public static IConfiguration Latest(ILoggerFactory? loggerFactory = null)
             {
                 var finalLoggerFactory = loggerFactory ?? NullLoggerFactory.Instance;
                 IRetryStrategy retryStrategy = new FixedCountRetryStrategy(finalLoggerFactory, maxAttempts: 3);

--- a/src/Momento.Sdk/Config/Transport/ITransportStrategy.cs
+++ b/src/Momento.Sdk/Config/Transport/ITransportStrategy.cs
@@ -13,6 +13,13 @@ public interface ITransportStrategy
     /// allow onto the wire at a given time.
     /// </summary>
     public int MaxConcurrentRequests { get; }
+    
+    /// <summary>
+    /// If false, the client will only attempt to connect to the server lazily when the first request is executed.
+    /// If true, the client will attempt to connect to the server immediately upon construction.
+    /// </summary>
+    public Boolean EagerConnection { get;  }
+    
     /// <summary>
     /// Configures the low-level gRPC settings for the Momento client's communication
     /// with the Momento server.
@@ -39,4 +46,10 @@ public interface ITransportStrategy
     /// <param name="clientTimeout"></param>
     /// <returns>A new ITransportStrategy with the specified client timeout</returns>
     public ITransportStrategy WithClientTimeout(TimeSpan clientTimeout);
+
+    /// <summary>
+    /// Copy constructor to enable eager connection to the server
+    /// </summary>
+    /// <returns>A new ITransportStrategy configured to eagerly connect to the server upon construction</returns>
+    public ITransportStrategy WithEagerConnection();
 }

--- a/src/Momento.Sdk/Config/Transport/ITransportStrategy.cs
+++ b/src/Momento.Sdk/Config/Transport/ITransportStrategy.cs
@@ -15,10 +15,12 @@ public interface ITransportStrategy
     public int MaxConcurrentRequests { get; }
     
     /// <summary>
-    /// If false, the client will only attempt to connect to the server lazily when the first request is executed.
-    /// If true, the client will attempt to connect to the server immediately upon construction.
+    /// If null, the client will only attempt to connect to the server lazily when the first request is executed.
+    /// If provided, the client will attempt to connect to the server immediately upon construction; if the connection
+    /// cannot be established within the specified TimeSpan, it will abort the connection attempt, log a warning,
+    /// and proceed with execution so that the application doesn't hang.
     /// </summary>
-    public Boolean EagerConnection { get;  }
+    public TimeSpan? EagerConnectionTimeout { get; }
     
     /// <summary>
     /// Configures the low-level gRPC settings for the Momento client's communication
@@ -50,6 +52,11 @@ public interface ITransportStrategy
     /// <summary>
     /// Copy constructor to enable eager connection to the server
     /// </summary>
+    /// <param name="connectionTimeout">A timeout for attempting an eager connection to the server.  When the client
+    /// is constructed, it will attempt to connect to the server immediately.  If the connection
+    /// cannot be established within the specified TimeSpan, it will abort the connection attempt, log a warning,
+    /// and proceed with execution so that the application doesn't hang.
+    /// </param>
     /// <returns>A new ITransportStrategy configured to eagerly connect to the server upon construction</returns>
-    public ITransportStrategy WithEagerConnection();
+    public ITransportStrategy WithEagerConnectionTimeout(TimeSpan connectionTimeout);
 }

--- a/src/Momento.Sdk/Config/Transport/StaticTransportStrategy.cs
+++ b/src/Momento.Sdk/Config/Transport/StaticTransportStrategy.cs
@@ -66,7 +66,7 @@ public class StaticTransportStrategy : ITransportStrategy
     public int MaxConcurrentRequests { get; }
 
     /// <inheritdoc />
-    public bool EagerConnection { get; }
+    public TimeSpan? EagerConnectionTimeout { get; }
 
     /// <inheritdoc />
     public IGrpcConfiguration GrpcConfig { get; }
@@ -77,12 +77,15 @@ public class StaticTransportStrategy : ITransportStrategy
     /// <param name="loggerFactory"></param>
     /// <param name="maxConcurrentRequests">The maximum number of concurrent requests that the Momento client will allow on the wire at one time.</param>
     /// <param name="grpcConfig">Configures how Momento client interacts with the Momento service via gRPC</param>
-    /// <param name="eagerConnection">If true, client will eagerly attempt to connect to the server on construction.  If false, will connect to the server lazily on the first request.  Defaults to false.</param>
-    public StaticTransportStrategy(ILoggerFactory loggerFactory, int maxConcurrentRequests, IGrpcConfiguration grpcConfig, Boolean eagerConnection = false)
+    /// <param name="eagerConnectionTimeout">If null, the client will only attempt to connect to the server lazily when the first request is executed.
+    /// If provided, the client will attempt to connect to the server immediately upon construction; if the connection
+    /// cannot be established within the specified TimeSpan, it will abort the connection attempt, log a warning,
+    /// and proceed with execution so that the application doesn't hang.</param>
+    public StaticTransportStrategy(ILoggerFactory loggerFactory, int maxConcurrentRequests, IGrpcConfiguration grpcConfig, TimeSpan? eagerConnectionTimeout = null)
     {
         _loggerFactory = loggerFactory;
         MaxConcurrentRequests = maxConcurrentRequests;
-        EagerConnection = eagerConnection;
+        EagerConnectionTimeout = eagerConnectionTimeout;
         GrpcConfig = grpcConfig;
     }
 
@@ -105,8 +108,8 @@ public class StaticTransportStrategy : ITransportStrategy
     }
 
     /// <inheritdoc/>
-    public ITransportStrategy WithEagerConnection()
+    public ITransportStrategy WithEagerConnectionTimeout(TimeSpan connectionTimeout)
     {
-        return new StaticTransportStrategy(_loggerFactory, MaxConcurrentRequests, GrpcConfig, true);
+        return new StaticTransportStrategy(_loggerFactory, MaxConcurrentRequests, GrpcConfig, connectionTimeout);
     }
 }

--- a/src/Momento.Sdk/Config/Transport/StaticTransportStrategy.cs
+++ b/src/Momento.Sdk/Config/Transport/StaticTransportStrategy.cs
@@ -62,14 +62,13 @@ public class StaticTransportStrategy : ITransportStrategy
 {
     private readonly ILoggerFactory _loggerFactory;
 
-    /// <summary>
-    /// The maximum number of concurrent requests that the Momento client will
-    /// allow on the wire at one time.
-    /// </summary>
+    /// <inheritdoc />
     public int MaxConcurrentRequests { get; }
-    /// <summary>
-    /// Configures how Momento client interacts with the Momento service via gRPC
-    /// </summary>
+
+    /// <inheritdoc />
+    public bool EagerConnection { get; }
+
+    /// <inheritdoc />
     public IGrpcConfiguration GrpcConfig { get; }
 
     /// <summary>
@@ -78,10 +77,12 @@ public class StaticTransportStrategy : ITransportStrategy
     /// <param name="loggerFactory"></param>
     /// <param name="maxConcurrentRequests">The maximum number of concurrent requests that the Momento client will allow on the wire at one time.</param>
     /// <param name="grpcConfig">Configures how Momento client interacts with the Momento service via gRPC</param>
-    public StaticTransportStrategy(ILoggerFactory loggerFactory, int maxConcurrentRequests, IGrpcConfiguration grpcConfig)
+    /// <param name="eagerConnection">If true, client will eagerly attempt to connect to the server on construction.  If false, will connect to the server lazily on the first request.  Defaults to false.</param>
+    public StaticTransportStrategy(ILoggerFactory loggerFactory, int maxConcurrentRequests, IGrpcConfiguration grpcConfig, Boolean eagerConnection = false)
     {
         _loggerFactory = loggerFactory;
         MaxConcurrentRequests = maxConcurrentRequests;
+        EagerConnection = eagerConnection;
         GrpcConfig = grpcConfig;
     }
 
@@ -101,5 +102,11 @@ public class StaticTransportStrategy : ITransportStrategy
     public ITransportStrategy WithClientTimeout(TimeSpan clientTimeout)
     {
         return new StaticTransportStrategy(_loggerFactory, MaxConcurrentRequests, GrpcConfig.WithDeadline(clientTimeout));
+    }
+
+    /// <inheritdoc/>
+    public ITransportStrategy WithEagerConnection()
+    {
+        return new StaticTransportStrategy(_loggerFactory, MaxConcurrentRequests, GrpcConfig, true);
     }
 }

--- a/src/Momento.Sdk/Internal/DataGrpcManager.cs
+++ b/src/Momento.Sdk/Internal/DataGrpcManager.cs
@@ -220,13 +220,15 @@ public class DataGrpcManager : IDisposable
 
         var client = new Scs.ScsClient(invoker);
 
-        if (config.TransportStrategy.EagerConnection)
+        if (config.TransportStrategy.EagerConnectionTimeout != null)
         {
+            TimeSpan eagerConnectionTimeout = config.TransportStrategy.EagerConnectionTimeout.Value;
             _logger.LogDebug("TransportStrategy EagerConnection is enabled; attempting to connect to server");
             var pingClient = new Ping.PingClient(this.channel);
             try
             {
-                pingClient.Ping(new _PingRequest());
+                pingClient.Ping(new _PingRequest(),
+                    new CallOptions(deadline: DateTime.UtcNow.Add(eagerConnectionTimeout)));
             }
             catch (RpcException ex)
             {

--- a/tests/Integration/Momento.Sdk.Tests/SimpleCacheEagerConnectionTest.cs
+++ b/tests/Integration/Momento.Sdk.Tests/SimpleCacheEagerConnectionTest.cs
@@ -1,0 +1,50 @@
+using Microsoft.Extensions.Logging;
+using Momento.Sdk.Auth;
+using Momento.Sdk.Config;
+
+namespace Momento.Sdk.Tests.Integration;
+
+public class SimpleCacheEagerConnectionTest
+{
+    private readonly ILoggerFactory loggerFactory = LoggerFactory.Create(builder =>
+    {
+        builder.AddSimpleConsole(options =>
+        {
+            options.IncludeScopes = true;
+            options.SingleLine = true;
+            options.TimestampFormat = "hh:mm:ss ";
+        });
+        builder.AddFilter("Grpc.Net.Client", LogLevel.Error);
+        builder.SetMinimumLevel(LogLevel.Information);
+    });
+    private readonly TimeSpan defaultTtl = TimeSpan.FromMinutes(1);
+    private readonly ICredentialProvider authProvider = new EnvMomentoTokenProvider("TEST_AUTH_TOKEN");
+    
+    [Fact]
+    public void SimpleCacheClientConstructor_LazyConnection()
+    {
+        var config = Configurations.Laptop.Latest(loggerFactory);
+        // just validating that we can construct the client
+        var client = new SimpleCacheClient(config, authProvider, defaultTtl);
+    }
+    
+    [Fact]
+    public void SimpleCacheClientConstructor_EagerConnection_Success()
+    {
+        var config = Configurations.Laptop.Latest(loggerFactory);
+        config = config.WithTransportStrategy(config.TransportStrategy.WithEagerConnection());
+        // just validating that we can construct the client when the eager connection is successful
+        var client = new SimpleCacheClient(config, authProvider, defaultTtl);
+    }
+    
+    
+    [Fact]
+    public void SimpleCacheClientConstructor_EagerConnection_BadEndpoint()
+    {
+        var config = Configurations.Laptop.Latest(loggerFactory);
+        config = config.WithTransportStrategy(config.TransportStrategy.WithEagerConnection());
+        var authProviderWithBadCacheEndpoint = authProvider.WithCacheEndpoint("localhost:65000");
+        // validating that the constructor doesn't fail when the eager connection fails
+        var client = new SimpleCacheClient(config, authProviderWithBadCacheEndpoint, defaultTtl);
+    }
+}

--- a/tests/Integration/Momento.Sdk.Tests/SimpleCacheEagerConnectionTest.cs
+++ b/tests/Integration/Momento.Sdk.Tests/SimpleCacheEagerConnectionTest.cs
@@ -32,7 +32,7 @@ public class SimpleCacheEagerConnectionTest
     public void SimpleCacheClientConstructor_EagerConnection_Success()
     {
         var config = Configurations.Laptop.Latest(loggerFactory);
-        config = config.WithTransportStrategy(config.TransportStrategy.WithEagerConnection());
+        config = config.WithTransportStrategy(config.TransportStrategy.WithEagerConnectionTimeout(TimeSpan.FromSeconds(5)));
         // just validating that we can construct the client when the eager connection is successful
         var client = new SimpleCacheClient(config, authProvider, defaultTtl);
     }
@@ -42,8 +42,8 @@ public class SimpleCacheEagerConnectionTest
     public void SimpleCacheClientConstructor_EagerConnection_BadEndpoint()
     {
         var config = Configurations.Laptop.Latest(loggerFactory);
-        config = config.WithTransportStrategy(config.TransportStrategy.WithEagerConnection());
-        var authProviderWithBadCacheEndpoint = authProvider.WithCacheEndpoint("localhost:65000");
+        config = config.WithTransportStrategy(config.TransportStrategy.WithEagerConnectionTimeout(TimeSpan.FromSeconds(2)));
+        var authProviderWithBadCacheEndpoint = authProvider.WithCacheEndpoint("cache.cell-external-beta-1.prod.a.momentohq.com:65000");
         // validating that the constructor doesn't fail when the eager connection fails
         var client = new SimpleCacheClient(config, authProviderWithBadCacheEndpoint, defaultTtl);
     }


### PR DESCRIPTION
This commit adds a configuration setting that can be used to enable eager connection to the server when the client is constructed.  By default, the client establishes the connection lazily when the first request is executed.  However, this approach can lead to request timeouts on the first request if the connection takes too long to establish, because the connection time is counted toward the client-side timeout. When eager connections are enabled, the client will attempt to establish the connection to the server at construction time, which means that the connection will already be established before the first user request is issued.