### PR TITLE
fix: Improve accessibility of field name in DictionaryGetField response

### DIFF
--- a/src/Momento.Sdk/Responses/CacheDictionaryGetFieldResponse.cs
+++ b/src/Momento.Sdk/Responses/CacheDictionaryGetFieldResponse.cs
@@ -10,21 +10,32 @@ namespace Momento.Sdk.Responses;
 
 public abstract class CacheDictionaryGetFieldResponse
 {
+    protected readonly ByteString field;
+
+    public byte[] FieldByteArray
+    {
+        get => field.ToByteArray();
+    }
+
+    public string FieldString { get => field.ToStringUtf8(); }
+
+    protected CacheDictionaryGetFieldResponse(ByteString field)
+    {
+        this.field = field;
+    }
+
     public class Hit : CacheDictionaryGetFieldResponse
     {
         protected readonly ByteString value;
-        protected readonly ByteString field;
 
-        public Hit(ByteString field, _DictionaryGetResponse response)
+        public Hit(ByteString field, _DictionaryGetResponse response) : base(field)
         {
             this.value = response.Found.Items[0].CacheBody;
-            this.field = field;
         }
 
-        public Hit(ByteString field, ByteString cacheBody)
+        public Hit(ByteString field, ByteString cacheBody) : base(field)
         {
             this.value = cacheBody;
-            this.field = field;
         }
 
         public byte[] ValueByteArray
@@ -32,14 +43,7 @@ public abstract class CacheDictionaryGetFieldResponse
             get => value.ToByteArray();
         }
 
-        public byte[] FieldByteArray
-        {
-            get => field.ToByteArray();
-        }
-
         public string ValueString { get => value.ToStringUtf8(); }
-
-        public string FieldString { get => field.ToStringUtf8(); }
 
         /// <inheritdoc />
         public override string ToString()
@@ -50,39 +54,22 @@ public abstract class CacheDictionaryGetFieldResponse
 
     public class Miss : CacheDictionaryGetFieldResponse
     {
-        protected readonly ByteString field;
-
-        public Miss(IEnumerable<ByteString> fields)
+        public Miss(ByteString field) : base(field)
         {
-            this.field = fields.ToList()[0];
         }
-
-        public Miss(ByteString field)
-        {
-            this.field = field;
-        }
-
-        public byte[] FieldByteArray
-        {
-            get => field.ToByteArray();
-        }
-
-        public string FieldString { get => field.ToStringUtf8(); }
     }
 
     public class Error : CacheDictionaryGetFieldResponse
     {
         private readonly SdkException _error;
-        protected readonly ByteString? field;
-
-        public Error(SdkException error)
+        
+        public Error(SdkException error): base(ByteString.Empty)
         {
             _error = error;
         }
 
-        public Error(ByteString? field, SdkException error)
+        public Error(ByteString field, SdkException error) : base(field)
         {
-            this.field = field;
             _error = error;
         }
 
@@ -100,13 +87,6 @@ public abstract class CacheDictionaryGetFieldResponse
         {
             get => $"{_error.MessageWrapper}: {_error.Message}";
         }
-
-        public byte[]? FieldByteArray
-        {
-            get => field?.ToByteArray();
-        }
-
-        public string? FieldString { get => field?.ToStringUtf8(); }
 
         /// <inheritdoc />
         public override string ToString()

--- a/src/Momento.Sdk/SimpleCacheClient.cs
+++ b/src/Momento.Sdk/SimpleCacheClient.cs
@@ -274,7 +274,7 @@ public class SimpleCacheClient : ISimpleCacheClient
         }
         catch (ArgumentNullException e)
         {
-            return new CacheDictionaryGetFieldResponse.Error(field?.ToByteString(), new InvalidArgumentException(e.Message));
+            return new CacheDictionaryGetFieldResponse.Error(field.ToByteString(), new InvalidArgumentException(e.Message));
         }
 
         return await this.DataClient.DictionaryGetFieldAsync(cacheName, dictionaryName, field);
@@ -291,7 +291,7 @@ public class SimpleCacheClient : ISimpleCacheClient
         }
         catch (ArgumentNullException e)
         {
-            return new CacheDictionaryGetFieldResponse.Error(field?.ToByteString(), new InvalidArgumentException(e.Message));
+            return new CacheDictionaryGetFieldResponse.Error(field.ToByteString(), new InvalidArgumentException(e.Message));
         }
 
         return await this.DataClient.DictionaryGetFieldAsync(cacheName, dictionaryName, field);

--- a/src/Momento.Sdk/SimpleCacheClient.cs
+++ b/src/Momento.Sdk/SimpleCacheClient.cs
@@ -274,7 +274,7 @@ public class SimpleCacheClient : ISimpleCacheClient
         }
         catch (ArgumentNullException e)
         {
-            return new CacheDictionaryGetFieldResponse.Error(field.ToByteString(), new InvalidArgumentException(e.Message));
+            return new CacheDictionaryGetFieldResponse.Error(field?.ToByteString() ?? Google.Protobuf.ByteString.Empty, new InvalidArgumentException(e.Message));
         }
 
         return await this.DataClient.DictionaryGetFieldAsync(cacheName, dictionaryName, field);
@@ -291,7 +291,7 @@ public class SimpleCacheClient : ISimpleCacheClient
         }
         catch (ArgumentNullException e)
         {
-            return new CacheDictionaryGetFieldResponse.Error(field.ToByteString(), new InvalidArgumentException(e.Message));
+            return new CacheDictionaryGetFieldResponse.Error(field?.ToByteString() ?? Google.Protobuf.ByteString.Empty, new InvalidArgumentException(e.Message));
         }
 
         return await this.DataClient.DictionaryGetFieldAsync(cacheName, dictionaryName, field);

--- a/tests/Integration/Momento.Sdk.Tests/DictionaryTest.cs
+++ b/tests/Integration/Momento.Sdk.Tests/DictionaryTest.cs
@@ -5,7 +5,7 @@ using Momento.Sdk.Requests;
 using Momento.Sdk.Responses;
 using Momento.Sdk.Tests;
 
-namespace Momento.Sdk.Incubating.Tests;
+namespace Momento.Sdk.Tests;
 
 [Collection("SimpleCacheClient")]
 public class DictionaryTest : TestBase
@@ -24,7 +24,7 @@ public class DictionaryTest : TestBase
         Assert.True(response is CacheDictionaryGetFieldResponse.Error, $"Unexpected response: {response}");
         var errResponse = (CacheDictionaryGetFieldResponse.Error)response;
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionaryGetFieldResponse.Error)response).ErrorCode);
-        Assert.Equal(field, ((CacheDictionaryGetFieldResponse.Error)response).FieldByteArray);
+        Assert.Equal(field ?? new byte[] {}, ((CacheDictionaryGetFieldResponse.Error)response).FieldByteArray);
     }
 
     [Theory]
@@ -241,7 +241,7 @@ public class DictionaryTest : TestBase
         Assert.True(response is CacheDictionaryGetFieldResponse.Error, $"Unexpected response: {response}");
         var errResponse = (CacheDictionaryGetFieldResponse.Error)response;
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheDictionaryGetFieldResponse.Error)response).ErrorCode);
-        Assert.Equal(field, ((CacheDictionaryGetFieldResponse.Error)response).FieldString);
+        Assert.Equal(field ?? "", ((CacheDictionaryGetFieldResponse.Error)response).FieldString);
     }
 
     [Theory]


### PR DESCRIPTION
This commit moves the definition of the `field` property up to
the parent class, DictionaryGetFieldResponse.  Prior to this
commit it was defined on each individual subclass, meaning you
could only access it within a type guard conditional.  This way,
you can access it regardless of whether your response was a Hit,
Miss, or Error.  This allows us to simplify some things in the
Dictionary example.
