### PR TITLE
chore: add interface for all error response types

### DIFF
--- a/src/Momento.Sdk/Responses/CacheDeleteResponse.cs
+++ b/src/Momento.Sdk/Responses/CacheDeleteResponse.cs
@@ -33,7 +33,7 @@ public abstract class CacheDeleteResponse
     public class Success : CacheDeleteResponse { }
 
     /// <include file="../docs.xml" path='docs/class[@name="Error"]/description/*' />
-    public class Error : CacheDeleteResponse
+    public class Error : CacheDeleteResponse, IError
     {
         private readonly SdkException _error;
 
@@ -43,19 +43,19 @@ public abstract class CacheDeleteResponse
             _error = error;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="InnerException"]/*' />
+        /// <inheritdoc />
         public SdkException InnerException
         {
             get => _error;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="ErrorCode"]/*' />
+        /// <inheritdoc />
         public MomentoErrorCode ErrorCode
         {
             get => _error.ErrorCode;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="Message"]/*' />
+        /// <inheritdoc />
         public string Message
         {
             get => $"{_error.MessageWrapper}: {_error.Message}";

--- a/src/Momento.Sdk/Responses/CacheDictionaryFetchResponse.cs
+++ b/src/Momento.Sdk/Responses/CacheDictionaryFetchResponse.cs
@@ -111,7 +111,7 @@ public abstract class CacheDictionaryFetchResponse
     }
 
     /// <include file="../docs.xml" path='docs/class[@name="Error"]/description/*' />
-    public class Error : CacheDictionaryFetchResponse
+    public class Error : CacheDictionaryFetchResponse, IError
     {
         private readonly SdkException _error;
 
@@ -121,19 +121,19 @@ public abstract class CacheDictionaryFetchResponse
             _error = error;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="InnerException"]/*' />
+        /// <inheritdoc />
         public SdkException InnerException
         {
             get => _error;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="ErrorCode"]/*' />
+        /// <inheritdoc />
         public MomentoErrorCode ErrorCode
         {
             get => _error.ErrorCode;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="Message"]/*' />
+        /// <inheritdoc />
         public string Message
         {
             get => $"{_error.MessageWrapper}: {_error.Message}";

--- a/src/Momento.Sdk/Responses/CacheDictionaryGetFieldResponse.cs
+++ b/src/Momento.Sdk/Responses/CacheDictionaryGetFieldResponse.cs
@@ -123,7 +123,7 @@ public abstract class CacheDictionaryGetFieldResponse
     }
 
     /// <include file="../docs.xml" path='docs/class[@name="Error"]/description/*' />
-    public class Error : CacheDictionaryGetFieldResponse
+    public class Error : CacheDictionaryGetFieldResponse, IError
     {
         private readonly SdkException _error;
 
@@ -139,19 +139,19 @@ public abstract class CacheDictionaryGetFieldResponse
             _error = error;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="InnerException"]/*' />
+        /// <inheritdoc />
         public SdkException InnerException
         {
             get => _error;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="ErrorCode"]/*' />
+        /// <inheritdoc />
         public MomentoErrorCode ErrorCode
         {
             get => _error.ErrorCode;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="Message"]/*' />
+        /// <inheritdoc />
         public string Message
         {
             get => $"{_error.MessageWrapper}: {_error.Message}";

--- a/src/Momento.Sdk/Responses/CacheDictionaryGetFieldsResponse.cs
+++ b/src/Momento.Sdk/Responses/CacheDictionaryGetFieldsResponse.cs
@@ -146,7 +146,7 @@ public abstract class CacheDictionaryGetFieldsResponse
     }
 
     /// <include file="../docs.xml" path='docs/class[@name="Error"]/description/*' />
-    public class Error : CacheDictionaryGetFieldsResponse
+    public class Error : CacheDictionaryGetFieldsResponse, IError
     {
         private readonly SdkException _error;
 
@@ -156,19 +156,19 @@ public abstract class CacheDictionaryGetFieldsResponse
             _error = error;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="InnerException"]/*' />
+        /// <inheritdoc />
         public SdkException InnerException
         {
             get => _error;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="ErrorCode"]/*' />
+        /// <inheritdoc />
         public MomentoErrorCode ErrorCode
         {
             get => _error.ErrorCode;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="Message"]/*' />
+        /// <inheritdoc />
         public string Message
         {
             get => $"{_error.MessageWrapper}: {_error.Message}";

--- a/src/Momento.Sdk/Responses/CacheDictionaryIncrementResponse.cs
+++ b/src/Momento.Sdk/Responses/CacheDictionaryIncrementResponse.cs
@@ -52,7 +52,7 @@ public abstract class CacheDictionaryIncrementResponse
     }
 
     /// <include file="../docs.xml" path='docs/class[@name="Error"]/description/*' />
-    public class Error : CacheDictionaryIncrementResponse
+    public class Error : CacheDictionaryIncrementResponse, IError
     {
         private readonly SdkException _error;
 
@@ -62,19 +62,19 @@ public abstract class CacheDictionaryIncrementResponse
             _error = error;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="InnerException"]/*' />
+        /// <inheritdoc />
         public SdkException InnerException
         {
             get => _error;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="ErrorCode"]/*' />
+        /// <inheritdoc />
         public MomentoErrorCode ErrorCode
         {
             get => _error.ErrorCode;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="Message"]/*' />
+        /// <inheritdoc />
         public string Message
         {
             get => $"{_error.MessageWrapper}: {_error.Message}";

--- a/src/Momento.Sdk/Responses/CacheDictionaryRemoveFieldResponse.cs
+++ b/src/Momento.Sdk/Responses/CacheDictionaryRemoveFieldResponse.cs
@@ -35,7 +35,7 @@ public abstract class CacheDictionaryRemoveFieldResponse
     }
 
     /// <include file="../docs.xml" path='docs/class[@name="Error"]/description/*' />
-    public class Error : CacheDictionaryRemoveFieldResponse
+    public class Error : CacheDictionaryRemoveFieldResponse, IError
     {
         private readonly SdkException _error;
 
@@ -45,19 +45,19 @@ public abstract class CacheDictionaryRemoveFieldResponse
             _error = error;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="InnerException"]/*' />
+        /// <inheritdoc />
         public SdkException InnerException
         {
             get => _error;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="ErrorCode"]/*' />
+        /// <inheritdoc />
         public MomentoErrorCode ErrorCode
         {
             get => _error.ErrorCode;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="Message"]/*' />
+        /// <inheritdoc />
         public string Message
         {
             get => $"{_error.MessageWrapper}: {_error.Message}";

--- a/src/Momento.Sdk/Responses/CacheDictionaryRemoveFieldsResponse.cs
+++ b/src/Momento.Sdk/Responses/CacheDictionaryRemoveFieldsResponse.cs
@@ -35,7 +35,7 @@ public abstract class CacheDictionaryRemoveFieldsResponse
     }
 
     /// <include file="../docs.xml" path='docs/class[@name="Error"]/description/*' />
-    public class Error : CacheDictionaryRemoveFieldsResponse
+    public class Error : CacheDictionaryRemoveFieldsResponse, IError
     {
         private readonly SdkException _error;
 
@@ -45,19 +45,19 @@ public abstract class CacheDictionaryRemoveFieldsResponse
             _error = error;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="InnerException"]/*' />
+        /// <inheritdoc />
         public SdkException InnerException
         {
             get => _error;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="ErrorCode"]/*' />
+        /// <inheritdoc />
         public MomentoErrorCode ErrorCode
         {
             get => _error.ErrorCode;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="Message"]/*' />
+        /// <inheritdoc />
         public string Message
         {
             get => $"{_error.MessageWrapper}: {_error.Message}";

--- a/src/Momento.Sdk/Responses/CacheDictionarySetFieldResponse.cs
+++ b/src/Momento.Sdk/Responses/CacheDictionarySetFieldResponse.cs
@@ -35,7 +35,7 @@ public abstract class CacheDictionarySetFieldResponse
     }
 
     /// <include file="../docs.xml" path='docs/class[@name="Error"]/description/*' />
-    public class Error : CacheDictionarySetFieldResponse
+    public class Error : CacheDictionarySetFieldResponse, IError
     {
         private readonly SdkException _error;
 
@@ -45,19 +45,19 @@ public abstract class CacheDictionarySetFieldResponse
             _error = error;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="InnerException"]/*' />
+        /// <inheritdoc />
         public SdkException InnerException
         {
             get => _error;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="ErrorCode"]/*' />
+        /// <inheritdoc />
         public MomentoErrorCode ErrorCode
         {
             get => _error.ErrorCode;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="Message"]/*' />
+        /// <inheritdoc />
         public string Message
         {
             get => $"{_error.MessageWrapper}: {_error.Message}";

--- a/src/Momento.Sdk/Responses/CacheDictionarySetFieldsResponse.cs
+++ b/src/Momento.Sdk/Responses/CacheDictionarySetFieldsResponse.cs
@@ -35,7 +35,7 @@ public abstract class CacheDictionarySetFieldsResponse
     }
 
     /// <include file="../docs.xml" path='docs/class[@name="Error"]/description/*' />
-    public class Error : CacheDictionarySetFieldsResponse
+    public class Error : CacheDictionarySetFieldsResponse, IError
     {
         private readonly SdkException _error;
 
@@ -45,19 +45,19 @@ public abstract class CacheDictionarySetFieldsResponse
             _error = error;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="InnerException"]/*' />
+        /// <inheritdoc />
         public SdkException InnerException
         {
             get => _error;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="ErrorCode"]/*' />
+        /// <inheritdoc />
         public MomentoErrorCode ErrorCode
         {
             get => _error.ErrorCode;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="Message"]/*' />
+        /// <inheritdoc />
         public string Message
         {
             get => $"{_error.MessageWrapper}: {_error.Message}";

--- a/src/Momento.Sdk/Responses/CacheGetBatchResponse.cs
+++ b/src/Momento.Sdk/Responses/CacheGetBatchResponse.cs
@@ -58,7 +58,7 @@ public abstract class CacheGetBatchResponse
         }
     }
 
-    public class Error : CacheGetBatchResponse
+    public class Error : CacheGetBatchResponse, IError
     {
         private readonly SdkException _error;
         public Error(SdkException error)

--- a/src/Momento.Sdk/Responses/CacheGetResponse.cs
+++ b/src/Momento.Sdk/Responses/CacheGetResponse.cs
@@ -85,7 +85,7 @@ public abstract class CacheGetResponse
     }
 
     /// <include file="../docs.xml" path='docs/class[@name="Error"]/description/*' />
-    public class Error : CacheGetResponse
+    public class Error : CacheGetResponse, IError
     {
         private readonly SdkException _error;
 
@@ -95,19 +95,19 @@ public abstract class CacheGetResponse
             _error = error;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="InnerException"]/*' />
+        /// <inheritdoc />
         public SdkException InnerException
         {
             get => _error;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="ErrorCode"]/*' />
+        /// <inheritdoc />
         public MomentoErrorCode ErrorCode
         {
             get => _error.ErrorCode;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="Message"]/*' />
+        /// <inheritdoc />
         public string Message
         {
             get => $"{_error.MessageWrapper}: {_error.Message}";

--- a/src/Momento.Sdk/Responses/CacheIncrementResponse.cs
+++ b/src/Momento.Sdk/Responses/CacheIncrementResponse.cs
@@ -52,7 +52,7 @@ public abstract class CacheIncrementResponse
     }
 
     /// <include file="../docs.xml" path='docs/class[@name="Error"]/description/*' />
-    public class Error : CacheIncrementResponse
+    public class Error : CacheIncrementResponse, IError
     {
         private readonly SdkException _error;
 
@@ -62,19 +62,19 @@ public abstract class CacheIncrementResponse
             _error = error;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="InnerException"]/*' />
+        /// <inheritdoc />
         public SdkException InnerException
         {
             get => _error;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="ErrorCode"]/*' />
+        /// <inheritdoc />
         public MomentoErrorCode ErrorCode
         {
             get => _error.ErrorCode;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="Message"]/*' />
+        /// <inheritdoc />
         public string Message
         {
             get => $"{_error.MessageWrapper}: {_error.Message}";

--- a/src/Momento.Sdk/Responses/CacheKeyExistsResponse.cs
+++ b/src/Momento.Sdk/Responses/CacheKeyExistsResponse.cs
@@ -53,7 +53,7 @@ public abstract class CacheKeyExistsResponse
     }
 
     /// <include file="../docs.xml" path='docs/class[@name="Error"]/description/*' />
-    public class Error : CacheKeyExistsResponse
+    public class Error : CacheKeyExistsResponse, IError
     {
         private readonly SdkException _error;
 
@@ -63,19 +63,19 @@ public abstract class CacheKeyExistsResponse
             _error = error;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="InnerException"]/*' />
+        /// <inheritdoc />
         public SdkException InnerException
         {
             get => _error;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="ErrorCode"]/*' />
+        /// <inheritdoc />
         public MomentoErrorCode ErrorCode
         {
             get => _error.ErrorCode;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="Message"]/*' />
+        /// <inheritdoc />
         public string Message
         {
             get => $"{_error.MessageWrapper}: {_error.Message}";

--- a/src/Momento.Sdk/Responses/CacheKeysExistResponse.cs
+++ b/src/Momento.Sdk/Responses/CacheKeysExistResponse.cs
@@ -82,7 +82,7 @@ public abstract class CacheKeysExistResponse
     }
 
     /// <include file="../docs.xml" path='docs/class[@name="Error"]/description/*' />
-    public class Error : CacheKeysExistResponse
+    public class Error : CacheKeysExistResponse, IError
     {
         private readonly SdkException _error;
 
@@ -92,19 +92,19 @@ public abstract class CacheKeysExistResponse
             _error = error;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="InnerException"]/*' />
+        /// <inheritdoc />
         public SdkException InnerException
         {
             get => _error;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="ErrorCode"]/*' />
+        /// <inheritdoc />
         public MomentoErrorCode ErrorCode
         {
             get => _error.ErrorCode;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="Message"]/*' />
+        /// <inheritdoc />
         public string Message
         {
             get => $"{_error.MessageWrapper}: {_error.Message}";

--- a/src/Momento.Sdk/Responses/CacheListConcatenateBackResponse.cs
+++ b/src/Momento.Sdk/Responses/CacheListConcatenateBackResponse.cs
@@ -55,7 +55,7 @@ public abstract class CacheListConcatenateBackResponse
     }
 
     /// <include file="../docs.xml" path='docs/class[@name="Error"]/description/*' />
-    public class Error : CacheListConcatenateBackResponse
+    public class Error : CacheListConcatenateBackResponse, IError
     {
         private readonly SdkException _error;
 
@@ -65,19 +65,19 @@ public abstract class CacheListConcatenateBackResponse
             _error = error;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="InnerException"]/*' />
+        /// <inheritdoc />
         public SdkException InnerException
         {
             get => _error;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="ErrorCode"]/*' />
+        /// <inheritdoc />
         public MomentoErrorCode ErrorCode
         {
             get => _error.ErrorCode;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="Message"]/*' />
+        /// <inheritdoc />
         public string Message
         {
             get => $"{_error.MessageWrapper}: {_error.Message}";

--- a/src/Momento.Sdk/Responses/CacheListConcatenateFrontResponse.cs
+++ b/src/Momento.Sdk/Responses/CacheListConcatenateFrontResponse.cs
@@ -55,7 +55,7 @@ public abstract class CacheListConcatenateFrontResponse
     }
 
     /// <include file="../docs.xml" path='docs/class[@name="Error"]/description/*' />
-    public class Error : CacheListConcatenateFrontResponse
+    public class Error : CacheListConcatenateFrontResponse, IError
     {
         private readonly SdkException _error;
 
@@ -65,19 +65,19 @@ public abstract class CacheListConcatenateFrontResponse
             _error = error;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="InnerException"]/*' />
+        /// <inheritdoc />
         public SdkException InnerException
         {
             get => _error;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="ErrorCode"]/*' />
+        /// <inheritdoc />
         public MomentoErrorCode ErrorCode
         {
             get => _error.ErrorCode;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="Message"]/*' />
+        /// <inheritdoc />
         public string Message
         {
             get => $"{_error.MessageWrapper}: {_error.Message}";

--- a/src/Momento.Sdk/Responses/CacheListFetchResponse.cs
+++ b/src/Momento.Sdk/Responses/CacheListFetchResponse.cs
@@ -94,7 +94,7 @@ public abstract class CacheListFetchResponse
     }
 
     /// <include file="../docs.xml" path='docs/class[@name="Error"]/description/*' />
-    public class Error : CacheListFetchResponse
+    public class Error : CacheListFetchResponse, IError
     {
         private readonly SdkException _error;
 
@@ -104,19 +104,19 @@ public abstract class CacheListFetchResponse
             _error = error;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="InnerException"]/*' />
+        /// <inheritdoc />
         public SdkException InnerException
         {
             get => _error;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="ErrorCode"]/*' />
+        /// <inheritdoc />
         public MomentoErrorCode ErrorCode
         {
             get => _error.ErrorCode;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="Message"]/*' />
+        /// <inheritdoc />
         public string Message
         {
             get => $"{_error.MessageWrapper}: {_error.Message}";

--- a/src/Momento.Sdk/Responses/CacheListLengthResponse.cs
+++ b/src/Momento.Sdk/Responses/CacheListLengthResponse.cs
@@ -58,7 +58,7 @@ public abstract class CacheListLengthResponse
     }
 
     /// <include file="../docs.xml" path='docs/class[@name="Error"]/description/*' />
-    public class Error : CacheListLengthResponse
+    public class Error : CacheListLengthResponse, IError
     {
         private readonly SdkException _error;
 
@@ -68,19 +68,19 @@ public abstract class CacheListLengthResponse
             _error = error;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="InnerException"]/*' />
+        /// <inheritdoc />
         public SdkException InnerException
         {
             get => _error;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="ErrorCode"]/*' />
+        /// <inheritdoc />
         public MomentoErrorCode ErrorCode
         {
             get => _error.ErrorCode;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="Message"]/*' />
+        /// <inheritdoc />
         public string Message
         {
             get => $"{_error.MessageWrapper}: {_error.Message}";

--- a/src/Momento.Sdk/Responses/CacheListPopBackResponse.cs
+++ b/src/Momento.Sdk/Responses/CacheListPopBackResponse.cs
@@ -80,7 +80,7 @@ public abstract class CacheListPopBackResponse
     }
 
     /// <include file="../docs.xml" path='docs/class[@name="Error"]/description/*' />
-    public class Error : CacheListPopBackResponse
+    public class Error : CacheListPopBackResponse, IError
     {
         private readonly SdkException _error;
 
@@ -90,19 +90,19 @@ public abstract class CacheListPopBackResponse
             _error = error;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="InnerException"]/*' />
+        /// <inheritdoc />
         public SdkException InnerException
         {
             get => _error;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="ErrorCode"]/*' />
+        /// <inheritdoc />
         public MomentoErrorCode ErrorCode
         {
             get => _error.ErrorCode;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="Message"]/*' />
+        /// <inheritdoc />
         public string Message
         {
             get => $"{_error.MessageWrapper}: {_error.Message}";

--- a/src/Momento.Sdk/Responses/CacheListPopFrontResponse.cs
+++ b/src/Momento.Sdk/Responses/CacheListPopFrontResponse.cs
@@ -80,7 +80,7 @@ public abstract class CacheListPopFrontResponse
     }
 
     /// <include file="../docs.xml" path='docs/class[@name="Error"]/description/*' />
-    public class Error : CacheListPopFrontResponse
+    public class Error : CacheListPopFrontResponse, IError
     {
         private readonly SdkException _error;
 
@@ -90,19 +90,19 @@ public abstract class CacheListPopFrontResponse
             _error = error;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="InnerException"]/*' />
+        /// <inheritdoc />
         public SdkException InnerException
         {
             get => _error;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="ErrorCode"]/*' />
+        /// <inheritdoc />
         public MomentoErrorCode ErrorCode
         {
             get => _error.ErrorCode;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="Message"]/*' />
+        /// <inheritdoc />
         public string Message
         {
             get => $"{_error.MessageWrapper}: {_error.Message}";

--- a/src/Momento.Sdk/Responses/CacheListPushBackResponse.cs
+++ b/src/Momento.Sdk/Responses/CacheListPushBackResponse.cs
@@ -56,7 +56,7 @@ public abstract class CacheListPushBackResponse
     }
 
     /// <include file="../docs.xml" path='docs/class[@name="Error"]/description/*' />
-    public class Error : CacheListPushBackResponse
+    public class Error : CacheListPushBackResponse, IError
     {
         private readonly SdkException _error;
 
@@ -66,19 +66,19 @@ public abstract class CacheListPushBackResponse
             _error = error;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="InnerException"]/*' />
+        /// <inheritdoc />
         public SdkException InnerException
         {
             get => _error;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="ErrorCode"]/*' />
+        /// <inheritdoc />
         public MomentoErrorCode ErrorCode
         {
             get => _error.ErrorCode;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="Message"]/*' />
+        /// <inheritdoc />
         public string Message
         {
             get => $"{_error.MessageWrapper}: {_error.Message}";

--- a/src/Momento.Sdk/Responses/CacheListPushFrontResponse.cs
+++ b/src/Momento.Sdk/Responses/CacheListPushFrontResponse.cs
@@ -55,7 +55,7 @@ public abstract class CacheListPushFrontResponse
     }
 
     /// <include file="../docs.xml" path='docs/class[@name="Error"]/description/*' />
-    public class Error : CacheListPushFrontResponse
+    public class Error : CacheListPushFrontResponse, IError
     {
         private readonly SdkException _error;
         /// <include file="../docs.xml" path='docs/class[@name="Error"]/constructor/*' />
@@ -64,19 +64,19 @@ public abstract class CacheListPushFrontResponse
             _error = error;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="InnerException"]/*' />
+        /// <inheritdoc />
         public SdkException InnerException
         {
             get => _error;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="ErrorCode"]/*' />
+        /// <inheritdoc />
         public MomentoErrorCode ErrorCode
         {
             get => _error.ErrorCode;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="Message"]/*' />
+        /// <inheritdoc />
         public string Message
         {
             get => $"{_error.MessageWrapper}: {_error.Message}";

--- a/src/Momento.Sdk/Responses/CacheListRemoveValueResponse.cs
+++ b/src/Momento.Sdk/Responses/CacheListRemoveValueResponse.cs
@@ -35,7 +35,7 @@ public abstract class CacheListRemoveValueResponse
     }
 
     /// <include file="../docs.xml" path='docs/class[@name="Error"]/description/*' />
-    public class Error : CacheListRemoveValueResponse
+    public class Error : CacheListRemoveValueResponse, IError
     {
         private readonly SdkException _error;
 
@@ -45,19 +45,19 @@ public abstract class CacheListRemoveValueResponse
             _error = error;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="InnerException"]/*' />
+        /// <inheritdoc />
         public SdkException InnerException
         {
             get => _error;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="ErrorCode"]/*' />
+        /// <inheritdoc />
         public MomentoErrorCode ErrorCode
         {
             get => _error.ErrorCode;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="Message"]/*' />
+        /// <inheritdoc />
         public string Message
         {
             get => $"{_error.MessageWrapper}: {_error.Message}";

--- a/src/Momento.Sdk/Responses/CacheListRetainResponse.cs
+++ b/src/Momento.Sdk/Responses/CacheListRetainResponse.cs
@@ -35,7 +35,7 @@ public abstract class CacheListRetainResponse
     }
 
     /// <include file="../docs.xml" path='docs/class[@name="Error"]/description/*' />
-    public class Error : CacheListRetainResponse
+    public class Error : CacheListRetainResponse, IError
     {
         private readonly SdkException _error;
 
@@ -45,19 +45,19 @@ public abstract class CacheListRetainResponse
             _error = error;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="InnerException"]/*' />
+        /// <inheritdoc />
         public SdkException InnerException
         {
             get => _error;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="ErrorCode"]/*' />
+        /// <inheritdoc />
         public MomentoErrorCode ErrorCode
         {
             get => _error.ErrorCode;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="Message"]/*' />
+        /// <inheritdoc />
         public string Message
         {
             get => $"{_error.MessageWrapper}: {_error.Message}";

--- a/src/Momento.Sdk/Responses/CacheSetAddElementResponse.cs
+++ b/src/Momento.Sdk/Responses/CacheSetAddElementResponse.cs
@@ -35,7 +35,7 @@ public abstract class CacheSetAddElementResponse
     }
 
     /// <include file="../docs.xml" path='docs/class[@name="Error"]/description/*' />
-    public class Error : CacheSetAddElementResponse
+    public class Error : CacheSetAddElementResponse, IError
     {
         private readonly SdkException _error;
 
@@ -45,19 +45,19 @@ public abstract class CacheSetAddElementResponse
             _error = error;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="InnerException"]/*' />
+        /// <inheritdoc />
         public SdkException InnerException
         {
             get => _error;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="ErrorCode"]/*' />
+        /// <inheritdoc />
         public MomentoErrorCode ErrorCode
         {
             get => _error.ErrorCode;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="Message"]/*' />
+        /// <inheritdoc />
         public string Message
         {
             get => $"{_error.MessageWrapper}: {_error.Message}";

--- a/src/Momento.Sdk/Responses/CacheSetAddElementsResponse.cs
+++ b/src/Momento.Sdk/Responses/CacheSetAddElementsResponse.cs
@@ -35,7 +35,7 @@ public abstract class CacheSetAddElementsResponse
     }
 
     /// <include file="../docs.xml" path='docs/class[@name="Error"]/description/*' />
-    public class Error : CacheSetAddElementsResponse
+    public class Error : CacheSetAddElementsResponse, IError
     {
         private readonly SdkException _error;
 
@@ -45,19 +45,19 @@ public abstract class CacheSetAddElementsResponse
             _error = error;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="InnerException"]/*' />
+        /// <inheritdoc />
         public SdkException InnerException
         {
             get => _error;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="ErrorCode"]/*' />
+        /// <inheritdoc />
         public MomentoErrorCode ErrorCode
         {
             get => _error.ErrorCode;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="Message"]/*' />
+        /// <inheritdoc />
         public string Message
         {
             get => $"{_error.MessageWrapper}: {_error.Message}";

--- a/src/Momento.Sdk/Responses/CacheSetBatchResponse.cs
+++ b/src/Momento.Sdk/Responses/CacheSetBatchResponse.cs
@@ -9,7 +9,7 @@ public abstract class CacheSetBatchResponse
 
     public class Success : CacheSetBatchResponse { }
 
-    public class Error : CacheSetBatchResponse
+    public class Error : CacheSetBatchResponse, IError
     {
         private readonly SdkException _error;
         public Error(SdkException error)

--- a/src/Momento.Sdk/Responses/CacheSetFetchResponse.cs
+++ b/src/Momento.Sdk/Responses/CacheSetFetchResponse.cs
@@ -98,7 +98,7 @@ public abstract class CacheSetFetchResponse
     }
 
     /// <include file="../docs.xml" path='docs/class[@name="Error"]/description/*' />
-    public class Error : CacheSetFetchResponse
+    public class Error : CacheSetFetchResponse, IError
     {
         private readonly SdkException _error;
 
@@ -108,19 +108,19 @@ public abstract class CacheSetFetchResponse
             _error = error;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="InnerException"]/*' />
+        /// <inheritdoc />
         public SdkException InnerException
         {
             get => _error;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="ErrorCode"]/*' />
+        /// <inheritdoc />
         public MomentoErrorCode ErrorCode
         {
             get => _error.ErrorCode;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="Message"]/*' />
+        /// <inheritdoc />
         public string Message
         {
             get => $"{_error.MessageWrapper}: {_error.Message}";

--- a/src/Momento.Sdk/Responses/CacheSetIfNotExistsResponse.cs
+++ b/src/Momento.Sdk/Responses/CacheSetIfNotExistsResponse.cs
@@ -45,7 +45,7 @@ public abstract class CacheSetIfNotExistsResponse
     }
 
     /// <include file="../docs.xml" path='docs/class[@name="Error"]/description/*' />
-    public class Error : CacheSetIfNotExistsResponse
+    public class Error : CacheSetIfNotExistsResponse, IError
     {
         private readonly SdkException _error;
 
@@ -55,19 +55,19 @@ public abstract class CacheSetIfNotExistsResponse
             _error = error;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="InnerException"]/*' />
+        /// <inheritdoc />
         public SdkException InnerException
         {
             get => _error;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="ErrorCode"]/*' />
+        /// <inheritdoc />
         public MomentoErrorCode ErrorCode
         {
             get => _error.ErrorCode;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="Message"]/*' />
+        /// <inheritdoc />
         public string Message
         {
             get => $"{_error.MessageWrapper}: {_error.Message}";

--- a/src/Momento.Sdk/Responses/CacheSetRemoveElementResponse.cs
+++ b/src/Momento.Sdk/Responses/CacheSetRemoveElementResponse.cs
@@ -35,7 +35,7 @@ public abstract class CacheSetRemoveElementResponse
     }
 
     /// <include file="../docs.xml" path='docs/class[@name="Error"]/description/*' />
-    public class Error : CacheSetRemoveElementResponse
+    public class Error : CacheSetRemoveElementResponse, IError
     {
         private readonly SdkException _error;
 
@@ -45,19 +45,19 @@ public abstract class CacheSetRemoveElementResponse
             _error = error;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="InnerException"]/*' />
+        /// <inheritdoc />
         public SdkException InnerException
         {
             get => _error;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="ErrorCode"]/*' />
+        /// <inheritdoc />
         public MomentoErrorCode ErrorCode
         {
             get => _error.ErrorCode;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="Message"]/*' />
+        /// <inheritdoc />
         public string Message
         {
             get => $"{_error.MessageWrapper}: {_error.Message}";

--- a/src/Momento.Sdk/Responses/CacheSetRemoveElementsResponse.cs
+++ b/src/Momento.Sdk/Responses/CacheSetRemoveElementsResponse.cs
@@ -35,7 +35,7 @@ public abstract class CacheSetRemoveElementsResponse
     }
 
     /// <include file="../docs.xml" path='docs/class[@name="Error"]/description/*' />
-    public class Error : CacheSetRemoveElementsResponse
+    public class Error : CacheSetRemoveElementsResponse, IError
     {
         private readonly SdkException _error;
 
@@ -45,19 +45,19 @@ public abstract class CacheSetRemoveElementsResponse
             _error = error;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="InnerException"]/*' />
+        /// <inheritdoc />
         public SdkException InnerException
         {
             get => _error;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="ErrorCode"]/*' />
+        /// <inheritdoc />
         public MomentoErrorCode ErrorCode
         {
             get => _error.ErrorCode;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="Message"]/*' />
+        /// <inheritdoc />
         public string Message
         {
             get => $"{_error.MessageWrapper}: {_error.Message}";

--- a/src/Momento.Sdk/Responses/CacheSetResponse.cs
+++ b/src/Momento.Sdk/Responses/CacheSetResponse.cs
@@ -34,7 +34,7 @@ public abstract class CacheSetResponse
     public class Success : CacheSetResponse { }
 
     /// <include file="../docs.xml" path='docs/class[@name="Error"]/description/*' />
-    public class Error : CacheSetResponse
+    public class Error : CacheSetResponse, IError
     {
         private readonly SdkException _error;
 
@@ -44,19 +44,19 @@ public abstract class CacheSetResponse
             _error = error;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="InnerException"]/*' />
+        /// <inheritdoc />
         public SdkException InnerException
         {
             get => _error;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="ErrorCode"]/*' />
+        /// <inheritdoc />
         public MomentoErrorCode ErrorCode
         {
             get => _error.ErrorCode;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="Message"]/*' />
+        /// <inheritdoc />
         public string Message
         {
             get => $"{_error.MessageWrapper}: {_error.Message}";

--- a/src/Momento.Sdk/Responses/CreateCacheResponse.cs
+++ b/src/Momento.Sdk/Responses/CreateCacheResponse.cs
@@ -40,7 +40,7 @@ public abstract class CreateCacheResponse
     public class CacheAlreadyExists : CreateCacheResponse { }
 
     /// <include file="../docs.xml" path='docs/class[@name="Error"]/description/*' />
-    public class Error : CreateCacheResponse
+    public class Error : CreateCacheResponse, IError
     {
         private readonly SdkException _error;
 
@@ -50,19 +50,19 @@ public abstract class CreateCacheResponse
             _error = error;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="InnerException"]/*' />
+        /// <inheritdoc />
         public SdkException InnerException
         {
             get => _error;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="ErrorCode"]/*' />
+        /// <inheritdoc />
         public MomentoErrorCode ErrorCode
         {
             get => _error.ErrorCode;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="Message"]/*' />
+        /// <inheritdoc />
         public string Message
         {
             get => $"{_error.MessageWrapper}: {_error.Message}";

--- a/src/Momento.Sdk/Responses/DeleteCacheResponse.cs
+++ b/src/Momento.Sdk/Responses/DeleteCacheResponse.cs
@@ -34,7 +34,7 @@ public abstract class DeleteCacheResponse
     public class Success : DeleteCacheResponse { }
 
     /// <include file="../docs.xml" path='docs/class[@name="Error"]/description/*' />
-    public class Error : DeleteCacheResponse
+    public class Error : DeleteCacheResponse, IError
     {
         private readonly SdkException _error;
 
@@ -44,19 +44,19 @@ public abstract class DeleteCacheResponse
             _error = error;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="InnerException"]/*' />
+        /// <inheritdoc />
         public SdkException InnerException
         {
             get => _error;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="ErrorCode"]/*' />
+        /// <inheritdoc />
         public MomentoErrorCode ErrorCode
         {
             get => _error.ErrorCode;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="Message"]/*' />
+        /// <inheritdoc />
         public string Message
         {
             get => $"{_error.MessageWrapper}: {_error.Message}";

--- a/src/Momento.Sdk/Responses/FlushCacheResponse.cs
+++ b/src/Momento.Sdk/Responses/FlushCacheResponse.cs
@@ -33,7 +33,7 @@ public abstract class FlushCacheResponse
     public class Success : FlushCacheResponse { }
 
     /// <include file="../docs.xml" path='docs/class[@name="Error"]/description/*' />
-    public class Error : FlushCacheResponse
+    public class Error : FlushCacheResponse, IError
     {
         private readonly SdkException _error;
 
@@ -43,19 +43,19 @@ public abstract class FlushCacheResponse
             _error = error;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="InnerException"]/*' />
+        /// <inheritdoc />
         public SdkException InnerException
         {
             get => _error;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="ErrorCode"]/*' />
+        /// <inheritdoc />
         public MomentoErrorCode ErrorCode
         {
             get => _error.ErrorCode;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="Message"]/*' />
+        /// <inheritdoc />
         public string Message
         {
             get => $"{_error.MessageWrapper}: {_error.Message}";

--- a/src/Momento.Sdk/Responses/IError.cs
+++ b/src/Momento.Sdk/Responses/IError.cs
@@ -1,0 +1,33 @@
+using Momento.Sdk.Exceptions;
+
+namespace Momento.Sdk.Responses;
+
+/// <summary>
+/// Represents an error response
+/// </summary>
+public interface IError
+{
+    /// <summary>
+    /// The <see cref="SdkException"/> object used to construct the response.
+    /// </summary>
+    SdkException InnerException { get; }
+
+    /// <summary>
+    /// The <see cref="MomentoErrorCode"/> value for the
+    /// <see cref="IError"/> object. Example:<br/>
+    /// <code>
+    /// if (errorResponse.ErrorCode == MomentoErrorCode.TIMEOUT_ERROR)
+    /// {
+    ///    // handle timeout error
+    /// }
+    /// </code>
+    /// </summary>
+    MomentoErrorCode ErrorCode { get; }
+
+    /// <summary>
+    /// An explanation of conditions that caused and potential
+    /// ways to resolve the error.
+    /// </summary>
+    string Message { get; }
+}
+

--- a/src/Momento.Sdk/Responses/ListCachesResponse.cs
+++ b/src/Momento.Sdk/Responses/ListCachesResponse.cs
@@ -66,7 +66,7 @@ public abstract class ListCachesResponse
     }
 
     /// <include file="../docs.xml" path='docs/class[@name="Error"]/description/*' />
-    public class Error : ListCachesResponse
+    public class Error : ListCachesResponse, IError
     {
         private readonly SdkException _error;
 
@@ -76,19 +76,19 @@ public abstract class ListCachesResponse
             _error = error;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="InnerException"]/*' />
+        /// <inheritdoc />
         public SdkException InnerException
         {
             get => _error;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="ErrorCode"]/*' />
+        /// <inheritdoc />
         public MomentoErrorCode ErrorCode
         {
             get => _error.ErrorCode;
         }
 
-        /// <include file="../docs.xml" path='docs/class[@name="Error"]/prop[@name="Message"]/*' />
+        /// <inheritdoc />
         public string Message
         {
             get => $"{_error.MessageWrapper}: {_error.Message}";

--- a/src/Momento.Sdk/docs.xml
+++ b/src/Momento.Sdk/docs.xml
@@ -27,29 +27,6 @@
         </list>
       </summary>
     </description>
-    <prop name="ErrorCode">
-      <summary>
-        The <c>Momento.Sdk.Exceptions.MomentoErrorCode</c> value for the
-        <c>Error</c> object. Example:<br/>
-        <code>
-          if (errorResponse.ErrorCode == MomentoErrorCode.TIMEOUT_ERROR)
-          {
-            // handle timeout error
-          }
-        </code>
-      </summary>
-    </prop>
-    <prop name="InnerException">
-      <summary>
-        The <c>SdkException</c> object used to construct the response.
-      </summary>
-    </prop>
-    <prop name="Message">
-      <summary>
-        An explanation of conditions that caused and potential
-        ways to resolve the error.
-      </summary>
-    </prop>
   </class>
   <class name="SdkException">
       <description>


### PR DESCRIPTION
In the current formulation, downstream code cannot consume a generic
`Error` type, because current error types inherit from a parent
abstract class.

This PR introduces an error interface, `IError`, which specifies that
an error response has the following properties:
- `InnerException`
- `ErrorCode`
- `Message`

which is common to all error classes.

With this in place we inherit the documentation from the interface,
simplifying the doc strings in the response classes.

Eventually we should the same for `Success`, `Hit`, and `Miss`.

closes #433 