### PR TITLE
feat: lower target framework to netstandard2.0

### DIFF
--- a/src/Momento.Sdk/Auth/Utils.cs
+++ b/src/Momento.Sdk/Auth/Utils.cs
@@ -7,7 +7,7 @@ namespace Momento.Sdk.Auth;
 
 internal class TokenAndEndpoints
 {
-    public string AuthToken { get;  }
+    public string AuthToken { get; }
     public string ControlEndpoint { get; }
     public string CacheEndpoint { get; }
 
@@ -29,8 +29,15 @@ internal static class AuthUtils
 {
     public static bool IsBase64String(string base64)
     {
-        Span<byte> buffer = new Span<byte>(new byte[base64.Length]);
-        return Convert.TryFromBase64String(base64, buffer, out int bytesParsed);
+        try
+        {
+            Convert.FromBase64String(base64);
+            return true;
+        }
+        catch (Exception)
+        {
+            return false;
+        }
     }
 
     public static TokenAndEndpoints TryDecodeAuthToken(string authToken)
@@ -47,7 +54,7 @@ internal static class AuthUtils
                     throw new InvalidArgumentException("");
                 }
                 return new TokenAndEndpoints(
-                    decodedToken.api_key,
+                    decodedToken.api_key!,
                     "control." + decodedToken.endpoint,
                     "cache." + decodedToken.endpoint
                 );

--- a/src/Momento.Sdk/Internal/ExtensionMethods/DictionaryExtensions.cs
+++ b/src/Momento.Sdk/Internal/ExtensionMethods/DictionaryExtensions.cs
@@ -56,3 +56,30 @@ public static class StringStringDictionaryExtensions
         return new Dictionary<string, string>(dictionary);
     }
 }
+
+
+/// <summary>
+/// Defines extension methods to operate on dictionaries with
+/// generic keys and values.
+/// </summary>
+public static class DictionaryExtensions
+{
+    /// <summary>
+    /// Add all items in <paramref name="items"/> to <paramref name="dictionary"/>.
+    /// </summary>
+    /// <remark>
+    /// We add this since the .NET Framework does not have a constructor that takes an
+    /// <see cref="IEnumerable{T}"/>.
+    /// </remark>
+    /// <typeparam name="TKey">The type of the key.</typeparam>
+    /// <typeparam name="TValue">The type of the value.</typeparam>
+    /// <param name="dictionary">The dictionary to add the items to.</param>
+    /// <param name="items">The key-value pairs to add.</param>
+    public static void AddRange<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, IEnumerable<KeyValuePair<TKey, TValue>> items)
+    {
+        foreach (var item in items)
+        {
+            dictionary.Add(item);
+        }
+    }
+}

--- a/src/Momento.Sdk/Momento.Sdk.csproj
+++ b/src/Momento.Sdk/Momento.Sdk.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<!-- Build Configuration -->
-		<TargetFramework>netstandard2.1</TargetFramework>
+		<TargetFramework>netstandard2.0</TargetFramework>
 		<LangVersion>latest</LangVersion>
 		<Nullable>enable</Nullable>
 		<!-- Include documentation in build -->

--- a/src/Momento.Sdk/Responses/CacheDictionaryFetchResponse.cs
+++ b/src/Momento.Sdk/Responses/CacheDictionaryFetchResponse.cs
@@ -60,20 +60,23 @@ public abstract class CacheDictionaryFetchResponse
             items = response.Found.Items;
             _dictionaryByteArrayByteArray = new(() =>
             {
-                return new Dictionary<byte[], byte[]>(
-                    items.Select(kv => new KeyValuePair<byte[], byte[]>(kv.Field.ToByteArray(), kv.Value.ToByteArray())),
-                    Utils.ByteArrayComparer);
+                var dictionary = new Dictionary<byte[], byte[]>(Utils.ByteArrayComparer);
+                dictionary.AddRange(items.Select(kv => new KeyValuePair<byte[], byte[]>(kv.Field.ToByteArray(), kv.Value.ToByteArray())));
+                return dictionary;
+
             });
 
             _dictionaryStringString = new(() =>
             {
-                return new Dictionary<string, string>(
-                    items.Select(kv => new KeyValuePair<string, string>(kv.Field.ToStringUtf8(), kv.Value.ToStringUtf8())));
+                var dictionary = new Dictionary<string, string>();
+                dictionary.AddRange(items.Select(kv => new KeyValuePair<string, string>(kv.Field.ToStringUtf8(), kv.Value.ToStringUtf8())));
+                return dictionary;
             });
             _dictionaryStringByteArray = new(() =>
             {
-                return new Dictionary<string, byte[]>(
-                    items.Select(kv => new KeyValuePair<string, byte[]>(kv.Field.ToStringUtf8(), kv.Value.ToByteArray())));
+                var dictionary = new Dictionary<string, byte[]>();
+                dictionary.AddRange(items.Select(kv => new KeyValuePair<string, byte[]>(kv.Field.ToStringUtf8(), kv.Value.ToByteArray())));
+                return dictionary;
             });
         }
 

--- a/src/Momento.Sdk/Responses/CacheDictionaryGetFieldsResponse.cs
+++ b/src/Momento.Sdk/Responses/CacheDictionaryGetFieldsResponse.cs
@@ -87,26 +87,31 @@ public abstract class CacheDictionaryGetFieldsResponse
 
             _dictionaryByteArrayByteArray = new(() =>
             {
-                return new Dictionary<byte[], byte[]>(
+                var dictionary = new Dictionary<byte[], byte[]>(Utils.ByteArrayComparer);
+                dictionary.AddRange(
                     fields.Zip(responses.Found.Items, (f, r) => new ValueTuple<ByteString, _DictionaryGetResponsePart>(f, r))
                         .Where(pair => pair.Item2.Result == ECacheResult.Hit)
-                        .Select(pair => new KeyValuePair<byte[], byte[]>(pair.Item1.ToByteArray(), pair.Item2.CacheBody.ToByteArray())),
-                    Utils.ByteArrayComparer);
+                        .Select(pair => new KeyValuePair<byte[], byte[]>(pair.Item1.ToByteArray(), pair.Item2.CacheBody.ToByteArray())));
+                return dictionary;
             });
 
             _dictionaryStringString = new(() =>
             {
-                return new Dictionary<string, string>(
+                var dictionary = new Dictionary<string, string>();
+                dictionary.AddRange(
                     fields.Zip(responses.Found.Items, (f, r) => new ValueTuple<ByteString, _DictionaryGetResponsePart>(f, r))
                         .Where(pair => pair.Item2.Result == ECacheResult.Hit)
                         .Select(pair => new KeyValuePair<string, string>(pair.Item1.ToStringUtf8(), pair.Item2.CacheBody.ToStringUtf8())));
+                return dictionary;
             });
             _dictionaryStringByteArray = new(() =>
             {
-                return new Dictionary<string, byte[]>(
+                var dictionary = new Dictionary<string, byte[]>();
+                dictionary.AddRange(
                     fields.Zip(responses.Found.Items, (f, r) => new ValueTuple<ByteString, _DictionaryGetResponsePart>(f, r))
                         .Where(pair => pair.Item2.Result == ECacheResult.Hit)
                         .Select(pair => new KeyValuePair<string, byte[]>(pair.Item1.ToStringUtf8(), pair.Item2.CacheBody.ToByteArray())));
+                return dictionary;
             });
         }
 


### PR DESCRIPTION
In order to support customers running older versions of the .NET
runtime, we lower the target framework. This requires only minor
changes to the code to account for missing implementations. These
include: `Convert.TryFromBase64String` and a `Dictionary` constructor
that takes `IEnumerable<KeyValuePair<TKey, TValue>>`.

Work towards: https://github.com/momentohq/dev-eco-issue-tracker/issues/317