### PR TITLE
feat: support configuring a minimum number of gRPC channels

### DIFF
--- a/src/Momento.Sdk/Config/Transport/IGrpcConfiguration.cs
+++ b/src/Momento.Sdk/Config/Transport/IGrpcConfiguration.cs
@@ -14,6 +14,19 @@ public interface IGrpcConfiguration
     public TimeSpan Deadline { get; }
 
     /// <summary>
+    /// Configures the minimum number of gRPC channels that the client will open to the
+    /// server.  By default, the client will only open one channel at startup, and will
+    /// dynamically create new channels whenever the existing channels have exceeded
+    /// the server's maximum number of concurrent requests (usually 100 requests per
+    /// channel).  For applications where the number of concurrent requests generally
+    /// stays below the server's threshold, this doesn't result in the ideal distribution
+    /// of load to the servers.  Setting this value to a number greater than one
+    /// ensures that there will be connections open to multiple servers, which can
+    /// help improve the load distribution (and thus performance).
+    /// </summary>
+    public int MinNumGrpcChannels { get; }
+
+    /// <summary>
     /// Override the default .NET GrpcChannelOptions.  (.NET only povides a strongly-typed
     /// interface for the channel options, which allows modifying specific values but does
     /// not allow the caller to use arbitrary strings to set the channel options.)
@@ -26,6 +39,14 @@ public interface IGrpcConfiguration
     /// <param name="deadline"></param>
     /// <returns>A new IGrpcConfiguration with the specified Deadline</returns>
     public IGrpcConfiguration WithDeadline(TimeSpan deadline);
+
+
+    /// <summary>
+    /// Copy constructor to override the minimum number of gRPC channels
+    /// </summary>
+    /// <param name="minNumGrpcChannels"></param>
+    /// <returns>A new IGrpcConfiguration with the specified minimum number of gRPC channels</returns>
+    public IGrpcConfiguration WithMinNumGrpcChannels(int minNumGrpcChannels);
 
     /// <summary>
     /// Copy constructor to override the channel options

--- a/src/Momento.Sdk/Config/Transport/StaticTransportStrategy.cs
+++ b/src/Momento.Sdk/Config/Transport/StaticTransportStrategy.cs
@@ -11,13 +11,11 @@ namespace Momento.Sdk.Config.Transport;
 /// </summary>
 public class StaticGrpcConfiguration : IGrpcConfiguration
 {
-    /// <summary>
-    /// Maximum amount of time before a request will timeout
-    /// </summary>
+    /// <inheritdoc/>
     public TimeSpan Deadline { get; }
-    /// <summary>
-    /// Customizations to low-level gRPC channel configuration
-    /// </summary>
+    /// <inheritdoc/>
+    public int MinNumGrpcChannels { get; }
+    /// <inheritdoc/>
     public GrpcChannelOptions GrpcChannelOptions { get; }
 
     /// <summary>
@@ -25,31 +23,31 @@ public class StaticGrpcConfiguration : IGrpcConfiguration
     /// </summary>
     /// <param name="deadline">Maximum amount of time before a request will timeout</param>
     /// <param name="grpcChannelOptions">Customizations to low-level gRPC channel configuration</param>
-    public StaticGrpcConfiguration(TimeSpan deadline, GrpcChannelOptions? grpcChannelOptions = null)
+    /// <param name="minNumGrpcChannels">minimum number of gRPC channels to open</param>
+    public StaticGrpcConfiguration(TimeSpan deadline, GrpcChannelOptions? grpcChannelOptions = null, int minNumGrpcChannels = 1)
     {
         Utils.ArgumentStrictlyPositive(deadline, nameof(deadline));
         this.Deadline = deadline;
+        this.MinNumGrpcChannels = minNumGrpcChannels;
         this.GrpcChannelOptions = grpcChannelOptions ?? new GrpcChannelOptions();
     }
 
-    /// <summary>
-    /// Copy constructor for overriding the deadline
-    /// </summary>
-    /// <param name="deadline"></param>
-    /// <returns>A new GrpcConfiguration with the updated deadline</returns>
+    /// <inheritdoc/>
     public IGrpcConfiguration WithDeadline(TimeSpan deadline)
     {
-        return new StaticGrpcConfiguration(deadline, this.GrpcChannelOptions);
+        return new StaticGrpcConfiguration(deadline, this.GrpcChannelOptions, this.MinNumGrpcChannels);
     }
 
-    /// <summary>
-    /// Copy constructor for overriding the gRPC channel options
-    /// </summary>
-    /// <param name="grpcChannelOptions"></param>
-    /// <returns>A new GrpcConfiguration with the specified channel options</returns>
+    /// <inheritdoc/>
+    public IGrpcConfiguration WithMinNumGrpcChannels(int minNumGrpcChannels)
+    {
+        return new StaticGrpcConfiguration(this.Deadline, this.GrpcChannelOptions, minNumGrpcChannels);
+    }
+
+    /// <inheritdoc/>
     public IGrpcConfiguration WithGrpcChannelOptions(GrpcChannelOptions grpcChannelOptions)
     {
-        return new StaticGrpcConfiguration(this.Deadline, grpcChannelOptions);
+        return new StaticGrpcConfiguration(this.Deadline, grpcChannelOptions, this.MinNumGrpcChannels);
     }
 }
 

--- a/src/Momento.Sdk/Internal/DataGrpcManager.cs
+++ b/src/Momento.Sdk/Internal/DataGrpcManager.cs
@@ -230,7 +230,7 @@ public class DataGrpcManager : IDisposable
                 pingClient.Ping(new _PingRequest(),
                     new CallOptions(deadline: DateTime.UtcNow.Add(eagerConnectionTimeout)));
             }
-            catch (RpcException ex)
+            catch (RpcException)
             {
                 _logger.LogWarning("Failed to eagerly connect to the server; continuing with execution in case failure is recoverable later.");
             }

--- a/src/Momento.Sdk/Momento.Sdk.csproj
+++ b/src/Momento.Sdk/Momento.Sdk.csproj
@@ -41,6 +41,7 @@
 	  <None Remove="Microsoft.Extensions.Logging" />
 	  <None Remove="Microsoft.SourceLink.GitHub" />
 	  <None Remove="Internal\Retry\" />
+	  <None Remove="System.Threading" />
 	</ItemGroup>
 	<ItemGroup>
 	  <Folder Include="Internal\Middleware\" />
@@ -57,6 +58,7 @@
 	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 	    <PrivateAssets>all</PrivateAssets>
 	  </PackageReference>
+	  <PackageReference Include="System.Threading" Version="4.3.0" />
 	</ItemGroup>
 	<ProjectExtensions>
 	  <MonoDevelop>

--- a/src/Momento.Sdk/SimpleCacheClient.cs
+++ b/src/Momento.Sdk/SimpleCacheClient.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Momento.Sdk.Auth;
@@ -17,7 +19,9 @@ namespace Momento.Sdk;
 public class SimpleCacheClient : ISimpleCacheClient
 {
     private readonly ScsControlClient controlClient;
-    private readonly ScsDataClient dataClient;
+    private readonly List<ScsDataClient> dataClients;
+    private int nextDataClientIndex = 0;
+
     /// <inheritdoc cref="Momento.Sdk.Config.IConfiguration" />
     protected readonly IConfiguration config;
     /// <inheritdoc cref="Microsoft.Extensions.Logging.ILogger" />
@@ -38,7 +42,11 @@ public class SimpleCacheClient : ISimpleCacheClient
         this._logger = _loggerFactory.CreateLogger<SimpleCacheClient>();
         Utils.ArgumentStrictlyPositive(defaultTtl, "defaultTtl");
         this.controlClient = new(_loggerFactory, authProvider.AuthToken, authProvider.ControlEndpoint);
-        this.dataClient = new(config, authProvider.AuthToken, authProvider.CacheEndpoint, defaultTtl);
+        this.dataClients = new List<ScsDataClient>();
+        for (var i = 1; i <= config.TransportStrategy.GrpcConfig.MinNumGrpcChannels; i++)
+        {
+            this.dataClients.Add(new(config, authProvider.AuthToken, authProvider.CacheEndpoint, defaultTtl));
+        }
     }
 
     /// <inheritdoc />
@@ -83,7 +91,7 @@ public class SimpleCacheClient : ISimpleCacheClient
         {
             return new CacheSetResponse.Error(new InvalidArgumentException(e.Message));
         }
-        return await this.dataClient.SetAsync(cacheName, key, value, ttl);
+        return await this.NextDataClient().SetAsync(cacheName, key, value, ttl);
     }
 
     /// <inheritdoc />
@@ -99,7 +107,7 @@ public class SimpleCacheClient : ISimpleCacheClient
             return new CacheGetResponse.Error(new InvalidArgumentException(e.Message));
         }
 
-        return await this.dataClient.GetAsync(cacheName, key);
+        return await this.NextDataClient().GetAsync(cacheName, key);
     }
 
     /// <inheritdoc />
@@ -115,7 +123,7 @@ public class SimpleCacheClient : ISimpleCacheClient
             return new CacheDeleteResponse.Error(new InvalidArgumentException(e.Message));
         }
 
-        return await this.dataClient.DeleteAsync(cacheName, key);
+        return await this.NextDataClient().DeleteAsync(cacheName, key);
     }
 
     /// <inheritdoc />
@@ -137,7 +145,7 @@ public class SimpleCacheClient : ISimpleCacheClient
             return new CacheSetResponse.Error(new InvalidArgumentException(e.Message));
         }
 
-        return await this.dataClient.SetAsync(cacheName, key, value, ttl);
+        return await this.NextDataClient().SetAsync(cacheName, key, value, ttl);
     }
 
     /// <inheritdoc />
@@ -152,7 +160,7 @@ public class SimpleCacheClient : ISimpleCacheClient
         {
             return new CacheGetResponse.Error(new InvalidArgumentException(e.Message));
         }
-        return await this.dataClient.GetAsync(cacheName, key);
+        return await this.NextDataClient().GetAsync(cacheName, key);
     }
 
     /// <inheritdoc />
@@ -168,7 +176,7 @@ public class SimpleCacheClient : ISimpleCacheClient
             return new CacheDeleteResponse.Error(new InvalidArgumentException(e.Message));
         }
 
-        return await this.dataClient.DeleteAsync(cacheName, key);
+        return await this.NextDataClient().DeleteAsync(cacheName, key);
     }
 
     /// <inheritdoc />
@@ -190,14 +198,23 @@ public class SimpleCacheClient : ISimpleCacheClient
             return new CacheSetResponse.Error(new InvalidArgumentException(e.Message));
         }
 
-        return await this.dataClient.SetAsync(cacheName, key, value, ttl);
+        return await this.NextDataClient().SetAsync(cacheName, key, value, ttl);
     }
 
     /// <inheritdoc />
     public void Dispose()
     {
         this.controlClient.Dispose();
-        this.dataClient.Dispose();
+        foreach (var dataClient in this.dataClients)
+        {
+            dataClient.Dispose();
+        }
         GC.SuppressFinalize(this);
+    }
+
+
+    private ScsDataClient NextDataClient()
+    {
+        return this.dataClients[Interlocked.Increment(ref this.nextDataClientIndex) % this.dataClients.Count];
     }
 }


### PR DESCRIPTION
This commit adds a setting to gRPC config that allows users to configure a minimum number of gRPC channels.  Prior to this, the client would always construct a single channel and would dynamically add additional ones only after we exceeded the maximum number of concurrent requests on the current channels. This results in imbalanced load on the server for cases where the number of concurrent requests remains below the threshold.

Users with this type of workload can increase this new setting to ensure they have more than one connection to the servers, and thus increase the likelihood of balancing requests across multiple servers for improved performance.