### PR TITLE
feat: add v1 pre-built configurations

### DIFF
--- a/src/Momento.Sdk/Config/Configuration.cs
+++ b/src/Momento.Sdk/Config/Configuration.cs
@@ -101,4 +101,18 @@ public class Configuration : IConfiguration
     {
         return WithClientTimeout(clientTimeout);
     }
+
+    public override bool Equals(object obj)
+    {
+        if ((obj == null) || !this.GetType().Equals(obj.GetType()))
+        {
+            return false;
+        }
+
+        var other = (Configuration)obj;
+        return RetryStrategy.Equals(other.RetryStrategy) &&
+            Middlewares.SequenceEqual(other.Middlewares) &&
+            TransportStrategy.Equals(other.TransportStrategy) &&
+            LoggerFactory.Equals(other.LoggerFactory);
+    }
 }

--- a/src/Momento.Sdk/Config/Configuration.cs
+++ b/src/Momento.Sdk/Config/Configuration.cs
@@ -115,4 +115,9 @@ public class Configuration : IConfiguration
             TransportStrategy.Equals(other.TransportStrategy) &&
             LoggerFactory.Equals(other.LoggerFactory);
     }
+
+    public override int GetHashCode()
+    {
+        return base.GetHashCode();
+    }
 }

--- a/src/Momento.Sdk/Config/Configurations.cs
+++ b/src/Momento.Sdk/Config/Configurations.cs
@@ -28,9 +28,27 @@ public class Configurations
         /// <summary>
         /// Provides the latest recommended configuration for a Laptop environment.
         /// </summary>
+        /// <remark>
+        /// This configuration may change in future releases to take advantage of
+        /// improvements we identify for default configurations.
+        /// </remark>
         /// <param name="loggerFactory"></param>
         /// <returns></returns>
         public static IConfiguration Latest(ILoggerFactory? loggerFactory = null)
+        {
+            return V1(loggerFactory);
+        }
+
+        /// <summary>
+        /// Provides version 1 configuration for a Laptop environment.
+        /// </summary>
+        /// <remark>
+        /// This configuration is guaranteed not to change in future
+        /// releases of the Momento .NET SDK.
+        /// </remark>
+        /// <param name="loggerFactory"></param>
+        /// <returns></returns>
+        public static IConfiguration V1(ILoggerFactory? loggerFactory = null)
         {
             var finalLoggerFactory = loggerFactory ?? NullLoggerFactory.Instance;
             IRetryStrategy retryStrategy = new FixedCountRetryStrategy(finalLoggerFactory, maxAttempts: 3);
@@ -63,9 +81,27 @@ public class Configurations
             /// <summary>
             /// Provides the latest recommended configuration for an InRegion environment.
             /// </summary>
+            /// <remark>
+            /// This configuration may change in future releases to take advantage of
+            /// improvements we identify for default configurations.
+            /// </remark>
             /// <param name="loggerFactory"></param>
             /// <returns></returns>
             public static IConfiguration Latest(ILoggerFactory? loggerFactory = null)
+            {
+                return V1(loggerFactory);
+            }
+
+            /// <summary>
+            /// Provides the version 1 configuration for an InRegion environment.
+            /// </summary>
+            /// <remark>
+            /// This configuration is guaranteed not to change in future
+            /// releases of the Momento .NET SDK.
+            /// </remark>
+            /// <param name="loggerFactory"></param>
+            /// <returns></returns>
+            public static IConfiguration V1(ILoggerFactory? loggerFactory = null)
             {
                 var finalLoggerFactory = loggerFactory ?? NullLoggerFactory.Instance;
                 IRetryStrategy retryStrategy = new FixedCountRetryStrategy(finalLoggerFactory, maxAttempts: 3);
@@ -94,9 +130,28 @@ public class Configurations
             /// Provides the latest recommended configuration for a low-latency in-region
             /// environment.
             /// </summary>
+            /// <remark>
+            /// This configuration may change in future releases to take advantage of
+            /// improvements we identify for default configurations.
+            /// </remark>
             /// <param name="loggerFactory"></param>
             /// <returns></returns>
             public static IConfiguration Latest(ILoggerFactory? loggerFactory = null)
+            {
+                return V1(loggerFactory);
+            }
+
+            /// <summary>
+            /// Provides the latest recommended configuration for a low-latency in-region
+            /// environment.
+            /// </summary>
+            /// <remark>
+            /// This configuration is guaranteed not to change in future
+            /// releases of the Momento .NET SDK.
+            /// </remark>
+            /// <param name="loggerFactory"></param>
+            /// <returns></returns>
+            public static IConfiguration V1(ILoggerFactory? loggerFactory = null)
             {
                 var finalLoggerFactory = loggerFactory ?? NullLoggerFactory.Instance;
                 IRetryStrategy retryStrategy = new FixedCountRetryStrategy(finalLoggerFactory, maxAttempts: 3);

--- a/src/Momento.Sdk/Config/Retry/FixedCountRetryStrategy.cs
+++ b/src/Momento.Sdk/Config/Retry/FixedCountRetryStrategy.cs
@@ -73,4 +73,9 @@ public class FixedCountRetryStrategy : IRetryStrategy
             _loggerFactory.Equals(other._loggerFactory) &&
             _eligibilityStrategy.Equals(other._eligibilityStrategy);
     }
+
+    public override int GetHashCode()
+    {
+        return base.GetHashCode();
+    }
 }

--- a/src/Momento.Sdk/Config/Retry/FixedCountRetryStrategy.cs
+++ b/src/Momento.Sdk/Config/Retry/FixedCountRetryStrategy.cs
@@ -48,7 +48,7 @@ public class FixedCountRetryStrategy : IRetryStrategy
     public int? DetermineWhenToRetryRequest<TRequest>(Status grpcStatus, TRequest grpcRequest, int attemptNumber) where TRequest : class
     {
         _logger.LogDebug($"Determining whether request is eligible for retry; status code: {grpcStatus.StatusCode}, request type: {grpcRequest.GetType()}, attemptNumber: {attemptNumber}, maxAttempts: {MaxAttempts}");
-        if (! _eligibilityStrategy.IsEligibleForRetry(grpcStatus, grpcRequest))
+        if (!_eligibilityStrategy.IsEligibleForRetry(grpcStatus, grpcRequest))
         {
             return null;
         }
@@ -61,4 +61,16 @@ public class FixedCountRetryStrategy : IRetryStrategy
         return 0;
     }
 
+    public override bool Equals(object obj)
+    {
+        if ((obj == null) || !this.GetType().Equals(obj.GetType()))
+        {
+            return false;
+        }
+
+        var other = (FixedCountRetryStrategy)obj;
+        return MaxAttempts.Equals(other.MaxAttempts) &&
+            _loggerFactory.Equals(other._loggerFactory) &&
+            _eligibilityStrategy.Equals(other._eligibilityStrategy);
+    }
 }

--- a/src/Momento.Sdk/Config/Transport/StaticTransportStrategy.cs
+++ b/src/Momento.Sdk/Config/Transport/StaticTransportStrategy.cs
@@ -49,6 +49,21 @@ public class StaticGrpcConfiguration : IGrpcConfiguration
     {
         return new StaticGrpcConfiguration(this.Deadline, grpcChannelOptions, this.MinNumGrpcChannels);
     }
+
+    public override bool Equals(object obj)
+    {
+        if ((obj == null) || !this.GetType().Equals(obj.GetType()))
+        {
+            return false;
+        }
+
+        var other = (StaticGrpcConfiguration)obj;
+
+        return Deadline.Equals(other.Deadline) &&
+                MinNumGrpcChannels == other.MinNumGrpcChannels;
+        // TODO: gRPC doesn't implement a to equals for this
+        //GrpcChannelOptions.Equals(other.GrpcChannelOptions);
+    }
 }
 
 /// <summary>
@@ -109,5 +124,19 @@ public class StaticTransportStrategy : ITransportStrategy
     public ITransportStrategy WithEagerConnectionTimeout(TimeSpan connectionTimeout)
     {
         return new StaticTransportStrategy(_loggerFactory, MaxConcurrentRequests, GrpcConfig, connectionTimeout);
+    }
+
+    public override bool Equals(object obj)
+    {
+        if ((obj == null) || !this.GetType().Equals(obj.GetType()))
+        {
+            return false;
+        }
+
+        var other = (StaticTransportStrategy)obj;
+        return MaxConcurrentRequests == other.MaxConcurrentRequests &&
+            ((EagerConnectionTimeout == null && other.EagerConnectionTimeout == null) ||
+                EagerConnectionTimeout.Equals(other.EagerConnectionTimeout)) &&
+            GrpcConfig.Equals(other.GrpcConfig);
     }
 }

--- a/src/Momento.Sdk/Config/Transport/StaticTransportStrategy.cs
+++ b/src/Momento.Sdk/Config/Transport/StaticTransportStrategy.cs
@@ -64,6 +64,11 @@ public class StaticGrpcConfiguration : IGrpcConfiguration
         // TODO: gRPC doesn't implement a to equals for this
         //GrpcChannelOptions.Equals(other.GrpcChannelOptions);
     }
+
+    public override int GetHashCode()
+    {
+        return base.GetHashCode();
+    }
 }
 
 /// <summary>
@@ -138,5 +143,10 @@ public class StaticTransportStrategy : ITransportStrategy
             ((EagerConnectionTimeout == null && other.EagerConnectionTimeout == null) ||
                 EagerConnectionTimeout.Equals(other.EagerConnectionTimeout)) &&
             GrpcConfig.Equals(other.GrpcConfig);
+    }
+
+    public override int GetHashCode()
+    {
+        return base.GetHashCode();
     }
 }

--- a/src/Momento.Sdk/Internal/Middleware/HeaderMiddleware.cs
+++ b/src/Momento.Sdk/Internal/Middleware/HeaderMiddleware.cs
@@ -22,6 +22,17 @@ namespace Momento.Sdk.Internal.Middleware
             this.Name = name;
             this.Value = value;
         }
+
+        public override bool Equals(object obj)
+        {
+            if ((obj == null) || !this.GetType().Equals(obj.GetType()))
+            {
+                return false;
+            }
+
+            var otherHeader = (Header)obj;
+            return Name.Equals(otherHeader.Name) && Value.Equals(otherHeader.Value);
+        }
     }
 
     internal class HeaderMiddleware : IMiddleware
@@ -73,6 +84,20 @@ namespace Momento.Sdk.Internal.Middleware
                 GetStatus: nextState.GetStatus,
                 GetTrailers: nextState.GetTrailers
             );
+        }
+
+        public override bool Equals(object obj)
+        {
+            if ((obj == null) || !this.GetType().Equals(obj.GetType()))
+            {
+                return false;
+            }
+
+            var other = (HeaderMiddleware)obj;
+            return _headers.SequenceEqual(other._headers) &&
+                headersToAddEveryTime.SequenceEqual(other.headersToAddEveryTime) &&
+                headersToAddOnce.SequenceEqual(other.headersToAddOnce) &&
+                areOnlyOnceHeadersSent == other.areOnlyOnceHeadersSent;
         }
     }
 }

--- a/src/Momento.Sdk/Internal/Middleware/HeaderMiddleware.cs
+++ b/src/Momento.Sdk/Internal/Middleware/HeaderMiddleware.cs
@@ -33,6 +33,11 @@ namespace Momento.Sdk.Internal.Middleware
             var otherHeader = (Header)obj;
             return Name.Equals(otherHeader.Name) && Value.Equals(otherHeader.Value);
         }
+
+        public override int GetHashCode()
+        {
+            return base.GetHashCode();
+        }
     }
 
     internal class HeaderMiddleware : IMiddleware
@@ -98,6 +103,11 @@ namespace Momento.Sdk.Internal.Middleware
                 headersToAddEveryTime.SequenceEqual(other.headersToAddEveryTime) &&
                 headersToAddOnce.SequenceEqual(other.headersToAddOnce) &&
                 areOnlyOnceHeadersSent == other.areOnlyOnceHeadersSent;
+        }
+
+        public override int GetHashCode()
+        {
+            return base.GetHashCode();
         }
     }
 }

--- a/src/Momento.Sdk/Internal/Middleware/MaxConcurrentRequestsMiddleware.cs
+++ b/src/Momento.Sdk/Internal/Middleware/MaxConcurrentRequestsMiddleware.cs
@@ -75,6 +75,11 @@ namespace Momento.Sdk.Internal.Middleware
             var other = (MaxConcurrentRequestsMiddleware)obj;
             return _maxConcurrentRequests == other._maxConcurrentRequests;
         }
+
+        public override int GetHashCode()
+        {
+            return base.GetHashCode();
+        }
     }
 }
 

--- a/src/Momento.Sdk/Internal/Middleware/MaxConcurrentRequestsMiddleware.cs
+++ b/src/Momento.Sdk/Internal/Middleware/MaxConcurrentRequestsMiddleware.cs
@@ -1,12 +1,12 @@
-﻿using Google.Protobuf.WellKnownTypes;
+﻿using System;
+using System.Drawing;
+using System.IO;
+using System.Threading.Tasks;
+using Google.Protobuf.WellKnownTypes;
 using Grpc.Core;
 using Microsoft.Extensions.Logging;
 using Momento.Sdk.Config;
 using Momento.Sdk.Config.Middleware;
-using System;
-using System.Drawing;
-using System.IO;
-using System.Threading.Tasks;
 
 namespace Momento.Sdk.Internal.Middleware
 {
@@ -63,6 +63,17 @@ namespace Momento.Sdk.Internal.Middleware
             {
                 _semaphore.Release();
             }
+        }
+
+        public override bool Equals(object obj)
+        {
+            if ((obj == null) || !this.GetType().Equals(obj.GetType()))
+            {
+                return false;
+            }
+
+            var other = (MaxConcurrentRequestsMiddleware)obj;
+            return _maxConcurrentRequests == other._maxConcurrentRequests;
         }
     }
 }

--- a/src/Momento.Sdk/Internal/Middleware/RetryMiddleware.cs
+++ b/src/Momento.Sdk/Internal/Middleware/RetryMiddleware.cs
@@ -1,11 +1,11 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Grpc.Core;
 using Microsoft.Extensions.Logging;
-using Momento.Sdk.Config.Middleware;
-using System.Linq;
 using Momento.Protos.CacheClient;
-using System.Collections.Generic;
+using Momento.Sdk.Config.Middleware;
 
 namespace Momento.Sdk.Config.Retry
 {
@@ -47,7 +47,7 @@ namespace Momento.Sdk.Config.Retry
                 try
                 {
                     await nextState.ResponseAsync;
-                    
+
                     if (attemptNumber > 1)
                     {
                         _logger.LogDebug($"Retry succeeded (attempt {attemptNumber})");
@@ -70,6 +70,17 @@ namespace Momento.Sdk.Config.Retry
                 GetStatus: nextState.GetStatus,
                 GetTrailers: nextState.GetTrailers
             );
+        }
+
+        public override bool Equals(object obj)
+        {
+            if ((obj == null) || !this.GetType().Equals(obj.GetType()))
+            {
+                return false;
+            }
+
+            var other = (RetryMiddleware)obj;
+            return _logger.Equals(other._logger) && _retryStrategy.Equals(other._retryStrategy);
         }
     }
 }

--- a/src/Momento.Sdk/Internal/Middleware/RetryMiddleware.cs
+++ b/src/Momento.Sdk/Internal/Middleware/RetryMiddleware.cs
@@ -82,6 +82,11 @@ namespace Momento.Sdk.Config.Retry
             var other = (RetryMiddleware)obj;
             return _logger.Equals(other._logger) && _retryStrategy.Equals(other._retryStrategy);
         }
+
+        public override int GetHashCode()
+        {
+            return base.GetHashCode();
+        }
     }
 }
 

--- a/src/Momento.Sdk/Internal/Retry/DefaultRetryEligibilityStrategy.cs
+++ b/src/Momento.Sdk/Internal/Retry/DefaultRetryEligibilityStrategy.cs
@@ -96,6 +96,18 @@ namespace Momento.Sdk.Internal.Retry
 
             return true;
         }
+
+        public override bool Equals(object obj)
+        {
+            if ((obj == null) || !this.GetType().Equals(obj.GetType()))
+            {
+                return false;
+            }
+
+            var other = (DefaultRetryEligibilityStrategy)obj;
+            return _retryableRequestTypes.SetEquals(other._retryableRequestTypes) &&
+                _retryableStatusCodes.SetEquals(other._retryableStatusCodes);
+        }
     }
 }
 

--- a/src/Momento.Sdk/Internal/Retry/DefaultRetryEligibilityStrategy.cs
+++ b/src/Momento.Sdk/Internal/Retry/DefaultRetryEligibilityStrategy.cs
@@ -108,6 +108,11 @@ namespace Momento.Sdk.Internal.Retry
             return _retryableRequestTypes.SetEquals(other._retryableRequestTypes) &&
                 _retryableStatusCodes.SetEquals(other._retryableStatusCodes);
         }
+
+        public override int GetHashCode()
+        {
+            return base.GetHashCode();
+        }
     }
 }
 

--- a/tests/Unit/Momento.Sdk.Tests/ConfigTest.cs
+++ b/tests/Unit/Momento.Sdk.Tests/ConfigTest.cs
@@ -1,4 +1,5 @@
 using System;
+using Momento.Sdk.Config;
 using Momento.Sdk.Config.Transport;
 using Xunit;
 
@@ -9,5 +10,13 @@ public class ConfigTest
     {
         Assert.Throws<ArgumentOutOfRangeException>(() => new StaticGrpcConfiguration(TimeSpan.FromSeconds(-1)));
         Assert.Throws<ArgumentOutOfRangeException>(() => new StaticGrpcConfiguration(TimeSpan.FromSeconds(0)));
+    }
+
+    [Fact]
+    public void V1VConfigs_EqualLatest_HappyPath()
+    {
+        Assert.Equal(Configurations.Laptop.Latest(), Configurations.Laptop.V1());
+        Assert.Equal(Configurations.InRegion.Default.Latest(), Configurations.InRegion.Default.V1());
+        Assert.Equal(Configurations.InRegion.LowLatency.Latest(), Configurations.InRegion.LowLatency.V1());
     }
 }


### PR DESCRIPTION
Users may want to avoid the possibility of us making changes to
the tuning settings in our pre-built configs between releases.
This commit renames the current versions to v1(), and converts
the latest() factory fns into aliases to v1(). This way
in the future we can introduce v2's if necessary without worrying
about rolling out unexpected/undesired config changes to users
who have pinned to v1.

Closes #368