### PR TITLE
chore: rename dictionary items to elements

### DIFF
--- a/src/Momento.Sdk/ISimpleCacheClient.cs
+++ b/src/Momento.Sdk/ISimpleCacheClient.cs
@@ -234,16 +234,16 @@ public interface ISimpleCacheClient : IDisposable
     /// <inheritdoc cref="DictionarySetFieldAsync(string, string, byte[], byte[], CollectionTtl)" path="remark"/>
     /// <param name="cacheName">Name of the cache to store the dictionary in.</param>
     /// <param name="dictionaryName">The dictionary to set.</param>
-    /// <param name="items">The field-value pairs in the dictionary to set.</param>
+    /// <param name="elements">The field-value pairs in the dictionary to set.</param>
     /// <param name="ttl">TTL for the dictionary in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.</param>
     /// <returns>Task representing the result of the cache operation.</returns>
-    public Task<CacheDictionarySetFieldsResponse> DictionarySetFieldsAsync(string cacheName, string dictionaryName, IEnumerable<KeyValuePair<byte[], byte[]>> items, CollectionTtl ttl = default(CollectionTtl));
+    public Task<CacheDictionarySetFieldsResponse> DictionarySetFieldsAsync(string cacheName, string dictionaryName, IEnumerable<KeyValuePair<byte[], byte[]>> elements, CollectionTtl ttl = default(CollectionTtl));
 
     /// <inheritdoc cref="DictionarySetFieldsAsync(string, string, IEnumerable{KeyValuePair{byte[], byte[]}}, CollectionTtl)"/>
-    public Task<CacheDictionarySetFieldsResponse> DictionarySetFieldsAsync(string cacheName, string dictionaryName, IEnumerable<KeyValuePair<string, string>> items, CollectionTtl ttl = default(CollectionTtl));
+    public Task<CacheDictionarySetFieldsResponse> DictionarySetFieldsAsync(string cacheName, string dictionaryName, IEnumerable<KeyValuePair<string, string>> elements, CollectionTtl ttl = default(CollectionTtl));
 
     /// <inheritdoc cref="DictionarySetFieldsAsync(string, string, IEnumerable{KeyValuePair{byte[], byte[]}}, CollectionTtl)"/>
-    public Task<CacheDictionarySetFieldsResponse> DictionarySetFieldsAsync(string cacheName, string dictionaryName, IEnumerable<KeyValuePair<string, byte[]>> items, CollectionTtl ttl = default(CollectionTtl));
+    public Task<CacheDictionarySetFieldsResponse> DictionarySetFieldsAsync(string cacheName, string dictionaryName, IEnumerable<KeyValuePair<string, byte[]>> elements, CollectionTtl ttl = default(CollectionTtl));
 
     /// <summary>
     /// <para>Add an integer quantity to a dictionary value.</para>

--- a/src/Momento.Sdk/Internal/ScsDataClient.cs
+++ b/src/Momento.Sdk/Internal/ScsDataClient.cs
@@ -155,21 +155,21 @@ internal sealed class ScsDataClient : ScsDataClientBase
         return await SendDictionarySetFieldAsync(cacheName, dictionaryName, ToSingletonFieldValuePair(field, value), ttl);
     }
 
-    public async Task<CacheDictionarySetFieldsResponse> DictionarySetFieldsAsync(string cacheName, string dictionaryName, IEnumerable<KeyValuePair<byte[], byte[]>> items, CollectionTtl ttl = default(CollectionTtl))
+    public async Task<CacheDictionarySetFieldsResponse> DictionarySetFieldsAsync(string cacheName, string dictionaryName, IEnumerable<KeyValuePair<byte[], byte[]>> elements, CollectionTtl ttl = default(CollectionTtl))
     {
-        var protoItems = items.Select(kv => new _DictionaryFieldValuePair() { Field = kv.Key.ToByteString(), Value = kv.Value.ToByteString() });
+        var protoItems = elements.Select(kv => new _DictionaryFieldValuePair() { Field = kv.Key.ToByteString(), Value = kv.Value.ToByteString() });
         return await SendDictionarySetFieldsAsync(cacheName, dictionaryName, protoItems, ttl);
     }
 
-    public async Task<CacheDictionarySetFieldsResponse> DictionarySetFieldsAsync(string cacheName, string dictionaryName, IEnumerable<KeyValuePair<string, string>> items, CollectionTtl ttl = default(CollectionTtl))
+    public async Task<CacheDictionarySetFieldsResponse> DictionarySetFieldsAsync(string cacheName, string dictionaryName, IEnumerable<KeyValuePair<string, string>> elements, CollectionTtl ttl = default(CollectionTtl))
     {
-        var protoItems = items.Select(kv => new _DictionaryFieldValuePair() { Field = kv.Key.ToByteString(), Value = kv.Value.ToByteString() });
+        var protoItems = elements.Select(kv => new _DictionaryFieldValuePair() { Field = kv.Key.ToByteString(), Value = kv.Value.ToByteString() });
         return await SendDictionarySetFieldsAsync(cacheName, dictionaryName, protoItems, ttl);
     }
 
-    public async Task<CacheDictionarySetFieldsResponse> DictionarySetFieldsAsync(string cacheName, string dictionaryName, IEnumerable<KeyValuePair<string, byte[]>> items, CollectionTtl ttl = default(CollectionTtl))
+    public async Task<CacheDictionarySetFieldsResponse> DictionarySetFieldsAsync(string cacheName, string dictionaryName, IEnumerable<KeyValuePair<string, byte[]>> elements, CollectionTtl ttl = default(CollectionTtl))
     {
-        var protoItems = items.Select(kv => new _DictionaryFieldValuePair() { Field = kv.Key.ToByteString(), Value = kv.Value.ToByteString() });
+        var protoItems = elements.Select(kv => new _DictionaryFieldValuePair() { Field = kv.Key.ToByteString(), Value = kv.Value.ToByteString() });
         return await SendDictionarySetFieldsAsync(cacheName, dictionaryName, protoItems, ttl);
     }
 
@@ -468,7 +468,7 @@ internal sealed class ScsDataClient : ScsDataClientBase
     }
 
     const string REQUEST_TYPE_DICTIONARY_SET_FIELD = "DICTIONARY_SET_FIELD";
-    private async Task<CacheDictionarySetFieldResponse> SendDictionarySetFieldAsync(string cacheName, string dictionaryName, IEnumerable<_DictionaryFieldValuePair> items, CollectionTtl ttl)
+    private async Task<CacheDictionarySetFieldResponse> SendDictionarySetFieldAsync(string cacheName, string dictionaryName, IEnumerable<_DictionaryFieldValuePair> elements, CollectionTtl ttl)
     {
         _DictionarySetRequest request = new()
         {
@@ -476,24 +476,24 @@ internal sealed class ScsDataClient : ScsDataClientBase
             RefreshTtl = ttl.RefreshTtl,
             TtlMilliseconds = TtlToMilliseconds(ttl.Ttl)
         };
-        request.Items.Add(items);
+        request.Items.Add(elements);
         var metadata = MetadataWithCache(cacheName);
 
         try
         {
-            this._logger.LogTraceExecutingCollectionRequest(REQUEST_TYPE_DICTIONARY_SET_FIELD, cacheName, dictionaryName, items, ttl);
+            this._logger.LogTraceExecutingCollectionRequest(REQUEST_TYPE_DICTIONARY_SET_FIELD, cacheName, dictionaryName, elements, ttl);
             await this.grpcManager.Client.DictionarySetAsync(request, new CallOptions(headers: metadata, deadline: CalculateDeadline()));
         }
         catch (Exception e)
         {
-            return this._logger.LogTraceCollectionRequestError(REQUEST_TYPE_DICTIONARY_SET_FIELD, cacheName, dictionaryName, items, ttl, new CacheDictionarySetFieldResponse.Error(_exceptionMapper.Convert(e, metadata)));
+            return this._logger.LogTraceCollectionRequestError(REQUEST_TYPE_DICTIONARY_SET_FIELD, cacheName, dictionaryName, elements, ttl, new CacheDictionarySetFieldResponse.Error(_exceptionMapper.Convert(e, metadata)));
         }
 
-        return this._logger.LogTraceCollectionRequestSuccess(REQUEST_TYPE_DICTIONARY_SET_FIELD, cacheName, dictionaryName, items, ttl, new CacheDictionarySetFieldResponse.Success());
+        return this._logger.LogTraceCollectionRequestSuccess(REQUEST_TYPE_DICTIONARY_SET_FIELD, cacheName, dictionaryName, elements, ttl, new CacheDictionarySetFieldResponse.Success());
     }
 
     const string REQUEST_TYPE_DICTIONARY_SET_FIELDS = "DICTIONARY_SET_FIELDS";
-    private async Task<CacheDictionarySetFieldsResponse> SendDictionarySetFieldsAsync(string cacheName, string dictionaryName, IEnumerable<_DictionaryFieldValuePair> items, CollectionTtl ttl)
+    private async Task<CacheDictionarySetFieldsResponse> SendDictionarySetFieldsAsync(string cacheName, string dictionaryName, IEnumerable<_DictionaryFieldValuePair> elements, CollectionTtl ttl)
     {
         _DictionarySetRequest request = new()
         {
@@ -501,20 +501,20 @@ internal sealed class ScsDataClient : ScsDataClientBase
             RefreshTtl = ttl.RefreshTtl,
             TtlMilliseconds = TtlToMilliseconds(ttl.Ttl)
         };
-        request.Items.Add(items);
+        request.Items.Add(elements);
         var metadata = MetadataWithCache(cacheName);
 
         try
         {
-            this._logger.LogTraceExecutingCollectionRequest(REQUEST_TYPE_DICTIONARY_SET_FIELDS, cacheName, dictionaryName, items, ttl);
+            this._logger.LogTraceExecutingCollectionRequest(REQUEST_TYPE_DICTIONARY_SET_FIELDS, cacheName, dictionaryName, elements, ttl);
             await this.grpcManager.Client.DictionarySetAsync(request, new CallOptions(headers: metadata, deadline: CalculateDeadline()));
         }
         catch (Exception e)
         {
-            return this._logger.LogTraceCollectionRequestError(REQUEST_TYPE_DICTIONARY_SET_FIELDS, cacheName, dictionaryName, items, ttl, new CacheDictionarySetFieldsResponse.Error(_exceptionMapper.Convert(e, metadata)));
+            return this._logger.LogTraceCollectionRequestError(REQUEST_TYPE_DICTIONARY_SET_FIELDS, cacheName, dictionaryName, elements, ttl, new CacheDictionarySetFieldsResponse.Error(_exceptionMapper.Convert(e, metadata)));
         }
 
-        return this._logger.LogTraceCollectionRequestSuccess(REQUEST_TYPE_DICTIONARY_SET_FIELDS, cacheName, dictionaryName, items, ttl, new CacheDictionarySetFieldsResponse.Success());
+        return this._logger.LogTraceCollectionRequestSuccess(REQUEST_TYPE_DICTIONARY_SET_FIELDS, cacheName, dictionaryName, elements, ttl, new CacheDictionarySetFieldsResponse.Success());
     }
 
 

--- a/src/Momento.Sdk/SimpleCacheClient.cs
+++ b/src/Momento.Sdk/SimpleCacheClient.cs
@@ -298,57 +298,57 @@ public class SimpleCacheClient : ISimpleCacheClient
     }
 
     /// <inheritdoc />
-    public async Task<CacheDictionarySetFieldsResponse> DictionarySetFieldsAsync(string cacheName, string dictionaryName, IEnumerable<KeyValuePair<byte[], byte[]>> items, CollectionTtl ttl = default(CollectionTtl))
+    public async Task<CacheDictionarySetFieldsResponse> DictionarySetFieldsAsync(string cacheName, string dictionaryName, IEnumerable<KeyValuePair<byte[], byte[]>> elements, CollectionTtl ttl = default(CollectionTtl))
     {
         try
         {
             Utils.ArgumentNotNull(cacheName, nameof(cacheName));
             Utils.ArgumentNotNull(dictionaryName, nameof(dictionaryName));
-            Utils.ArgumentNotNull(items, nameof(items));
-            Utils.KeysAndValuesNotNull(items, nameof(items));
+            Utils.ArgumentNotNull(elements, nameof(elements));
+            Utils.KeysAndValuesNotNull(elements, nameof(elements));
         }
         catch (ArgumentNullException e)
         {
             return new CacheDictionarySetFieldsResponse.Error(new InvalidArgumentException(e.Message));
         }
 
-        return await this.DataClient.DictionarySetFieldsAsync(cacheName, dictionaryName, items, ttl);
+        return await this.DataClient.DictionarySetFieldsAsync(cacheName, dictionaryName, elements, ttl);
     }
 
     /// <inheritdoc />
-    public async Task<CacheDictionarySetFieldsResponse> DictionarySetFieldsAsync(string cacheName, string dictionaryName, IEnumerable<KeyValuePair<string, string>> items, CollectionTtl ttl = default(CollectionTtl))
+    public async Task<CacheDictionarySetFieldsResponse> DictionarySetFieldsAsync(string cacheName, string dictionaryName, IEnumerable<KeyValuePair<string, string>> elements, CollectionTtl ttl = default(CollectionTtl))
     {
         try
         {
             Utils.ArgumentNotNull(cacheName, nameof(cacheName));
             Utils.ArgumentNotNull(dictionaryName, nameof(dictionaryName));
-            Utils.ArgumentNotNull(items, nameof(items));
-            Utils.KeysAndValuesNotNull(items, nameof(items));
+            Utils.ArgumentNotNull(elements, nameof(elements));
+            Utils.KeysAndValuesNotNull(elements, nameof(elements));
         }
         catch (ArgumentNullException e)
         {
             return new CacheDictionarySetFieldsResponse.Error(new InvalidArgumentException(e.Message));
         }
 
-        return await this.DataClient.DictionarySetFieldsAsync(cacheName, dictionaryName, items, ttl);
+        return await this.DataClient.DictionarySetFieldsAsync(cacheName, dictionaryName, elements, ttl);
     }
 
     /// <inheritdoc />
-    public async Task<CacheDictionarySetFieldsResponse> DictionarySetFieldsAsync(string cacheName, string dictionaryName, IEnumerable<KeyValuePair<string, byte[]>> items, CollectionTtl ttl = default(CollectionTtl))
+    public async Task<CacheDictionarySetFieldsResponse> DictionarySetFieldsAsync(string cacheName, string dictionaryName, IEnumerable<KeyValuePair<string, byte[]>> elements, CollectionTtl ttl = default(CollectionTtl))
     {
         try
         {
             Utils.ArgumentNotNull(cacheName, nameof(cacheName));
             Utils.ArgumentNotNull(dictionaryName, nameof(dictionaryName));
-            Utils.ArgumentNotNull(items, nameof(items));
-            Utils.KeysAndValuesNotNull(items, nameof(items));
+            Utils.ArgumentNotNull(elements, nameof(elements));
+            Utils.KeysAndValuesNotNull(elements, nameof(elements));
         }
         catch (ArgumentNullException e)
         {
             return new CacheDictionarySetFieldsResponse.Error(new InvalidArgumentException(e.Message));
         }
 
-        return await this.DataClient.DictionarySetFieldsAsync(cacheName, dictionaryName, items, ttl);
+        return await this.DataClient.DictionarySetFieldsAsync(cacheName, dictionaryName, elements, ttl);
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
We rename dictionary "items" (field value pairs) to elements. That way
the way refer to an abstract collections contents (elements) is
consistent across dictionaries, sets, lists, etc. This change is
consistent with other SDKs.

Closes #365