### PR TITLE
chore: use unique cache name for CI jobs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       TEST_AUTH_TOKEN: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
-      TEST_CACHE_NAME: client-sdk-dotnet
+      TEST_CACHE_NAME: client-sdk-dotnet-${{ github.sha }}
 
     steps:
       - name: Get current time

--- a/.github/workflows/on-push-to-main-branch.yaml
+++ b/.github/workflows/on-push-to-main-branch.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       TEST_AUTH_TOKEN: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
-      TEST_CACHE_NAME: client-sdk-dotnet
+      TEST_CACHE_NAME: client-sdk-dotnet-${{ github.sha }}
 
     steps:
       - name: Get current time

--- a/.github/workflows/on-push-to-release-branch.yaml
+++ b/.github/workflows/on-push-to-release-branch.yaml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       TEST_AUTH_TOKEN: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
-      TEST_CACHE_NAME: client-sdk-dotnet
+      TEST_CACHE_NAME: client-sdk-dotnet-${{ github.sha }}
 
     steps:
       - name: Get current time
@@ -65,9 +65,6 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     needs: [release, test]
-    env:
-      TEST_AUTH_TOKEN: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
-      TEST_CACHE_NAME: client-sdk-dotnet
 
     steps:
       - name: Get current time


### PR DESCRIPTION
To prevent collisions when running multiple actions at the same time,
we append the commit sha to the cache name to make it unique.

Closes #372 