### PR TITLE
feat: add lambda configuration

### DIFF
--- a/src/Momento.Sdk/Config/Configurations.cs
+++ b/src/Momento.Sdk/Config/Configurations.cs
@@ -165,8 +165,8 @@ public class Configurations
         }
 
         /// <summary>
-        /// This config optimizes for lambda environments. In addition to the low latency settings of
-        /// <see cref="LowLatency"/>, this configures the clients to eagerly connect to the Momento service
+        /// This config optimizes for lambda environments. In addition to the in region settings of
+        /// <see cref="Default"/>, this configures the clients to eagerly connect to the Momento service
         /// to avoid the cold start penalty of establishing a connection on the first request.
         /// </summary>
         public class Lambda : Configuration
@@ -184,7 +184,7 @@ public class Configurations
             /// <returns></returns>
             public static IConfiguration Latest(ILoggerFactory? loggerFactory = null)
             {
-                var config = LowLatency.V1(loggerFactory);
+                var config = Default.V1(loggerFactory);
                 var transportStrategy = config.TransportStrategy.WithEagerConnectionTimeout(
                     TimeSpan.FromSeconds(30)
                 );

--- a/src/Momento.Sdk/Config/Configurations.cs
+++ b/src/Momento.Sdk/Config/Configurations.cs
@@ -163,5 +163,33 @@ public class Configurations
                 return new LowLatency(finalLoggerFactory, retryStrategy, transportStrategy);
             }
         }
+
+        /// <summary>
+        /// This config optimizes for lambda environments. In addition to the low latency settings of
+        /// <see cref="LowLatency"/>, this configures the clients to eagerly connect to the Momento service
+        /// to avoid the cold start penalty of establishing a connection on the first request.
+        /// </summary>
+        public class Lambda : Configuration
+        {
+            private Lambda(ILoggerFactory loggerFactory, IRetryStrategy retryStrategy, ITransportStrategy transportStrategy)
+                : base(loggerFactory, retryStrategy, transportStrategy)
+            {
+
+            }
+
+            /// <summary>
+            /// Provides the latest recommended configuration for a lambda environment.
+            /// </summary>
+            /// <param name="loggerFactory"></param>
+            /// <returns></returns>
+            public static IConfiguration Latest(ILoggerFactory? loggerFactory = null)
+            {
+                var config = LowLatency.V1(loggerFactory);
+                var transportStrategy = config.TransportStrategy.WithEagerConnectionTimeout(
+                    TimeSpan.FromSeconds(30)
+                );
+                return config.WithTransportStrategy(transportStrategy);
+            }
+        }
     }
 }

--- a/tests/Unit/Momento.Sdk.Tests/ConfigTest.cs
+++ b/tests/Unit/Momento.Sdk.Tests/ConfigTest.cs
@@ -19,4 +19,11 @@ public class ConfigTest
         Assert.Equal(Configurations.InRegion.Default.Latest(), Configurations.InRegion.Default.V1());
         Assert.Equal(Configurations.InRegion.LowLatency.Latest(), Configurations.InRegion.LowLatency.V1());
     }
+
+    [Fact]
+    public void LambdaLatest_HasEagerConnectionTimeout_HappyPath()
+    {
+        var config = Configurations.InRegion.Lambda.Latest();
+        Assert.Equal(TimeSpan.FromSeconds(30), config.TransportStrategy.EagerConnectionTimeout);
+    }
 }


### PR DESCRIPTION
Adds a configuration optimized for Lambda environments. This is the
same as the `InRegion.Default` config but also eagerly connects the
client. This avoids the cold start penalty from before where we
established the connection on the first request, leading to
first-request timeouts.
