### PR TITLE
feat: support .NET Framework 4.61+ using gRPC-Web

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       TEST_AUTH_TOKEN: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
-      TEST_CACHE_NAME: client-sdk-dotnet-${{ github.sha }}
+      TEST_CACHE_NAME: client-sdk-dotnet-${{ github.sha }}-${{ matrix.target-framework }}
 
     steps:
       - name: Get current time

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,7 +6,14 @@ on:
 
 jobs:
   build_csharp:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target-framework: net6.0
+          - os: windows-latest
+            target-framework: net461
+    runs-on: ${{ matrix.os }}
     env:
       TEST_AUTH_TOKEN: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
       TEST_CACHE_NAME: client-sdk-dotnet-${{ github.sha }}
@@ -37,19 +44,13 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build
-        run: |
-          dotnet build
-        shell: bash
+        run: dotnet build
 
       - name: Unit Test
-        run: |
-          dotnet test tests/Unit/Momento.Sdk.Tests
-        shell: bash
+        run: dotnet test -f ${{ matrix.target-framework }} tests/Unit/Momento.Sdk.Tests
 
       - name: Integration Test
-        run: |
-          dotnet test tests/Integration/Momento.Sdk.Tests
-        shell: bash
+        run: dotnet test -f ${{ matrix.target-framework }} tests/Integration/Momento.Sdk.Tests
 
   build_examples:
     runs-on: ubuntu-latest
@@ -75,7 +76,6 @@ jobs:
             dotnet build MomentoApplication
             dotnet run --project MomentoApplication
           popd
-        shell: bash
 
       - name: Send CI failure mail
         if: ${{ steps.validation.outcome == 'failure' }}

--- a/.github/workflows/on-push-to-main-branch.yaml
+++ b/.github/workflows/on-push-to-main-branch.yaml
@@ -6,7 +6,14 @@ on:
 
 jobs:
   build_csharp:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target-framework: net6.0
+          - os: windows-latest
+            target-framework: net461
+    runs-on: ${{ matrix.os }}
     env:
       TEST_AUTH_TOKEN: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
       TEST_CACHE_NAME: client-sdk-dotnet-${{ github.sha }}
@@ -26,19 +33,13 @@ jobs:
           dotnet-version: "6.0.x"
 
       - name: Build
-        run: |
-          dotnet build
-        shell: bash
+        run: dotnet build
 
       - name: Unit Test
-        run: |
-          dotnet test tests/Unit/Momento.Sdk.Tests
-        shell: bash
+        run: dotnet test -f ${{ matrix.target-framework }} tests/Unit/Momento.Sdk.Tests
 
       - name: Integration Test
-        run: |
-          dotnet test tests/Integration/Momento.Sdk.Tests
-        shell: bash
+        run: dotnet test -f ${{ matrix.target-framework }} tests/Integration/Momento.Sdk.Tests
 
       - name: Generate README
         uses: momentohq/standards-and-practices/github-actions/generate-and-commit-oss-readme@gh-actions-v1

--- a/.github/workflows/on-push-to-main-branch.yaml
+++ b/.github/workflows/on-push-to-main-branch.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       TEST_AUTH_TOKEN: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
-      TEST_CACHE_NAME: client-sdk-dotnet-${{ github.sha }}
+      TEST_CACHE_NAME: client-sdk-dotnet-${{ github.sha }}-${{ matrix.target-framework }}
 
     steps:
       - name: Get current time

--- a/.github/workflows/on-push-to-release-branch.yaml
+++ b/.github/workflows/on-push-to-release-branch.yaml
@@ -29,42 +29,9 @@ jobs:
         id: release
         run: echo "::set-output name=release::${{ steps.semrel.outputs.version }}"
 
-
-  test:
-    runs-on: ubuntu-latest
-    env:
-      TEST_AUTH_TOKEN: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
-      TEST_CACHE_NAME: client-sdk-dotnet-${{ github.sha }}
-
-    steps:
-      - name: Get current time
-        uses: gerred/actions/current-time@master
-        id: current-time
-
-      - uses: actions/checkout@v3
-
-      - uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: "6.0.x"
-
-      - name: Build
-        run: |
-          dotnet build
-        shell: bash
-
-      - name: Unit Test
-        run: |
-          dotnet test tests/Unit/Momento.Sdk.Tests
-        shell: bash
-
-      - name: Integration Test
-        run: |
-          dotnet test tests/Integration/Momento.Sdk.Tests
-        shell: bash
-
   publish:
     runs-on: ubuntu-latest
-    needs: [release, test]
+    needs: release
 
     steps:
       - name: Get current time
@@ -78,9 +45,7 @@ jobs:
           dotnet-version: "6.0.x"
 
       - name: Build
-        run: |
-          dotnet build
-        shell: bash
+        run: dotnet build
 
       - name: Pack and Publish
         run: |
@@ -92,4 +57,3 @@ jobs:
             dotnet pack -c Release -p:Version=${VERSION}
             dotnet nuget push ./bin/Release/Momento.Sdk.${VERSION}.nupkg --source https://api.nuget.org/v3/index.json --api-key=${{secrets.NUGET_API_KEY}}
           popd
-        shell: bash

--- a/src/Momento.Sdk/Internal/ControlGrpcManager.cs
+++ b/src/Momento.Sdk/Internal/ControlGrpcManager.cs
@@ -1,9 +1,4 @@
-﻿#if NETFRAMEWORK
-// Because .NET Framework does not support HTTP/2, we need to use gRPC-Web over HTTP/1.1
-#define USE_GRPC_WEB
-#endif
-
-#pragma warning disable 1591
+﻿#pragma warning disable 1591
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;

--- a/src/Momento.Sdk/Internal/DataGrpcManager.cs
+++ b/src/Momento.Sdk/Internal/DataGrpcManager.cs
@@ -1,10 +1,19 @@
-﻿#pragma warning disable 1591
+﻿#if NETFRAMEWORK
+// Because .NET Framework does not support HTTP/2, we need to use gRPC-Web over HTTP/1.1
+#define USE_GRPC_WEB
+#endif
+
+#pragma warning disable 1591
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Grpc.Core;
 using Grpc.Net.Client;
+#if USE_GRPC_WEB
+using System.Net.Http;
+using Grpc.Net.Client.Web;
+#endif
 using Microsoft.Extensions.Logging;
 using Momento.Protos.CacheClient;
 using Momento.Protos.CachePing;
@@ -230,6 +239,9 @@ public class DataGrpcManager : IDisposable
             channelOptions.LoggerFactory = config.LoggerFactory;
         }
         channelOptions.Credentials = ChannelCredentials.SecureSsl;
+#if USE_GRPC_WEB
+        channelOptions.HttpHandler = new GrpcWebHandler(new HttpClientHandler());
+#endif
 
         this.channel = GrpcChannel.ForAddress(url, channelOptions);
         List<Header> headers = new List<Header> { new Header(name: Header.AuthorizationKey, value: authToken), new Header(name: Header.AgentKey, value: version), new Header(name: Header.RuntimeVersionKey, value: runtimeVersion) };

--- a/src/Momento.Sdk/Internal/DataGrpcManager.cs
+++ b/src/Momento.Sdk/Internal/DataGrpcManager.cs
@@ -1,9 +1,4 @@
-﻿#if NETFRAMEWORK
-// Because .NET Framework does not support HTTP/2, we need to use gRPC-Web over HTTP/1.1
-#define USE_GRPC_WEB
-#endif
-
-#pragma warning disable 1591
+﻿#pragma warning disable 1591
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Momento.Sdk/Momento.Sdk.csproj
+++ b/src/Momento.Sdk/Momento.Sdk.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<!-- Build Configuration -->
-		<TargetFramework>netstandard2.0</TargetFramework>
+		<TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
 		<LangVersion>latest</LangVersion>
 		<Nullable>enable</Nullable>
 		<!-- Include documentation in build -->
@@ -55,6 +55,10 @@
 	    <PrivateAssets>all</PrivateAssets>
 	  </PackageReference>
 	  <PackageReference Include="System.Threading" Version="4.3.0" />
+	</ItemGroup>
+	<ItemGroup Condition="'$(TargetFramework)' == 'net461'">
+	  <!-- Because .NET Framework does not support HTTP/2, we fall back to gRPC-Web over HTTP/1.1 -->
+	  <PackageReference Include="Grpc.Net.Client.Web" Version="2.52.0" />
 	</ItemGroup>
 	<ProjectExtensions>
 	  <MonoDevelop>

--- a/src/Momento.Sdk/Momento.Sdk.csproj
+++ b/src/Momento.Sdk/Momento.Sdk.csproj
@@ -29,6 +29,14 @@
 		<PackageProjectUrl>https://github.com/momentohq/client-sdk-dotnet</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/momentohq/client-sdk-dotnet</RepositoryUrl>
 	</PropertyGroup>
+
+	<!-- Because .NET Framework doesn't support HTTP/2, we use gRPC-Web over HTTP/1.1.
+		 Dependency resolution: .NET Framework binaries or libraries >= v4.61 that link
+		 to Momento.Sdk will link to the .NET Framework 4.61 build. -->
+	<PropertyGroup Condition="'$(TargetFramework)' == 'net461' ">
+    	<DefineConstants>USE_GRPC_WEB</DefineConstants>
+  	</PropertyGroup>
+
 	<ItemGroup>
 	  <None Remove="System.Threading.Channels" />
 	  <None Remove="Internal\Middleware\" />

--- a/tests/Integration/Momento.Sdk.Tests/Momento.Sdk.Tests.Integration.csproj
+++ b/tests/Integration/Momento.Sdk.Tests/Momento.Sdk.Tests.Integration.csproj
@@ -15,13 +15,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.0.2">
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/tests/Integration/Momento.Sdk.Tests/Momento.Sdk.Tests.Integration.csproj
+++ b/tests/Integration/Momento.Sdk.Tests/Momento.Sdk.Tests.Integration.csproj
@@ -1,10 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net461</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>
-    <AssemblyName>Momento.Sdk.Tests</AssemblyName>
+    <LangVersion>latest</LangVersion>
+    <!-- We get some warnings for the logger (used only in the tests) on net461.
+         These are safe to ignore -->
+    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
+    <!-- Because this assembly targets multiple versions, and the test runner runs
+         the target frameworks sequentially, we get spurious warnings about multiple
+         versions of dependencies -->
+    <NoWarn>MSB3277</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Unit/Momento.Sdk.Tests/Momento.Sdk.Tests.Unit.csproj
+++ b/tests/Unit/Momento.Sdk.Tests/Momento.Sdk.Tests.Unit.csproj
@@ -15,13 +15,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.0.2">
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/tests/Unit/Momento.Sdk.Tests/Momento.Sdk.Tests.Unit.csproj
+++ b/tests/Unit/Momento.Sdk.Tests/Momento.Sdk.Tests.Unit.csproj
@@ -1,9 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net461</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
+    <!-- We get some warnings for the logger (used only in the tests) on net461.
+        These are safe to ignore -->
+    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
+    <!-- Because this assembly targets multiple versions, and the test runner runs
+         the target frameworks sequentially, we get spurious warnings about multiple
+         versions of dependencies -->
+    <NoWarn>MSB3277</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Because .NET Framework does not support gRPC over HTTP/2, we fall back
to using gRPC for those older versions. To do this we:

1. Add another target framework for the library, `net461`. This is the
lowest .NET Framework version also supported by `netstandard2.0`.

2. Conditional on a `net461` build, link the gRPC-Web client
dependency.

3. Conditional on a `net461` build, use a gRPC-Web `HttpHandler` for
the control and data gRPC channels.

4. Update the test projects to exercise the `net461` build as well.

closes: https://github.com/momentohq/dev-eco-issue-tracker/issues/317