### PR TITLE
doc: Make it clear what dotnet you need to install to run the examples.

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -4,7 +4,7 @@
 
 ## Prerequisites
 
-* [`dotnet`](https://dotnet.microsoft.com/en-us/download) 6.0 or higher is required
+* [`dotnet`](https://dotnet.microsoft.com/en-us/download) SDK version 6 is required.
 * A Momento auth token is required.  You can generate one using the [Momento CLI](https://github.com/momentohq/momento-cli).
 
 ## Running the advanced example


### PR DESCRIPTION
When I tried to install the examples, I tried both dotnet and dotnet-sdk from homebrew. They are v7 and did not work...

```
$ dotnet run --project MomentoApplication
You must install or update .NET to run this application.

App: /Volumes/Momento/client-sdk-dotnet/examples/MomentoApplication/bin/Debug/net6.0/MomentoApplication
Architecture: x64
Framework: 'Microsoft.NETCore.App', version '6.0.0' (x64)
.NET location: /usr/local/Cellar/dotnet/7.0.100/libexec

The following frameworks were found:
  7.0.0 at [/usr/local/Cellar/dotnet/7.0.100/libexec/shared/Microsoft.NETCore.App]

Learn about framework resolution:
https://aka.ms/dotnet/app-launch-failed

To install missing framework, download:
https://aka.ms/dotnet-core-applaunch?framework=Microsoft.NETCore.App&framework_version=6.0.0&arch=x64&rid=osx.12-x64
```

The above link there goes to the dotnet *runtime*, and that didn't work either. The SDK is needed. Once I got that installed it worked.

* The examples require v6 only.
* Make it clear the SDK is required.