### PR TITLE
chore: add `startIndex` and `endIndex` to `listFetch` API

### DIFF
--- a/src/Momento.Sdk/CacheClient.cs
+++ b/src/Momento.Sdk/CacheClient.cs
@@ -1060,7 +1060,7 @@ public class CacheClient : ICacheClient
     }
 
     /// <inheritdoc />
-    public async Task<CacheListFetchResponse> ListFetchAsync(string cacheName, string listName, int? startIndex, int? endIndex)
+    public async Task<CacheListFetchResponse> ListFetchAsync(string cacheName, string listName, int? startIndex = null, int? endIndex = null)
     {
         try
         {

--- a/src/Momento.Sdk/CacheClient.cs
+++ b/src/Momento.Sdk/CacheClient.cs
@@ -1060,19 +1060,24 @@ public class CacheClient : ICacheClient
     }
 
     /// <inheritdoc />
-    public async Task<CacheListFetchResponse> ListFetchAsync(string cacheName, string listName)
+    public async Task<CacheListFetchResponse> ListFetchAsync(string cacheName, string listName, int? startIndex, int? endIndex)
     {
         try
         {
             Utils.ArgumentNotNull(cacheName, nameof(cacheName));
             Utils.ArgumentNotNull(listName, nameof(listName));
+            Utils.ValidateStartEndIndex(startIndex, endIndex);
         }
         catch (ArgumentNullException e)
         {
             return new CacheListFetchResponse.Error(new InvalidArgumentException(e.Message));
         }
+        catch (Momento.Sdk.Exceptions.InvalidArgumentException e)
+        {
+            return new CacheListFetchResponse.Error(new InvalidArgumentException(e.Message));
+        }
 
-        return await this.DataClient.ListFetchAsync(cacheName, listName);
+        return await this.DataClient.ListFetchAsync(cacheName, listName, startIndex, endIndex);
     }
 
     /// <inheritdoc />

--- a/src/Momento.Sdk/ICacheClient.cs
+++ b/src/Momento.Sdk/ICacheClient.cs
@@ -593,7 +593,7 @@ public interface ICacheClient : IDisposable
     /// <param name="startIndex">Start inclusive index for fetch operation. Must be smaller than the endIndex.</param>
     /// <param name="endIndex">End exclusive index for fetch operation. Must be larger than the startIndex.</param>
     /// <returns>Task representing with the status of the fetch operation and the associated list.</returns>
-    public Task<CacheListFetchResponse> ListFetchAsync(string cacheName, string listName, int? startIndex, int? endIndex);
+    public Task<CacheListFetchResponse> ListFetchAsync(string cacheName, string listName, int? startIndex = null, int? endIndex = null);
 
     /// <summary>
     /// Remove all elements in a list equal to a particular value.

--- a/src/Momento.Sdk/ICacheClient.cs
+++ b/src/Momento.Sdk/ICacheClient.cs
@@ -590,8 +590,10 @@ public interface ICacheClient : IDisposable
     /// </summary>
     /// <param name="cacheName">Name of the cache to perform the lookup in.</param>
     /// <param name="listName">The list to fetch.</param>
+    /// <param name="startIndex">Start inclusive index for fetch operation. Must be smaller than the endIndex.</param>
+    /// <param name="endIndex">End exclusive index for fetch operation. Must be larger than the startIndex.</param>
     /// <returns>Task representing with the status of the fetch operation and the associated list.</returns>
-    public Task<CacheListFetchResponse> ListFetchAsync(string cacheName, string listName);
+    public Task<CacheListFetchResponse> ListFetchAsync(string cacheName, string listName, int? startIndex, int? endIndex);
 
     /// <summary>
     /// Remove all elements in a list equal to a particular value.

--- a/src/Momento.Sdk/Internal/ScsDataClient.cs
+++ b/src/Momento.Sdk/Internal/ScsDataClient.cs
@@ -343,9 +343,9 @@ internal sealed class ScsDataClient : ScsDataClientBase
         return await SendListPopBackAsync(cacheName, listName);
     }
 
-    public async Task<CacheListFetchResponse> ListFetchAsync(string cacheName, string listName)
+    public async Task<CacheListFetchResponse> ListFetchAsync(string cacheName, string listName, int? startIndex, int? endIndex)
     {
-        return await SendListFetchAsync(cacheName, listName);
+        return await SendListFetchAsync(cacheName, listName, startIndex, endIndex);
     }
 
     public async Task<CacheListRemoveValueResponse> ListRemoveValueAsync(string cacheName, string listName, byte[] value)
@@ -1012,9 +1012,26 @@ internal sealed class ScsDataClient : ScsDataClientBase
     }
 
     const string REQUEST_TYPE_LIST_FETCH = "LIST_FETCH";
-    private async Task<CacheListFetchResponse> SendListFetchAsync(string cacheName, string listName)
+    private async Task<CacheListFetchResponse> SendListFetchAsync(string cacheName, string listName, int? startIndex, int? endIndex)
     {
         _ListFetchRequest request = new() { ListName = listName.ToByteString() };
+        if (startIndex is null)
+        {
+            request.UnboundedStart = new _Unbounded { };
+        }
+        else
+        {
+            request.InclusiveStart = startIndex.Value;
+        }
+        if (endIndex is null)
+        {
+            request.UnboundedEnd = new _Unbounded { };
+        }
+        else
+        {
+            request.ExclusiveEnd = endIndex.Value;
+        }
+
         _ListFetchResponse response;
         var metadata = MetadataWithCache(cacheName);
 

--- a/src/Momento.Sdk/Internal/Utils.cs
+++ b/src/Momento.Sdk/Internal/Utils.cs
@@ -144,14 +144,8 @@ public static class Utils
             {
                 throw new Momento.Sdk.Exceptions.InvalidArgumentException("endIndex (exclusive) must be larger than startIndex (inclusive)");
             }
-            else
-            {
-                return;
-            }
-        }
-        else
-        {
             return;
         }
+        return;
     }
 }

--- a/src/Momento.Sdk/Internal/Utils.cs
+++ b/src/Momento.Sdk/Internal/Utils.cs
@@ -125,4 +125,27 @@ public static class Utils
     /// so comparisons operate on byte-array content instead of reference.
     /// </summary>
     public static StructuralEqualityComparer<byte[]> ByteArrayComparer = new();
+
+    /// <summary>
+    /// Thrown an exception if the end index is larger than the start index.
+    /// </summary>
+    /// <param name="startIndex">Starting inclusive index of operation.</param>
+    /// <param name="endIndex">Ending exclusive index of operation.</param>
+    /// <exception cref="Momento.Sdk.Exceptions.InvalidArgumentException"><paramref name="endIndex"/> is less than or equal to <paramref name="startIndex"/></exception>
+    public static void ValidateStartEndIndex(int? startIndex, int? endIndex)
+    {
+        if (startIndex is null || endIndex is null)
+        {
+            return;
+        }
+
+        if (startIndex > 0 || endIndex < 0)
+        {
+            return;
+        }
+        if (endIndex <= startIndex)
+        {
+            throw new Momento.Sdk.Exceptions.InvalidArgumentException("endIndex (exclusive) must be larger than startIndex (inclusive)");
+        }
+    }
 }

--- a/src/Momento.Sdk/Internal/Utils.cs
+++ b/src/Momento.Sdk/Internal/Utils.cs
@@ -134,18 +134,17 @@ public static class Utils
     /// <exception cref="Momento.Sdk.Exceptions.InvalidArgumentException"><paramref name="endIndex"/> is less than or equal to <paramref name="startIndex"/></exception>
     public static void ValidateStartEndIndex(int? startIndex, int? endIndex)
     {
-        if (startIndex is null || endIndex is null)
-        {
-            return;
-        }
-
-        if (startIndex > 0 || endIndex < 0)
-        {
-            return;
-        }
-        if (endIndex <= startIndex)
+        if (startIndex >= 0 && endIndex >= 0 && startIndex >= endIndex)
         {
             throw new Momento.Sdk.Exceptions.InvalidArgumentException("endIndex (exclusive) must be larger than startIndex (inclusive)");
+        }
+        if (startIndex < 0 && endIndex < 0 && startIndex >= endIndex)
+        {
+            throw new Momento.Sdk.Exceptions.InvalidArgumentException("endIndex (exclusive) must be larger than startIndex (inclusive)");
+        }
+        else
+        {
+            return;
         }
     }
 }

--- a/src/Momento.Sdk/Internal/Utils.cs
+++ b/src/Momento.Sdk/Internal/Utils.cs
@@ -134,13 +134,20 @@ public static class Utils
     /// <exception cref="Momento.Sdk.Exceptions.InvalidArgumentException"><paramref name="endIndex"/> is less than or equal to <paramref name="startIndex"/></exception>
     public static void ValidateStartEndIndex(int? startIndex, int? endIndex)
     {
-        if (startIndex >= 0 && endIndex >= 0 && startIndex >= endIndex)
+        if (startIndex.HasValue && endIndex.HasValue)
         {
-            throw new Momento.Sdk.Exceptions.InvalidArgumentException("endIndex (exclusive) must be larger than startIndex (inclusive)");
-        }
-        if (startIndex < 0 && endIndex < 0 && startIndex >= endIndex)
-        {
-            throw new Momento.Sdk.Exceptions.InvalidArgumentException("endIndex (exclusive) must be larger than startIndex (inclusive)");
+            if (startIndex >= 0 && endIndex >= 0 && startIndex >= endIndex)
+            {
+                throw new Momento.Sdk.Exceptions.InvalidArgumentException("endIndex (exclusive) must be larger than startIndex (inclusive)");
+            }
+            if (startIndex < 0 && endIndex < 0 && startIndex >= endIndex)
+            {
+                throw new Momento.Sdk.Exceptions.InvalidArgumentException("endIndex (exclusive) must be larger than startIndex (inclusive)");
+            }
+            else
+            {
+                return;
+            }
         }
         else
         {

--- a/tests/Integration/Momento.Sdk.Tests/ListTest.cs
+++ b/tests/Integration/Momento.Sdk.Tests/ListTest.cs
@@ -123,10 +123,17 @@ public class ListTest : TestBase
         CacheListConcatenateFrontResponse response = await client.ListConcatenateFrontAsync(cacheName, listName, values);
         Assert.True(response is CacheListConcatenateFrontResponse.Success, $"Unexpected response: {response}");
 
-        CacheListFetchResponse fetchResponse = await client.ListFetchAsync(cacheName, listName, 0, null);
+        // valid case for a negative startIndex and null endIndex
+        CacheListFetchResponse fetchResponse = await client.ListFetchAsync(cacheName, listName, -3, null);
         Assert.True(fetchResponse is CacheListFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
         var hitResponse = (CacheListFetchResponse.Hit)fetchResponse;
-        Assert.Equal(values, hitResponse.ValueListString);
+        Assert.Equal(new string[] { value2, value3, value4 }, hitResponse.ValueListString);
+
+        // valid case for a positive startIndex and null endIndex
+        fetchResponse = await client.ListFetchAsync(cacheName, listName, 2, null);
+        Assert.True(fetchResponse is CacheListFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
+        hitResponse = (CacheListFetchResponse.Hit)fetchResponse;
+        Assert.Equal(new string[] { value3, value4 }, hitResponse.ValueListString);
     }
 
     [Fact]

--- a/tests/Integration/Momento.Sdk.Tests/ListTest.cs
+++ b/tests/Integration/Momento.Sdk.Tests/ListTest.cs
@@ -26,6 +26,94 @@ public class ListTest : TestBase
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheListConcatenateFrontResponse.Error)response).ErrorCode);
     }
 
+    [Theory]
+    [InlineData("cache", "my-list", 3, 1)]
+    [InlineData("cache", "my-list", 3, 3)]
+    [InlineData("cache", "my-list", -2, -3)]
+    public async Task ListFetchAsync_InvalidIndex_IsError(string cacheName, string listName, int startIndex, int endIndex)
+    {
+        string[] values = new string[] { Utils.NewGuidString(), Utils.NewGuidString(), Utils.NewGuidString(), Utils.NewGuidString() };
+        CacheListConcatenateFrontResponse response = await client.ListConcatenateFrontAsync(cacheName, listName, values);
+        Assert.True(response is CacheListConcatenateFrontResponse.Success, $"Unexpected response: {response}");
+
+        CacheListFetchResponse fetchResponse = await client.ListFetchAsync(cacheName, listName, startIndex, endIndex);
+        Assert.True(fetchResponse is CacheListFetchResponse.Error, $"Unexpected response: {fetchResponse}");
+        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheListFetchResponse.Error)fetchResponse).ErrorCode);
+    }
+
+    [Fact]
+    public async Task ListFetchAsync_WithPositiveStartEndIndcies_HappyPath()
+    {
+        var listName = Utils.NewGuidString();
+        string value1 = Utils.NewGuidString();
+        string value2 = Utils.NewGuidString();
+        string value3 = Utils.NewGuidString();
+        string value4 = Utils.NewGuidString();
+        string[] values = new string[] { value1, value2, value3, value4 };
+        CacheListConcatenateFrontResponse response = await client.ListConcatenateFrontAsync(cacheName, listName, values);
+        Assert.True(response is CacheListConcatenateFrontResponse.Success, $"Unexpected response: {response}");
+
+        CacheListFetchResponse fetchResponse = await client.ListFetchAsync(cacheName, listName, 1, 3);
+        Assert.True(fetchResponse is CacheListFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
+        var hitResponse = (CacheListFetchResponse.Hit)fetchResponse;
+        Assert.Equal(new string[] { value2, value3 }, hitResponse.ValueListString);
+    }
+
+    [Fact]
+    public async Task ListFetchAsync_WithNegativeStartEndIndcies_HappyPath()
+    {
+        var listName = Utils.NewGuidString();
+        string value1 = Utils.NewGuidString();
+        string value2 = Utils.NewGuidString();
+        string value3 = Utils.NewGuidString();
+        string value4 = Utils.NewGuidString();
+        string[] values = new string[] { value1, value2, value3, value4 };
+        CacheListConcatenateFrontResponse response = await client.ListConcatenateFrontAsync(cacheName, listName, values);
+        Assert.True(response is CacheListConcatenateFrontResponse.Success, $"Unexpected response: {response}");
+
+        CacheListFetchResponse fetchResponse = await client.ListFetchAsync(cacheName, listName, -2, -1);
+        Assert.True(fetchResponse is CacheListFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
+        var hitResponse = (CacheListFetchResponse.Hit)fetchResponse;
+        Assert.Equal(new string[] { value3 }, hitResponse.ValueListString);
+    }
+
+    [Theory]
+    [InlineData("cache", "my-list", null, 1)]
+    [InlineData("cache", "my-list", null, -3)]
+    public async Task ListFetchAsync_WithNullStartIndex_HappyPath(string cacheName, string listName, int startIndex, int endIndex)
+    {
+        string value1 = Utils.NewGuidString();
+        string value2 = Utils.NewGuidString();
+        string value3 = Utils.NewGuidString();
+        string value4 = Utils.NewGuidString();
+        string[] values = new string[] { value1, value2, value3, value4 };
+        CacheListConcatenateFrontResponse response = await client.ListConcatenateFrontAsync(cacheName, listName, values);
+        Assert.True(response is CacheListConcatenateFrontResponse.Success, $"Unexpected response: {response}");
+
+        CacheListFetchResponse fetchResponse = await client.ListFetchAsync(cacheName, listName, startIndex, endIndex);
+        Assert.True(fetchResponse is CacheListFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
+        var hitResponse = (CacheListFetchResponse.Hit)fetchResponse;
+        Assert.Equal(new string[] { value1 }, hitResponse.ValueListString);
+    }
+
+    [Fact]
+    public async Task ListFetchAsync_WithNullEndIndex_HappyPath()
+    {
+        var listName = Utils.NewGuidString();
+        string value1 = Utils.NewGuidString();
+        string value2 = Utils.NewGuidString();
+        string value3 = Utils.NewGuidString();
+        string value4 = Utils.NewGuidString();
+        string[] values = new string[] { value1, value2, value3, value4 };
+        CacheListConcatenateFrontResponse response = await client.ListConcatenateFrontAsync(cacheName, listName, values);
+        Assert.True(response is CacheListConcatenateFrontResponse.Success, $"Unexpected response: {response}");
+
+        CacheListFetchResponse fetchResponse = await client.ListFetchAsync(cacheName, listName, 0, null);
+        Assert.True(fetchResponse is CacheListFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
+        var hitResponse = (CacheListFetchResponse.Hit)fetchResponse;
+        Assert.Equal(values, hitResponse.ValueListString);
+    }
+
     [Fact]
     public async Task ListConcatenateFrontFetch_ValueIsByteArray_HappyPath()
     {

--- a/tests/Integration/Momento.Sdk.Tests/ListTest.cs
+++ b/tests/Integration/Momento.Sdk.Tests/ListTest.cs
@@ -30,7 +30,7 @@ public class ListTest : TestBase
     [InlineData("cache", "my-list", 3, 1)]
     [InlineData("cache", "my-list", 3, 3)]
     [InlineData("cache", "my-list", -2, -3)]
-    public async Task ListFetchAsync_InvalidIndex_IsError(string cacheName, string listName, int startIndex, int endIndex)
+    public async Task ListFetchAsync_InvalidIndex_IsError(string cacheName, string listName, int? startIndex, int? endIndex)
     {
         string[] values = new string[] { Utils.NewGuidString(), Utils.NewGuidString(), Utils.NewGuidString(), Utils.NewGuidString() };
         CacheListConcatenateFrontResponse response = await client.ListConcatenateFrontAsync(cacheName, listName, values);
@@ -80,7 +80,7 @@ public class ListTest : TestBase
     [Theory]
     [InlineData("cache", "my-list", null, 1)]
     [InlineData("cache", "my-list", null, -3)]
-    public async Task ListFetchAsync_WithNullStartIndex_HappyPath(string cacheName, string listName, int startIndex, int endIndex)
+    public async Task ListFetchAsync_WithNullStartIndex_HappyPath(string cacheName, string listName, int? startIndex, int? endIndex)
     {
         string value1 = Utils.NewGuidString();
         string value2 = Utils.NewGuidString();


### PR DESCRIPTION
- Added additional params, `startIndex` and `endIndex` to the `listFetch` API
- Added tests for the new params

Closes #410 