### PR TITLE
refactor: use interfaces for collections in response types

### DIFF
--- a/src/Momento.Sdk/Internal/ExtensionMethods/DictionaryExtensions.cs
+++ b/src/Momento.Sdk/Internal/ExtensionMethods/DictionaryExtensions.cs
@@ -19,7 +19,7 @@ public static class ByteArrayDictionaryExtensions
     /// <param name="dictionary">LHS to compare</param>
     /// <param name="other">RHS to compare</param>
     /// <returns><see langword="true"/> if the dictionaries contain the same content.</returns>
-    public static bool DictionaryEquals(this Dictionary<byte[], byte[]> dictionary, Dictionary<byte[], byte[]> other)
+    public static bool DictionaryEquals(this IDictionary<byte[], byte[]> dictionary, IDictionary<byte[], byte[]> other)
     {
         if (dictionary == null && other == null)
         {

--- a/src/Momento.Sdk/Internal/ExtensionMethods/ListExtensions.cs
+++ b/src/Momento.Sdk/Internal/ExtensionMethods/ListExtensions.cs
@@ -19,7 +19,7 @@ public static class ByteArrayListExtensions
     /// <param name="list">LHS to compare</param>
     /// <param name="other">RHS to compare</param>
     /// <returns><see langword="true"/> if the lists contain the same content.</returns>
-    public static bool ListEquals(this List<byte[]> list, List<byte[]> other)
+    public static bool ListEquals(this IList<byte[]> list, IList<byte[]> other)
     {
         if (list == null && other == null)
         {

--- a/src/Momento.Sdk/Responses/CacheDictionaryFetchResponse.cs
+++ b/src/Momento.Sdk/Responses/CacheDictionaryFetchResponse.cs
@@ -14,9 +14,9 @@ public abstract class CacheDictionaryFetchResponse
     public class Hit : CacheDictionaryFetchResponse
     {
         protected readonly RepeatedField<_DictionaryFieldValuePair>? items;
-        protected readonly Lazy<Dictionary<byte[], byte[]>> _dictionaryByteArrayByteArray;
-        protected readonly Lazy<Dictionary<string, string>> _dictionaryStringString;
-        protected readonly Lazy<Dictionary<string, byte[]>> _dictionaryStringByteArray;
+        protected readonly Lazy<IDictionary<byte[], byte[]>> _dictionaryByteArrayByteArray;
+        protected readonly Lazy<IDictionary<string, string>> _dictionaryStringString;
+        protected readonly Lazy<IDictionary<string, byte[]>> _dictionaryStringByteArray;
 
         public Hit(_DictionaryFetchResponse response)
         {
@@ -40,11 +40,11 @@ public abstract class CacheDictionaryFetchResponse
             });
         }
 
-        public Dictionary<byte[], byte[]> ValueDictionaryByteArrayByteArray { get => _dictionaryByteArrayByteArray.Value; }
+        public IDictionary<byte[], byte[]> ValueDictionaryByteArrayByteArray { get => _dictionaryByteArrayByteArray.Value; }
 
-        public Dictionary<string, string> ValueDictionaryStringString { get => _dictionaryStringString.Value; }
+        public IDictionary<string, string> ValueDictionaryStringString { get => _dictionaryStringString.Value; }
 
-        public Dictionary<string, byte[]> ValueDictionaryStringByteArray { get => _dictionaryStringByteArray.Value; }
+        public IDictionary<string, byte[]> ValueDictionaryStringByteArray { get => _dictionaryStringByteArray.Value; }
 
         /// <inheritdoc />
         public override string ToString()

--- a/src/Momento.Sdk/Responses/CacheDictionaryGetFieldsResponse.cs
+++ b/src/Momento.Sdk/Responses/CacheDictionaryGetFieldsResponse.cs
@@ -16,9 +16,9 @@ public abstract class CacheDictionaryGetFieldsResponse
     public class Hit : CacheDictionaryGetFieldsResponse
     {
         public List<CacheDictionaryGetFieldResponse> Responses { get; private set; }
-        protected readonly Lazy<Dictionary<byte[], byte[]>> _dictionaryByteArrayByteArray;
-        protected readonly Lazy<Dictionary<string, string>> _dictionaryStringString;
-        protected readonly Lazy<Dictionary<string, byte[]>> _dictionaryStringByteArray;
+        protected readonly Lazy<IDictionary<byte[], byte[]>> _dictionaryByteArrayByteArray;
+        protected readonly Lazy<IDictionary<string, string>> _dictionaryStringString;
+        protected readonly Lazy<IDictionary<string, byte[]>> _dictionaryStringByteArray;
 
         public Hit(IEnumerable<ByteString> fields, _DictionaryGetResponse responses)
         {
@@ -68,11 +68,11 @@ public abstract class CacheDictionaryGetFieldsResponse
             });
         }
 
-        public Dictionary<byte[], byte[]> ValueDictionaryByteArrayByteArray { get => _dictionaryByteArrayByteArray.Value; }
+        public IDictionary<byte[], byte[]> ValueDictionaryByteArrayByteArray { get => _dictionaryByteArrayByteArray.Value; }
 
-        public Dictionary<string, string> ValueDictionaryStringString { get => _dictionaryStringString.Value; }
+        public IDictionary<string, string> ValueDictionaryStringString { get => _dictionaryStringString.Value; }
 
-        public Dictionary<string, byte[]> ValueDictionaryStringByteArray { get => _dictionaryStringByteArray.Value; }
+        public IDictionary<string, byte[]> ValueDictionaryStringByteArray { get => _dictionaryStringByteArray.Value; }
 
         /// <inheritdoc />
         public override string ToString()

--- a/src/Momento.Sdk/Responses/CacheListFetchResponse.cs
+++ b/src/Momento.Sdk/Responses/CacheListFetchResponse.cs
@@ -14,8 +14,8 @@ public abstract class CacheListFetchResponse
     public class Hit : CacheListFetchResponse
     {
         protected readonly RepeatedField<ByteString> values;
-        protected readonly Lazy<List<byte[]>> _byteArrayList;
-        protected readonly Lazy<List<string>> _stringList;
+        protected readonly Lazy<IList<byte[]>> _byteArrayList;
+        protected readonly Lazy<IList<string>> _stringList;
 
         public Hit(_ListFetchResponse response)
         {
@@ -31,9 +31,9 @@ public abstract class CacheListFetchResponse
             });
         }
 
-        public List<byte[]> ValueListByteArray { get => _byteArrayList.Value; }
+        public IList<byte[]> ValueListByteArray { get => _byteArrayList.Value; }
 
-        public List<string> ValueListString { get => _stringList.Value; }
+        public IList<string> ValueListString { get => _stringList.Value; }
 
         /// <inheritdoc />
         public override string ToString()

--- a/src/Momento.Sdk/Responses/CacheSetFetchResponse.cs
+++ b/src/Momento.Sdk/Responses/CacheSetFetchResponse.cs
@@ -15,8 +15,8 @@ public abstract class CacheSetFetchResponse
     public class Hit : CacheSetFetchResponse
     {
         protected readonly RepeatedField<ByteString> elements;
-        protected readonly Lazy<HashSet<byte[]>> _byteArraySet;
-        protected readonly Lazy<HashSet<string>> _stringSet;
+        protected readonly Lazy<ISet<byte[]>> _byteArraySet;
+        protected readonly Lazy<ISet<string>> _stringSet;
 
         public Hit(_SetFetchResponse response)
         {
@@ -36,9 +36,9 @@ public abstract class CacheSetFetchResponse
             });
         }
 
-        public HashSet<byte[]> ValueSetByteArray { get => _byteArraySet.Value; }
+        public ISet<byte[]> ValueSetByteArray { get => _byteArraySet.Value; }
 
-        public HashSet<string> ValueSetString { get => _stringSet.Value; }
+        public ISet<string> ValueSetString { get => _stringSet.Value; }
 
         /// <inheritdoc />
         public override string ToString()


### PR DESCRIPTION
Refactor the response types to return/contain interfaces to
collections instead of concrete collection types. This allows greater
flexiblity for developers to mock and integrate the responses.

Closes #376 