### PR TITLE
feat: remove next token param from list caches

### DIFF
--- a/src/Momento.Sdk/ISimpleCacheClient.cs
+++ b/src/Momento.Sdk/ISimpleCacheClient.cs
@@ -86,7 +86,6 @@ public interface ISimpleCacheClient : IDisposable
     /// <summary>
     /// List all caches.
     /// </summary>
-    /// <param name="nextPageToken">A token to specify where to start paginating. This is the NextToken from a previous response.</param>
     /// <returns>
     /// Task representing the result of the list cache operation. The
     /// response object is resolved to a type-safe object of one of
@@ -104,7 +103,7 @@ public interface ISimpleCacheClient : IDisposable
     /// }
     /// </code>
     /// </returns>
-    public Task<ListCachesResponse> ListCachesAsync(string? nextPageToken = null);
+    public Task<ListCachesResponse> ListCachesAsync();
 
     /// <summary>
     /// Set the value in cache with a given time to live (TTL) seconds.

--- a/src/Momento.Sdk/Responses/ListCachesResponse.cs
+++ b/src/Momento.Sdk/Responses/ListCachesResponse.cs
@@ -33,17 +33,10 @@ public abstract class ListCachesResponse
         /// </summary>
         public List<CacheInfo> Caches { get; }
 
-        /// <summary>
-        /// A token to specify where to start paging. This is the NextToken from
-        /// a previous response.
-        /// </summary>
-        public string? NextPageToken { get; }
-
         /// <include file="../docs.xml" path='docs/class[@name="Success"]/description/*' />
         /// <param name="result">gRPC list caches request result</param>
         public Success(_ListCachesResponse result)
         {
-            NextPageToken = result.NextToken == "" ? null : result.NextToken;
             Caches = new List<CacheInfo>();
             foreach (_Cache c in result.Cache)
             {

--- a/src/Momento.Sdk/SimpleCacheClient.cs
+++ b/src/Momento.Sdk/SimpleCacheClient.cs
@@ -76,9 +76,9 @@ public class SimpleCacheClient : ISimpleCacheClient
     }
 
     /// <inheritdoc />
-    public async Task<ListCachesResponse> ListCachesAsync(string? nextPageToken = null)
+    public async Task<ListCachesResponse> ListCachesAsync()
     {
-        return await this.controlClient.ListCachesAsync(nextPageToken);
+        return await this.controlClient.ListCachesAsync();
     }
 
     /// <inheritdoc />

--- a/tests/Integration/Momento.Sdk.Tests/SimpleCacheControlTest.cs
+++ b/tests/Integration/Momento.Sdk.Tests/SimpleCacheControlTest.cs
@@ -161,7 +161,9 @@ public class SimpleCacheControlTest : TestBase
                 {
                     break;
                 }
-                result = await client.ListCachesAsync(successResult.NextPageToken);
+                break;
+                // TODO: enable pending server side support
+                //result = await client.ListCachesAsync(successResult.NextPageToken);
             }
             foreach (String cache in cacheNames)
             {
@@ -179,11 +181,12 @@ public class SimpleCacheControlTest : TestBase
         }
 
     }
-
-    [Fact]
-    public async Task ListCachesAsync_BadNextToken_NoException()
-    {
-        // A bad next token does not throw an exception
-        await client.ListCachesAsync(nextPageToken: "hello world");
-    }
+    /* TODO: enable pending server side support
+        [Fact]
+        public async Task ListCachesAsync_BadNextToken_NoException()
+        {
+            // A bad next token does not throw an exception
+            await client.ListCachesAsync(nextPageToken: "hello world");
+        }
+    */
 }

--- a/tests/Integration/Momento.Sdk.Tests/SimpleCacheControlTest.cs
+++ b/tests/Integration/Momento.Sdk.Tests/SimpleCacheControlTest.cs
@@ -149,27 +149,18 @@ public class SimpleCacheControlTest : TestBase
             // List caches
             HashSet<String> retrievedCaches = new HashSet<string>();
             ListCachesResponse result = await client.ListCachesAsync();
-            while (true)
+
+            Assert.True(result is ListCachesResponse.Success, $"Unexpected response: {result}");
+            var successResult = (ListCachesResponse.Success)result;
+            foreach (CacheInfo cache in successResult.Caches)
             {
-                Assert.True(result is ListCachesResponse.Success, $"Unexpected response: {result}");
-                var successResult = (ListCachesResponse.Success)result;
-                foreach (CacheInfo cache in successResult.Caches)
-                {
-                    retrievedCaches.Add(cache.Name);
-                }
-                if (successResult.NextPageToken == null)
-                {
-                    break;
-                }
-                break;
-                // TODO: enable pending server side support
-                //result = await client.ListCachesAsync(successResult.NextPageToken);
+                retrievedCaches.Add(cache.Name);
             }
+
             foreach (String cache in cacheNames)
             {
                 Assert.Contains(cache, retrievedCaches);
             }
-
         }
         finally
         {
@@ -179,14 +170,5 @@ public class SimpleCacheControlTest : TestBase
                 await client.DeleteCacheAsync(cacheName);
             }
         }
-
     }
-    /* TODO: enable pending server side support
-        [Fact]
-        public async Task ListCachesAsync_BadNextToken_NoException()
-        {
-            // A bad next token does not throw an exception
-            await client.ListCachesAsync(nextPageToken: "hello world");
-        }
-    */
 }


### PR DESCRIPTION
Pending server side support, we remove the next token param from the
list caches control operation.

Closes #382