### PR TITLE
feat: implement `UpdateTtl` command

### DIFF
--- a/src/Momento.Sdk/CacheClient.cs
+++ b/src/Momento.Sdk/CacheClient.cs
@@ -84,7 +84,7 @@ public class CacheClient : ICacheClient
     }
 
     /// <inheritdoc />
-    async Task<CacheKeyExistsResponse> ICacheClient.KeyExistsAsync(string cacheName, byte[] key)
+    public async Task<CacheKeyExistsResponse> KeyExistsAsync(string cacheName, byte[] key)
     {
         try
         {
@@ -99,7 +99,7 @@ public class CacheClient : ICacheClient
     }
 
     /// <inheritdoc />
-    async Task<CacheKeyExistsResponse> ICacheClient.KeyExistsAsync(string cacheName, string key)
+    public async Task<CacheKeyExistsResponse> KeyExistsAsync(string cacheName, string key)
     {
         try
         {
@@ -114,7 +114,7 @@ public class CacheClient : ICacheClient
     }
 
     /// <inheritdoc />
-    async Task<CacheKeysExistResponse> ICacheClient.KeysExistAsync(string cacheName, IEnumerable<byte[]> keys)
+    public async Task<CacheKeysExistResponse> KeysExistAsync(string cacheName, IEnumerable<byte[]> keys)
     {
         try
         {
@@ -130,7 +130,7 @@ public class CacheClient : ICacheClient
     }
 
     /// <inheritdoc />
-    async Task<CacheKeysExistResponse> ICacheClient.KeysExistAsync(string cacheName, IEnumerable<string> keys)
+    public async Task<CacheKeysExistResponse> KeysExistAsync(string cacheName, IEnumerable<string> keys)
     {
         try
         {
@@ -145,6 +145,45 @@ public class CacheClient : ICacheClient
         return await this.DataClient.KeysExistAsync(cacheName, keys);
     }
 
+    /// <inheritdoc />
+    public async Task<CacheUpdateTtlResponse> UpdateTtlAsync(string cacheName, byte[] key, TimeSpan ttl)
+    {
+        try
+        {
+            Utils.ArgumentNotNull(cacheName, nameof(cacheName));
+            Utils.ArgumentNotNull(key, nameof(key));
+            Utils.ArgumentStrictlyPositive(ttl, nameof(ttl));
+        }
+        catch (ArgumentNullException e)
+        {
+            return new CacheUpdateTtlResponse.Error(new InvalidArgumentException(e.Message));
+        }
+        catch (ArgumentOutOfRangeException e)
+        {
+            return new CacheUpdateTtlResponse.Error(new InvalidArgumentException(e.Message));
+        }
+        return await this.DataClient.UpdateTtlAsync(cacheName, key, ttl);
+    }
+
+    /// <inheritdoc />
+    public async Task<CacheUpdateTtlResponse> UpdateTtlAsync(string cacheName, string key, TimeSpan ttl)
+    {
+        try
+        {
+            Utils.ArgumentNotNull(cacheName, nameof(cacheName));
+            Utils.ArgumentNotNull(key, nameof(key));
+            Utils.ArgumentStrictlyPositive(ttl, nameof(ttl));
+        }
+        catch (ArgumentNullException e)
+        {
+            return new CacheUpdateTtlResponse.Error(new InvalidArgumentException(e.Message));
+        }
+        catch (ArgumentOutOfRangeException e)
+        {
+            return new CacheUpdateTtlResponse.Error(new InvalidArgumentException(e.Message));
+        }
+        return await this.DataClient.UpdateTtlAsync(cacheName, key, ttl);
+    }
 
     /// <inheritdoc />
     public async Task<CacheSetResponse> SetAsync(string cacheName, byte[] key, byte[] value, TimeSpan? ttl = null)

--- a/src/Momento.Sdk/ICacheClient.cs
+++ b/src/Momento.Sdk/ICacheClient.cs
@@ -160,6 +160,17 @@ public interface ICacheClient : IDisposable
     /// <inheritdoc cref="KeysExistAsync(string, IEnumerable{byte[]})"/>
     public Task<CacheKeysExistResponse> KeysExistAsync(string cacheName, IEnumerable<string> keys);
 
+    /// <summary>
+    /// Overwrites the TTL of a cache item with the provided TTL.
+    /// </summary>
+    /// <param name="cacheName">The name of the cache to perform the lookup in.</param>
+    /// <param name="key">The key to update the TTL for.</param>
+    /// <param name="ttl">The new TTL for the item.</param>
+    /// <returns>Task representing the result of the update TTL operation.</returns>
+    public Task<CacheUpdateTtlResponse> UpdateTtlAsync(string cacheName, byte[] key, TimeSpan ttl);
+
+    /// <inheritdoc cref="UpdateTtlAsync(string, byte[], TimeSpan)"/>
+    public Task<CacheUpdateTtlResponse> UpdateTtlAsync(string cacheName, string key, TimeSpan ttl);
 
     /// <summary>
     /// Set the value in cache with a given time to live (TTL) seconds.

--- a/src/Momento.Sdk/Internal/DataGrpcManager.cs
+++ b/src/Momento.Sdk/Internal/DataGrpcManager.cs
@@ -23,6 +23,7 @@ namespace Momento.Sdk.Internal;
 public interface IDataClient
 {
     public Task<_KeysExistResponse> KeysExistAsync(_KeysExistRequest request, CallOptions callOptions);
+    public Task<_UpdateTtlResponse> UpdateTtlAsync(_UpdateTtlRequest request, CallOptions callOptions);
     public Task<_GetResponse> GetAsync(_GetRequest request, CallOptions callOptions);
     public Task<_SetResponse> SetAsync(_SetRequest request, CallOptions callOptions);
     public Task<_DeleteResponse> DeleteAsync(_DeleteRequest request, CallOptions callOptions);
@@ -71,6 +72,12 @@ public class DataClientWithMiddleware : IDataClient
     public async Task<_KeysExistResponse> KeysExistAsync(_KeysExistRequest request, CallOptions callOptions)
     {
         var wrapped = await _middlewares.WrapRequest(request, callOptions, (r, o) => _generatedClient.KeysExistAsync(r, o));
+        return await wrapped.ResponseAsync;
+    }
+
+    public async Task<_UpdateTtlResponse> UpdateTtlAsync(_UpdateTtlRequest request, CallOptions callOptions)
+    {
+        var wrapped = await _middlewares.WrapRequest(request, callOptions, (r, o) => _generatedClient.UpdateTtlAsync(r, o));
         return await wrapped.ResponseAsync;
     }
 

--- a/src/Momento.Sdk/Internal/ScsDataClient.cs
+++ b/src/Momento.Sdk/Internal/ScsDataClient.cs
@@ -444,7 +444,7 @@ internal sealed class ScsDataClient : ScsDataClientBase
 
         if (response.ResultCase == _UpdateTtlResponse.ResultOneofCase.Set)
         {
-            return this._logger.LogTraceRequestSuccess(REQUEST_TYPE_UPDATE_TTL, cacheName, key, null, ttl, new CacheUpdateTtlResponse.Hit());
+            return this._logger.LogTraceRequestSuccess(REQUEST_TYPE_UPDATE_TTL, cacheName, key, null, ttl, new CacheUpdateTtlResponse.Set());
         }
         else if (response.ResultCase == _UpdateTtlResponse.ResultOneofCase.Missing)
         {

--- a/src/Momento.Sdk/Momento.Sdk.csproj
+++ b/src/Momento.Sdk/Momento.Sdk.csproj
@@ -54,7 +54,7 @@
 	</ItemGroup>
 	<ItemGroup>
 	  <PackageReference Include="Grpc.Net.Client" Version="2.49.0" />
-	  <PackageReference Include="Momento.Protos" Version="0.51.1" />
+	  <PackageReference Include="Momento.Protos" Version="0.60.1" />
 	  <PackageReference Include="JWT" Version="9.0.3" />
 	  <PackageReference Include="System.Threading.Channels" Version="6.0.0" />
 	  <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />

--- a/src/Momento.Sdk/Responses/CacheUpdateTtlResponse.cs
+++ b/src/Momento.Sdk/Responses/CacheUpdateTtlResponse.cs
@@ -8,7 +8,7 @@ using Momento.Sdk.Exceptions;
 /// response object is resolved to a type-safe object of one of
 /// the following subtypes:
 /// <list type="bullet">
-/// <item><description>CacheUpdateTtlResponse.Hit</description></item>
+/// <item><description>CacheUpdateTtlResponse.Set</description></item>
 /// <item><description>CacheUpdateTtlResponse.Miss</description></item>
 /// <item><description>CacheUpdateTtlResponse.Error</description></item>
 /// </list>
@@ -40,7 +40,7 @@ public abstract class CacheUpdateTtlResponse
     /// <summary>
     /// Indicates the key was found in the cache and the ttl was updated.
     /// </summary>
-    public class Hit : CacheUpdateTtlResponse { }
+    public class Set : CacheUpdateTtlResponse { }
 
     /// <summary>
     /// Indicates the key was not found in the cache, hence the ttl was not updated.

--- a/src/Momento.Sdk/Responses/CacheUpdateTtlResponse.cs
+++ b/src/Momento.Sdk/Responses/CacheUpdateTtlResponse.cs
@@ -15,14 +15,13 @@ using Momento.Sdk.Exceptions;
 /// Pattern matching can be used to operate on the appropriate subtype.
 /// For example:
 /// <code>
-/// if (response is CacheUpdateTtlResponse.Hit hitResponse)
+/// if (response is CacheUpdateTtlResponse.Set setResponse)
 /// {
-///    // handle hit as appropriate
-///    return hitResponse.ValueString;
+///    // handle ttl updated as appropriate
 /// }
 /// else if (response is CacheUpdateTtlResponse.Miss missResponse)
 /// {
-///    // handle miss as appropriate
+///    // handle ttl not updated because key was not found as appropriate
 /// }
 /// else if (response is CacheUpdateTtlResponse.Error errorResponse)
 /// {

--- a/src/Momento.Sdk/Responses/CacheUpdateTtlResponse.cs
+++ b/src/Momento.Sdk/Responses/CacheUpdateTtlResponse.cs
@@ -1,0 +1,79 @@
+namespace Momento.Sdk.Responses;
+
+using Momento.Sdk.Exceptions;
+
+
+/// <summary>
+/// Parent response type for a cache update ttl request. The
+/// response object is resolved to a type-safe object of one of
+/// the following subtypes:
+/// <list type="bullet">
+/// <item><description>CacheUpdateTtlResponse.Hit</description></item>
+/// <item><description>CacheUpdateTtlResponse.Miss</description></item>
+/// <item><description>CacheUpdateTtlResponse.Error</description></item>
+/// </list>
+/// Pattern matching can be used to operate on the appropriate subtype.
+/// For example:
+/// <code>
+/// if (response is CacheUpdateTtlResponse.Hit hitResponse)
+/// {
+///    // handle hit as appropriate
+///    return hitResponse.ValueString;
+/// }
+/// else if (response is CacheUpdateTtlResponse.Miss missResponse)
+/// {
+///    // handle miss as appropriate
+/// }
+/// else if (response is CacheUpdateTtlResponse.Error errorResponse)
+/// {
+///   // handle error as appropriate
+///   return errorResponse.Message;
+/// }
+/// else
+/// {
+///   // handle unexpected response
+/// }
+/// </code>
+/// </summary>
+public abstract class CacheUpdateTtlResponse
+{
+    /// <summary>
+    /// Indicates the key was found in the cache and the ttl was updated.
+    /// </summary>
+    public class Hit : CacheUpdateTtlResponse { }
+
+    /// <summary>
+    /// Indicates the key was not found in the cache, hence the ttl was not updated.
+    /// </summary>
+    public class Miss : CacheUpdateTtlResponse { }
+
+    /// <include file = "../docs.xml" path='docs/class[@name="Error"]/description/*' />
+    public class Error : CacheUpdateTtlResponse, IError
+    {
+        private readonly SdkException _error;
+
+        /// <include file = "../docs.xml" path='docs/class[@name="Error"]/constructor/*' />
+        public Error(SdkException error)
+        {
+            _error = error;
+        }
+
+        /// <inheritdoc />
+        public SdkException InnerException
+        {
+            get => _error;
+        }
+
+        /// <inheritdoc />
+        public MomentoErrorCode ErrorCode
+        {
+            get => _error.ErrorCode;
+        }
+
+        /// <inheritdoc />
+        public string Message
+        {
+            get => _error.Message;
+        }
+    }
+}

--- a/tests/Integration/Momento.Sdk.Tests/TtlTest.cs
+++ b/tests/Integration/Momento.Sdk.Tests/TtlTest.cs
@@ -58,7 +58,7 @@ public class TtlTest : TestBase
     }
 
     [Fact]
-    public async Task UpdateTtlAsync_KeyIsByteArrayAndExists_UpdatesTtl()
+    public async Task UpdateTtlAsync_KeyIsByteArrayAndExists_IsSet()
     {
         // Add an item with a minute ttl
         byte[] key = Utils.NewGuidByteArray();
@@ -73,7 +73,7 @@ public class TtlTest : TestBase
 
         // Let's make the TTL really small.
         var updateTtlResponse = await client.UpdateTtlAsync(cacheName, key, TimeSpan.FromSeconds(1));
-        Assert.True(updateTtlResponse is CacheUpdateTtlResponse.Hit, $"UpdateTtl call should have been Hit but was: {response}");
+        Assert.True(updateTtlResponse is CacheUpdateTtlResponse.Set, $"UpdateTtl call should have been Set but was: {response}");
 
         // Wait for the TTL to expire
         await Task.Delay(1000);
@@ -85,7 +85,7 @@ public class TtlTest : TestBase
     }
 
     [Fact]
-    public async Task UpdateTtlAsync_KeyIsStringAndExists_UpdatesTtl()
+    public async Task UpdateTtlAsync_KeyIsStringAndExists_IsSet()
     {
         // Add an item with a minute ttl
         string key = Utils.NewGuidString();
@@ -100,7 +100,7 @@ public class TtlTest : TestBase
 
         // Let's make the TTL really small.
         var updateTtlResponse = await client.UpdateTtlAsync(cacheName, key, TimeSpan.FromSeconds(1));
-        Assert.True(updateTtlResponse is CacheUpdateTtlResponse.Hit, $"UpdateTtl call should have been Hit but was: {response}");
+        Assert.True(updateTtlResponse is CacheUpdateTtlResponse.Set, $"UpdateTtl call should have been Set but was: {response}");
 
         // Wait for the TTL to expire
         await Task.Delay(1000);

--- a/tests/Integration/Momento.Sdk.Tests/TtlTest.cs
+++ b/tests/Integration/Momento.Sdk.Tests/TtlTest.cs
@@ -1,0 +1,113 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Momento.Sdk.Internal.ExtensionMethods;
+
+namespace Momento.Sdk.Tests;
+
+[Collection("CacheClient")]
+public class TtlTest : TestBase
+{
+    // Test initialization
+    public TtlTest(CacheClientFixture fixture) : base(fixture)
+    {
+    }
+
+
+    [Theory]
+    [InlineData(null, new byte[] { 0x00 }, 60)]
+    [InlineData("cache", null, 60)]
+    [InlineData(null, new byte[] { 0x00 }, -1)]
+    public async Task UpdateTtlAsync_NullChecksByteArray_IsError(string cacheName, byte[] key, int ttlSeconds)
+    {
+        var ttl = TimeSpan.FromSeconds(ttlSeconds);
+        var response = await client.UpdateTtlAsync(cacheName, key, ttl);
+        Assert.True(response is CacheUpdateTtlResponse.Error, $"Unexpected response: {response}");
+        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheUpdateTtlResponse.Error)response).ErrorCode);
+    }
+
+    [Theory]
+    [InlineData(null, "key", 60)]
+    [InlineData("cache", null, 60)]
+    [InlineData(null, "key", -1)]
+    public async Task UpdateTtlAsync_NullChecksString_IsError(string cacheName, string key, int ttlSeconds)
+    {
+        var ttl = TimeSpan.FromSeconds(ttlSeconds);
+        var response = await client.UpdateTtlAsync(cacheName, key, ttl);
+        Assert.True(response is CacheUpdateTtlResponse.Error, $"Unexpected response: {response}");
+        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheUpdateTtlResponse.Error)response).ErrorCode);
+    }
+
+    [Fact]
+    public async Task UpdateTtlAsync_KeyIsByteArrayAndMissing_IsMiss()
+    {
+        byte[] key = Utils.NewGuidByteArray();
+        var ttl = TimeSpan.FromSeconds(60);
+        var response = await client.UpdateTtlAsync(cacheName, key, ttl);
+        Assert.True(response is CacheUpdateTtlResponse.Miss, $"Unexpected response: {response}");
+    }
+
+    [Fact]
+    public async Task UpdateTtlAsync_KeyIsStringAndMissing_IsMiss()
+    {
+        string key = Utils.NewGuidString();
+        var ttl = TimeSpan.FromSeconds(60);
+        var response = await client.UpdateTtlAsync(cacheName, key, ttl);
+        Assert.True(response is CacheUpdateTtlResponse.Miss, $"Unexpected response: {response}");
+    }
+
+    [Fact]
+    public async Task UpdateTtlAsync_KeyIsByteArrayAndExists_UpdatesTtl()
+    {
+        // Add an item with a minute ttl
+        byte[] key = Utils.NewGuidByteArray();
+        var ttl = TimeSpan.FromSeconds(60);
+        var response = await client.SetAsync(cacheName, key, Utils.NewGuidByteArray());
+        Assert.True(response is CacheSetResponse.Success, $"Unexpected response: {response}");
+
+        // Check it is there
+        var existsResponse = await client.KeyExistsAsync(cacheName, key);
+        Assert.True(existsResponse is CacheKeyExistsResponse.Success, "exists response should be success");
+        Assert.True(((CacheKeyExistsResponse.Success)existsResponse).Exists, "Key should exist");
+
+        // Let's make the TTL really small.
+        var updateTtlResponse = await client.UpdateTtlAsync(cacheName, key, TimeSpan.FromSeconds(1));
+        Assert.True(updateTtlResponse is CacheUpdateTtlResponse.Hit, $"UpdateTtl call should have been Hit but was: {response}");
+
+        // Wait for the TTL to expire
+        await Task.Delay(1000);
+
+        // Check it is gone
+        existsResponse = await client.KeyExistsAsync(cacheName, key);
+        Assert.True(existsResponse is CacheKeyExistsResponse.Success, "exists response should be success");
+        Assert.False(((CacheKeyExistsResponse.Success)existsResponse).Exists, "Key should not exist");
+    }
+
+    [Fact]
+    public async Task UpdateTtlAsync_KeyIsStringAndExists_UpdatesTtl()
+    {
+        // Add an item with a minute ttl
+        string key = Utils.NewGuidString();
+        var ttl = TimeSpan.FromSeconds(60);
+        var response = await client.SetAsync(cacheName, key, Utils.NewGuidString());
+        Assert.True(response is CacheSetResponse.Success, $"Unexpected response: {response}");
+
+        // Check it is there
+        var existsResponse = await client.KeyExistsAsync(cacheName, key);
+        Assert.True(existsResponse is CacheKeyExistsResponse.Success, "exists response should be success");
+        Assert.True(((CacheKeyExistsResponse.Success)existsResponse).Exists, "Key should exist");
+
+        // Let's make the TTL really small.
+        var updateTtlResponse = await client.UpdateTtlAsync(cacheName, key, TimeSpan.FromSeconds(1));
+        Assert.True(updateTtlResponse is CacheUpdateTtlResponse.Hit, $"UpdateTtl call should have been Hit but was: {response}");
+
+        // Wait for the TTL to expire
+        await Task.Delay(1000);
+
+        // Check it is gone
+        existsResponse = await client.KeyExistsAsync(cacheName, key);
+        Assert.True(existsResponse is CacheKeyExistsResponse.Success, "exists response should be success");
+        Assert.False(((CacheKeyExistsResponse.Success)existsResponse).Exists, "Key should not exist");
+    }
+}


### PR DESCRIPTION
This adds the command `UpdateTtl`, which unconditionally overwrites
the TTL of an item in the cache. Bumps protos version; adds the
command, documentation, and integration tests.
