### PR TITLE
fix: update int test ttls to be more lenient

### DIFF
--- a/tests/Integration/Momento.Sdk.Tests/DictionaryTest.cs
+++ b/tests/Integration/Momento.Sdk.Tests/DictionaryTest.cs
@@ -85,13 +85,13 @@ public class DictionaryTest : TestBase
         var field = Utils.NewGuidByteArray();
         var value = Utils.NewGuidByteArray();
 
-        CacheDictionarySetFieldResponse setResponse = await client.DictionarySetFieldAsync(cacheName, dictionaryName, field, value, CollectionTtl.Of(TimeSpan.FromSeconds(4)).WithNoRefreshTtlOnUpdates());
+        CacheDictionarySetFieldResponse setResponse = await client.DictionarySetFieldAsync(cacheName, dictionaryName, field, value, CollectionTtl.Of(TimeSpan.FromSeconds(Utils.initialRefreshTtl)).WithNoRefreshTtlOnUpdates());
         Assert.True(setResponse is CacheDictionarySetFieldResponse.Success, $"Unexpected response: {setResponse}");
-        await Task.Delay(100);
+        await Task.Delay(Utils.waitForItemToBeSet);
 
-        setResponse = await client.DictionarySetFieldAsync(cacheName, dictionaryName, field, value, CollectionTtl.Of(TimeSpan.FromSeconds(10)).WithNoRefreshTtlOnUpdates());
+        setResponse = await client.DictionarySetFieldAsync(cacheName, dictionaryName, field, value, CollectionTtl.Of(TimeSpan.FromSeconds(Utils.updatedRefreshTtl)).WithNoRefreshTtlOnUpdates());
         Assert.True(setResponse is CacheDictionarySetFieldResponse.Success, $"Unexpected response: {setResponse}");
-        await Task.Delay(4900);
+        await Task.Delay(Utils.waitForInitialItemToExpire);
 
         CacheDictionaryGetFieldResponse response = await client.DictionaryGetFieldAsync(cacheName, dictionaryName, field);
         Assert.True(response is CacheDictionaryGetFieldResponse.Miss, $"Unexpected response: {response}");
@@ -106,7 +106,7 @@ public class DictionaryTest : TestBase
 
         CacheDictionarySetFieldResponse setResponse = await client.DictionarySetFieldAsync(cacheName, dictionaryName, field, value, CollectionTtl.Of(TimeSpan.FromSeconds(2)));
         Assert.True(setResponse is CacheDictionarySetFieldResponse.Success, $"Unexpected response: {setResponse}");
-        setResponse = await client.DictionarySetFieldAsync(cacheName, dictionaryName, field, value, CollectionTtl.Of(TimeSpan.FromSeconds(10)));
+        setResponse = await client.DictionarySetFieldAsync(cacheName, dictionaryName, field, value, CollectionTtl.Of(TimeSpan.FromSeconds(Utils.updatedRefreshTtl)));
         Assert.True(setResponse is CacheDictionarySetFieldResponse.Success, $"Unexpected response: {setResponse}");
         await Task.Delay(2000);
 
@@ -162,7 +162,7 @@ public class DictionaryTest : TestBase
 
         CacheDictionaryIncrementResponse resp = await client.DictionaryIncrementAsync(cacheName, dictionaryName, field, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(2)));
         Assert.True(resp is CacheDictionaryIncrementResponse.Success, $"Unexpected response: {resp}");
-        resp = await client.DictionaryIncrementAsync(cacheName, dictionaryName, field, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(10)));
+        resp = await client.DictionaryIncrementAsync(cacheName, dictionaryName, field, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.updatedRefreshTtl)));
         Assert.True(resp is CacheDictionaryIncrementResponse.Success, $"Unexpected response: {resp}");
         await Task.Delay(2000);
 
@@ -177,13 +177,13 @@ public class DictionaryTest : TestBase
         var dictionaryName = Utils.NewGuidString();
         var field = Utils.NewGuidString();
 
-        CacheDictionaryIncrementResponse resp = await client.DictionaryIncrementAsync(cacheName, dictionaryName, field, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(4)));
+        CacheDictionaryIncrementResponse resp = await client.DictionaryIncrementAsync(cacheName, dictionaryName, field, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.initialRefreshTtl)));
         Assert.True(resp is CacheDictionaryIncrementResponse.Success, $"Unexpected response: {resp}");
-        await Task.Delay(101);
+        await Task.Delay(Utils.waitForItemToBeSet);
 
-        resp = await client.DictionaryIncrementAsync(cacheName, dictionaryName, field, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(10)).WithNoRefreshTtlOnUpdates());
+        resp = await client.DictionaryIncrementAsync(cacheName, dictionaryName, field, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.updatedRefreshTtl)).WithNoRefreshTtlOnUpdates());
         Assert.True(resp is CacheDictionaryIncrementResponse.Success, $"Unexpected response: {resp}");
-        await Task.Delay(4900);
+        await Task.Delay(Utils.waitForInitialItemToExpire);
 
         CacheDictionaryGetFieldResponse response = await client.DictionaryGetFieldAsync(cacheName, dictionaryName, field);
         Assert.True(response is CacheDictionaryGetFieldResponse.Miss, $"Unexpected response: {response}");
@@ -316,13 +316,13 @@ public class DictionaryTest : TestBase
         var field = Utils.NewGuidString();
         var value = Utils.NewGuidString();
 
-        CacheDictionarySetFieldResponse setResponse = await client.DictionarySetFieldAsync(cacheName, dictionaryName, field, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(4)));
+        CacheDictionarySetFieldResponse setResponse = await client.DictionarySetFieldAsync(cacheName, dictionaryName, field, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.initialRefreshTtl)));
         Assert.True(setResponse is CacheDictionarySetFieldResponse.Success, $"Unexpected response: {setResponse}");
-        await Task.Delay(100);
+        await Task.Delay(Utils.waitForItemToBeSet);
 
-        setResponse = await client.DictionarySetFieldAsync(cacheName, dictionaryName, field, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(10)).WithNoRefreshTtlOnUpdates());
+        setResponse = await client.DictionarySetFieldAsync(cacheName, dictionaryName, field, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.updatedRefreshTtl)).WithNoRefreshTtlOnUpdates());
         Assert.True(setResponse is CacheDictionarySetFieldResponse.Success, $"Unexpected response: {setResponse}");
-        await Task.Delay(4900);
+        await Task.Delay(Utils.waitForInitialItemToExpire);
 
         CacheDictionaryGetFieldResponse response = await client.DictionaryGetFieldAsync(cacheName, dictionaryName, field);
         Assert.True(response is CacheDictionaryGetFieldResponse.Miss, $"Unexpected response: {response}");
@@ -337,7 +337,7 @@ public class DictionaryTest : TestBase
 
         CacheDictionarySetFieldResponse setResponse = await client.DictionarySetFieldAsync(cacheName, dictionaryName, field, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(2)));
         Assert.True(setResponse is CacheDictionarySetFieldResponse.Success, $"Unexpected response: {setResponse}");
-        setResponse = await client.DictionarySetFieldAsync(cacheName, dictionaryName, field, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(10)));
+        setResponse = await client.DictionarySetFieldAsync(cacheName, dictionaryName, field, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.updatedRefreshTtl)));
         Assert.True(setResponse is CacheDictionarySetFieldResponse.Success, $"Unexpected response: {setResponse}");
         await Task.Delay(2000);
 
@@ -379,13 +379,13 @@ public class DictionaryTest : TestBase
         var field = Utils.NewGuidString();
         var value = Utils.NewGuidByteArray();
 
-        CacheDictionarySetFieldResponse setResponse = await client.DictionarySetFieldAsync(cacheName, dictionaryName, field, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(4)));
+        CacheDictionarySetFieldResponse setResponse = await client.DictionarySetFieldAsync(cacheName, dictionaryName, field, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.initialRefreshTtl)));
         Assert.True(setResponse is CacheDictionarySetFieldResponse.Success, $"Unexpected response: {setResponse}");
-        await Task.Delay(100);
+        await Task.Delay(Utils.waitForItemToBeSet);
 
-        setResponse = await client.DictionarySetFieldAsync(cacheName, dictionaryName, field, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(10)).WithNoRefreshTtlOnUpdates());
+        setResponse = await client.DictionarySetFieldAsync(cacheName, dictionaryName, field, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.updatedRefreshTtl)).WithNoRefreshTtlOnUpdates());
         Assert.True(setResponse is CacheDictionarySetFieldResponse.Success, $"Unexpected response: {setResponse}");
-        await Task.Delay(4900);
+        await Task.Delay(Utils.waitForInitialItemToExpire);
 
         CacheDictionaryGetFieldResponse response = await client.DictionaryGetFieldAsync(cacheName, dictionaryName, field);
         Assert.True(response is CacheDictionaryGetFieldResponse.Miss, $"Unexpected response: {response}");
@@ -400,7 +400,7 @@ public class DictionaryTest : TestBase
 
         CacheDictionarySetFieldResponse setResponse = await client.DictionarySetFieldAsync(cacheName, dictionaryName, field, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(2)));
         Assert.True(setResponse is CacheDictionarySetFieldResponse.Success, $"Unexpected response: {setResponse}");
-        setResponse = await client.DictionarySetFieldAsync(cacheName, dictionaryName, field, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(10)));
+        setResponse = await client.DictionarySetFieldAsync(cacheName, dictionaryName, field, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.updatedRefreshTtl)));
         Assert.True(setResponse is CacheDictionarySetFieldResponse.Success, $"Unexpected response: {setResponse}");
         await Task.Delay(2000);
 
@@ -441,7 +441,7 @@ public class DictionaryTest : TestBase
 
         var items = new Dictionary<byte[], byte[]>() { { field1, value1 }, { field2, value2 } };
 
-        await client.DictionarySetFieldsAsync(cacheName, dictionaryName, items, CollectionTtl.Of(TimeSpan.FromSeconds(10)));
+        await client.DictionarySetFieldsAsync(cacheName, dictionaryName, items, CollectionTtl.Of(TimeSpan.FromSeconds(Utils.updatedRefreshTtl)));
 
         CacheDictionaryGetFieldResponse getResponse = await client.DictionaryGetFieldAsync(cacheName, dictionaryName, field1);
         Assert.True(getResponse is CacheDictionaryGetFieldResponse.Hit, $"Unexpected response: {getResponse}");
@@ -460,11 +460,11 @@ public class DictionaryTest : TestBase
         var value = Utils.NewGuidByteArray();
         var content = new Dictionary<byte[], byte[]>() { { field, value } };
 
-        await client.DictionarySetFieldsAsync(cacheName, dictionaryName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(4)));
-        await Task.Delay(100);
+        await client.DictionarySetFieldsAsync(cacheName, dictionaryName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.initialRefreshTtl)));
+        await Task.Delay(Utils.waitForItemToBeSet);
 
-        await client.DictionarySetFieldsAsync(cacheName, dictionaryName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(10)).WithNoRefreshTtlOnUpdates());
-        await Task.Delay(4900);
+        await client.DictionarySetFieldsAsync(cacheName, dictionaryName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.updatedRefreshTtl)).WithNoRefreshTtlOnUpdates());
+        await Task.Delay(Utils.waitForInitialItemToExpire);
 
         CacheDictionaryGetFieldResponse response = await client.DictionaryGetFieldAsync(cacheName, dictionaryName, field);
         Assert.True(response is CacheDictionaryGetFieldResponse.Miss, $"Unexpected response: {response}");
@@ -479,7 +479,7 @@ public class DictionaryTest : TestBase
         var content = new Dictionary<byte[], byte[]>() { { field, value } };
 
         await client.DictionarySetFieldsAsync(cacheName, dictionaryName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(2)));
-        await client.DictionarySetFieldsAsync(cacheName, dictionaryName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(10)));
+        await client.DictionarySetFieldsAsync(cacheName, dictionaryName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.updatedRefreshTtl)));
         await Task.Delay(2000);
 
         CacheDictionaryGetFieldResponse response = await client.DictionaryGetFieldAsync(cacheName, dictionaryName, field);
@@ -538,11 +538,11 @@ public class DictionaryTest : TestBase
         var value = Utils.NewGuidString();
         var content = new Dictionary<string, string>() { { field, value } };
 
-        await client.DictionarySetFieldsAsync(cacheName, dictionaryName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(4)));
-        await Task.Delay(100);
+        await client.DictionarySetFieldsAsync(cacheName, dictionaryName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.initialRefreshTtl)));
+        await Task.Delay(Utils.waitForItemToBeSet);
 
-        await client.DictionarySetFieldsAsync(cacheName, dictionaryName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(10)).WithNoRefreshTtlOnUpdates());
-        await Task.Delay(4900);
+        await client.DictionarySetFieldsAsync(cacheName, dictionaryName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.updatedRefreshTtl)).WithNoRefreshTtlOnUpdates());
+        await Task.Delay(Utils.waitForInitialItemToExpire);
 
         CacheDictionaryGetFieldResponse response = await client.DictionaryGetFieldAsync(cacheName, dictionaryName, field);
         Assert.True(response is CacheDictionaryGetFieldResponse.Miss, $"Unexpected response: {response}");
@@ -557,7 +557,7 @@ public class DictionaryTest : TestBase
         var content = new Dictionary<string, string>() { { field, value } };
 
         await client.DictionarySetFieldsAsync(cacheName, dictionaryName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(2)));
-        await client.DictionarySetFieldsAsync(cacheName, dictionaryName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(10)));
+        await client.DictionarySetFieldsAsync(cacheName, dictionaryName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.updatedRefreshTtl)));
         await Task.Delay(2000);
 
         CacheDictionaryGetFieldResponse response = await client.DictionaryGetFieldAsync(cacheName, dictionaryName, field);
@@ -616,11 +616,11 @@ public class DictionaryTest : TestBase
         var value = Utils.NewGuidByteArray();
         var content = new Dictionary<string, byte[]>() { { field, value } };
 
-        await client.DictionarySetFieldsAsync(cacheName, dictionaryName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(4)).WithNoRefreshTtlOnUpdates());
-        await Task.Delay(100);
+        await client.DictionarySetFieldsAsync(cacheName, dictionaryName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.initialRefreshTtl)).WithNoRefreshTtlOnUpdates());
+        await Task.Delay(Utils.waitForItemToBeSet);
 
-        await client.DictionarySetFieldsAsync(cacheName, dictionaryName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(10)).WithNoRefreshTtlOnUpdates());
-        await Task.Delay(4900);
+        await client.DictionarySetFieldsAsync(cacheName, dictionaryName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.updatedRefreshTtl)).WithNoRefreshTtlOnUpdates());
+        await Task.Delay(Utils.waitForInitialItemToExpire);
 
         CacheDictionaryGetFieldResponse response = await client.DictionaryGetFieldAsync(cacheName, dictionaryName, field);
         Assert.True(response is CacheDictionaryGetFieldResponse.Miss, $"Unexpected response: {response}");
@@ -635,7 +635,7 @@ public class DictionaryTest : TestBase
         var content = new Dictionary<string, byte[]>() { { field, value } };
 
         await client.DictionarySetFieldsAsync(cacheName, dictionaryName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(2)));
-        await client.DictionarySetFieldsAsync(cacheName, dictionaryName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(10)));
+        await client.DictionarySetFieldsAsync(cacheName, dictionaryName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.updatedRefreshTtl)));
         await Task.Delay(2000);
 
         CacheDictionaryGetFieldResponse response = await client.DictionaryGetFieldAsync(cacheName, dictionaryName, field);

--- a/tests/Integration/Momento.Sdk.Tests/DictionaryTest.cs
+++ b/tests/Integration/Momento.Sdk.Tests/DictionaryTest.cs
@@ -85,7 +85,7 @@ public class DictionaryTest : TestBase
         var field = Utils.NewGuidByteArray();
         var value = Utils.NewGuidByteArray();
 
-        CacheDictionarySetFieldResponse setResponse = await client.DictionarySetFieldAsync(cacheName, dictionaryName, field, value, CollectionTtl.Of(TimeSpan.FromSeconds(5)).WithNoRefreshTtlOnUpdates());
+        CacheDictionarySetFieldResponse setResponse = await client.DictionarySetFieldAsync(cacheName, dictionaryName, field, value, CollectionTtl.Of(TimeSpan.FromSeconds(4)).WithNoRefreshTtlOnUpdates());
         Assert.True(setResponse is CacheDictionarySetFieldResponse.Success, $"Unexpected response: {setResponse}");
         await Task.Delay(100);
 
@@ -177,7 +177,7 @@ public class DictionaryTest : TestBase
         var dictionaryName = Utils.NewGuidString();
         var field = Utils.NewGuidString();
 
-        CacheDictionaryIncrementResponse resp = await client.DictionaryIncrementAsync(cacheName, dictionaryName, field, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(5)));
+        CacheDictionaryIncrementResponse resp = await client.DictionaryIncrementAsync(cacheName, dictionaryName, field, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(4)));
         Assert.True(resp is CacheDictionaryIncrementResponse.Success, $"Unexpected response: {resp}");
         await Task.Delay(101);
 
@@ -316,7 +316,7 @@ public class DictionaryTest : TestBase
         var field = Utils.NewGuidString();
         var value = Utils.NewGuidString();
 
-        CacheDictionarySetFieldResponse setResponse = await client.DictionarySetFieldAsync(cacheName, dictionaryName, field, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(5)));
+        CacheDictionarySetFieldResponse setResponse = await client.DictionarySetFieldAsync(cacheName, dictionaryName, field, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(4)));
         Assert.True(setResponse is CacheDictionarySetFieldResponse.Success, $"Unexpected response: {setResponse}");
         await Task.Delay(100);
 
@@ -379,7 +379,7 @@ public class DictionaryTest : TestBase
         var field = Utils.NewGuidString();
         var value = Utils.NewGuidByteArray();
 
-        CacheDictionarySetFieldResponse setResponse = await client.DictionarySetFieldAsync(cacheName, dictionaryName, field, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(5)));
+        CacheDictionarySetFieldResponse setResponse = await client.DictionarySetFieldAsync(cacheName, dictionaryName, field, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(4)));
         Assert.True(setResponse is CacheDictionarySetFieldResponse.Success, $"Unexpected response: {setResponse}");
         await Task.Delay(100);
 
@@ -460,7 +460,7 @@ public class DictionaryTest : TestBase
         var value = Utils.NewGuidByteArray();
         var content = new Dictionary<byte[], byte[]>() { { field, value } };
 
-        await client.DictionarySetFieldsAsync(cacheName, dictionaryName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(5)));
+        await client.DictionarySetFieldsAsync(cacheName, dictionaryName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(4)));
         await Task.Delay(100);
 
         await client.DictionarySetFieldsAsync(cacheName, dictionaryName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(10)).WithNoRefreshTtlOnUpdates());
@@ -538,7 +538,7 @@ public class DictionaryTest : TestBase
         var value = Utils.NewGuidString();
         var content = new Dictionary<string, string>() { { field, value } };
 
-        await client.DictionarySetFieldsAsync(cacheName, dictionaryName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(5)));
+        await client.DictionarySetFieldsAsync(cacheName, dictionaryName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(4)));
         await Task.Delay(100);
 
         await client.DictionarySetFieldsAsync(cacheName, dictionaryName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(10)).WithNoRefreshTtlOnUpdates());
@@ -616,7 +616,7 @@ public class DictionaryTest : TestBase
         var value = Utils.NewGuidByteArray();
         var content = new Dictionary<string, byte[]>() { { field, value } };
 
-        await client.DictionarySetFieldsAsync(cacheName, dictionaryName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(5)).WithNoRefreshTtlOnUpdates());
+        await client.DictionarySetFieldsAsync(cacheName, dictionaryName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(4)).WithNoRefreshTtlOnUpdates());
         await Task.Delay(100);
 
         await client.DictionarySetFieldsAsync(cacheName, dictionaryName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(10)).WithNoRefreshTtlOnUpdates());

--- a/tests/Integration/Momento.Sdk.Tests/DictionaryTest.cs
+++ b/tests/Integration/Momento.Sdk.Tests/DictionaryTest.cs
@@ -85,13 +85,13 @@ public class DictionaryTest : TestBase
         var field = Utils.NewGuidByteArray();
         var value = Utils.NewGuidByteArray();
 
-        CacheDictionarySetFieldResponse setResponse = await client.DictionarySetFieldAsync(cacheName, dictionaryName, field, value, CollectionTtl.Of(TimeSpan.FromSeconds(Utils.initialRefreshTtl)).WithNoRefreshTtlOnUpdates());
+        CacheDictionarySetFieldResponse setResponse = await client.DictionarySetFieldAsync(cacheName, dictionaryName, field, value, CollectionTtl.Of(TimeSpan.FromSeconds(Utils.InitialRefreshTtl)).WithNoRefreshTtlOnUpdates());
         Assert.True(setResponse is CacheDictionarySetFieldResponse.Success, $"Unexpected response: {setResponse}");
-        await Task.Delay(Utils.waitForItemToBeSet);
+        await Task.Delay(Utils.WaitForItemToBeSet);
 
-        setResponse = await client.DictionarySetFieldAsync(cacheName, dictionaryName, field, value, CollectionTtl.Of(TimeSpan.FromSeconds(Utils.updatedRefreshTtl)).WithNoRefreshTtlOnUpdates());
+        setResponse = await client.DictionarySetFieldAsync(cacheName, dictionaryName, field, value, CollectionTtl.Of(TimeSpan.FromSeconds(Utils.UpdatedRefreshTtl)).WithNoRefreshTtlOnUpdates());
         Assert.True(setResponse is CacheDictionarySetFieldResponse.Success, $"Unexpected response: {setResponse}");
-        await Task.Delay(Utils.waitForInitialItemToExpire);
+        await Task.Delay(Utils.WaitForInitialItemToExpire);
 
         CacheDictionaryGetFieldResponse response = await client.DictionaryGetFieldAsync(cacheName, dictionaryName, field);
         Assert.True(response is CacheDictionaryGetFieldResponse.Miss, $"Unexpected response: {response}");
@@ -106,7 +106,7 @@ public class DictionaryTest : TestBase
 
         CacheDictionarySetFieldResponse setResponse = await client.DictionarySetFieldAsync(cacheName, dictionaryName, field, value, CollectionTtl.Of(TimeSpan.FromSeconds(2)));
         Assert.True(setResponse is CacheDictionarySetFieldResponse.Success, $"Unexpected response: {setResponse}");
-        setResponse = await client.DictionarySetFieldAsync(cacheName, dictionaryName, field, value, CollectionTtl.Of(TimeSpan.FromSeconds(Utils.updatedRefreshTtl)));
+        setResponse = await client.DictionarySetFieldAsync(cacheName, dictionaryName, field, value, CollectionTtl.Of(TimeSpan.FromSeconds(Utils.UpdatedRefreshTtl)));
         Assert.True(setResponse is CacheDictionarySetFieldResponse.Success, $"Unexpected response: {setResponse}");
         await Task.Delay(2000);
 
@@ -162,7 +162,7 @@ public class DictionaryTest : TestBase
 
         CacheDictionaryIncrementResponse resp = await client.DictionaryIncrementAsync(cacheName, dictionaryName, field, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(2)));
         Assert.True(resp is CacheDictionaryIncrementResponse.Success, $"Unexpected response: {resp}");
-        resp = await client.DictionaryIncrementAsync(cacheName, dictionaryName, field, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.updatedRefreshTtl)));
+        resp = await client.DictionaryIncrementAsync(cacheName, dictionaryName, field, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.UpdatedRefreshTtl)));
         Assert.True(resp is CacheDictionaryIncrementResponse.Success, $"Unexpected response: {resp}");
         await Task.Delay(2000);
 
@@ -177,13 +177,13 @@ public class DictionaryTest : TestBase
         var dictionaryName = Utils.NewGuidString();
         var field = Utils.NewGuidString();
 
-        CacheDictionaryIncrementResponse resp = await client.DictionaryIncrementAsync(cacheName, dictionaryName, field, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.initialRefreshTtl)));
+        CacheDictionaryIncrementResponse resp = await client.DictionaryIncrementAsync(cacheName, dictionaryName, field, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.InitialRefreshTtl)));
         Assert.True(resp is CacheDictionaryIncrementResponse.Success, $"Unexpected response: {resp}");
-        await Task.Delay(Utils.waitForItemToBeSet);
+        await Task.Delay(Utils.WaitForItemToBeSet);
 
-        resp = await client.DictionaryIncrementAsync(cacheName, dictionaryName, field, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.updatedRefreshTtl)).WithNoRefreshTtlOnUpdates());
+        resp = await client.DictionaryIncrementAsync(cacheName, dictionaryName, field, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.UpdatedRefreshTtl)).WithNoRefreshTtlOnUpdates());
         Assert.True(resp is CacheDictionaryIncrementResponse.Success, $"Unexpected response: {resp}");
-        await Task.Delay(Utils.waitForInitialItemToExpire);
+        await Task.Delay(Utils.WaitForInitialItemToExpire);
 
         CacheDictionaryGetFieldResponse response = await client.DictionaryGetFieldAsync(cacheName, dictionaryName, field);
         Assert.True(response is CacheDictionaryGetFieldResponse.Miss, $"Unexpected response: {response}");
@@ -316,13 +316,13 @@ public class DictionaryTest : TestBase
         var field = Utils.NewGuidString();
         var value = Utils.NewGuidString();
 
-        CacheDictionarySetFieldResponse setResponse = await client.DictionarySetFieldAsync(cacheName, dictionaryName, field, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.initialRefreshTtl)));
+        CacheDictionarySetFieldResponse setResponse = await client.DictionarySetFieldAsync(cacheName, dictionaryName, field, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.InitialRefreshTtl)));
         Assert.True(setResponse is CacheDictionarySetFieldResponse.Success, $"Unexpected response: {setResponse}");
-        await Task.Delay(Utils.waitForItemToBeSet);
+        await Task.Delay(Utils.WaitForItemToBeSet);
 
-        setResponse = await client.DictionarySetFieldAsync(cacheName, dictionaryName, field, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.updatedRefreshTtl)).WithNoRefreshTtlOnUpdates());
+        setResponse = await client.DictionarySetFieldAsync(cacheName, dictionaryName, field, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.UpdatedRefreshTtl)).WithNoRefreshTtlOnUpdates());
         Assert.True(setResponse is CacheDictionarySetFieldResponse.Success, $"Unexpected response: {setResponse}");
-        await Task.Delay(Utils.waitForInitialItemToExpire);
+        await Task.Delay(Utils.WaitForInitialItemToExpire);
 
         CacheDictionaryGetFieldResponse response = await client.DictionaryGetFieldAsync(cacheName, dictionaryName, field);
         Assert.True(response is CacheDictionaryGetFieldResponse.Miss, $"Unexpected response: {response}");
@@ -337,7 +337,7 @@ public class DictionaryTest : TestBase
 
         CacheDictionarySetFieldResponse setResponse = await client.DictionarySetFieldAsync(cacheName, dictionaryName, field, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(2)));
         Assert.True(setResponse is CacheDictionarySetFieldResponse.Success, $"Unexpected response: {setResponse}");
-        setResponse = await client.DictionarySetFieldAsync(cacheName, dictionaryName, field, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.updatedRefreshTtl)));
+        setResponse = await client.DictionarySetFieldAsync(cacheName, dictionaryName, field, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.UpdatedRefreshTtl)));
         Assert.True(setResponse is CacheDictionarySetFieldResponse.Success, $"Unexpected response: {setResponse}");
         await Task.Delay(2000);
 
@@ -379,13 +379,13 @@ public class DictionaryTest : TestBase
         var field = Utils.NewGuidString();
         var value = Utils.NewGuidByteArray();
 
-        CacheDictionarySetFieldResponse setResponse = await client.DictionarySetFieldAsync(cacheName, dictionaryName, field, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.initialRefreshTtl)));
+        CacheDictionarySetFieldResponse setResponse = await client.DictionarySetFieldAsync(cacheName, dictionaryName, field, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.InitialRefreshTtl)));
         Assert.True(setResponse is CacheDictionarySetFieldResponse.Success, $"Unexpected response: {setResponse}");
-        await Task.Delay(Utils.waitForItemToBeSet);
+        await Task.Delay(Utils.WaitForItemToBeSet);
 
-        setResponse = await client.DictionarySetFieldAsync(cacheName, dictionaryName, field, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.updatedRefreshTtl)).WithNoRefreshTtlOnUpdates());
+        setResponse = await client.DictionarySetFieldAsync(cacheName, dictionaryName, field, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.UpdatedRefreshTtl)).WithNoRefreshTtlOnUpdates());
         Assert.True(setResponse is CacheDictionarySetFieldResponse.Success, $"Unexpected response: {setResponse}");
-        await Task.Delay(Utils.waitForInitialItemToExpire);
+        await Task.Delay(Utils.WaitForInitialItemToExpire);
 
         CacheDictionaryGetFieldResponse response = await client.DictionaryGetFieldAsync(cacheName, dictionaryName, field);
         Assert.True(response is CacheDictionaryGetFieldResponse.Miss, $"Unexpected response: {response}");
@@ -400,7 +400,7 @@ public class DictionaryTest : TestBase
 
         CacheDictionarySetFieldResponse setResponse = await client.DictionarySetFieldAsync(cacheName, dictionaryName, field, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(2)));
         Assert.True(setResponse is CacheDictionarySetFieldResponse.Success, $"Unexpected response: {setResponse}");
-        setResponse = await client.DictionarySetFieldAsync(cacheName, dictionaryName, field, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.updatedRefreshTtl)));
+        setResponse = await client.DictionarySetFieldAsync(cacheName, dictionaryName, field, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.UpdatedRefreshTtl)));
         Assert.True(setResponse is CacheDictionarySetFieldResponse.Success, $"Unexpected response: {setResponse}");
         await Task.Delay(2000);
 
@@ -441,7 +441,7 @@ public class DictionaryTest : TestBase
 
         var items = new Dictionary<byte[], byte[]>() { { field1, value1 }, { field2, value2 } };
 
-        await client.DictionarySetFieldsAsync(cacheName, dictionaryName, items, CollectionTtl.Of(TimeSpan.FromSeconds(Utils.updatedRefreshTtl)));
+        await client.DictionarySetFieldsAsync(cacheName, dictionaryName, items, CollectionTtl.Of(TimeSpan.FromSeconds(Utils.UpdatedRefreshTtl)));
 
         CacheDictionaryGetFieldResponse getResponse = await client.DictionaryGetFieldAsync(cacheName, dictionaryName, field1);
         Assert.True(getResponse is CacheDictionaryGetFieldResponse.Hit, $"Unexpected response: {getResponse}");
@@ -460,11 +460,11 @@ public class DictionaryTest : TestBase
         var value = Utils.NewGuidByteArray();
         var content = new Dictionary<byte[], byte[]>() { { field, value } };
 
-        await client.DictionarySetFieldsAsync(cacheName, dictionaryName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.initialRefreshTtl)));
-        await Task.Delay(Utils.waitForItemToBeSet);
+        await client.DictionarySetFieldsAsync(cacheName, dictionaryName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.InitialRefreshTtl)));
+        await Task.Delay(Utils.WaitForItemToBeSet);
 
-        await client.DictionarySetFieldsAsync(cacheName, dictionaryName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.updatedRefreshTtl)).WithNoRefreshTtlOnUpdates());
-        await Task.Delay(Utils.waitForInitialItemToExpire);
+        await client.DictionarySetFieldsAsync(cacheName, dictionaryName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.UpdatedRefreshTtl)).WithNoRefreshTtlOnUpdates());
+        await Task.Delay(Utils.WaitForInitialItemToExpire);
 
         CacheDictionaryGetFieldResponse response = await client.DictionaryGetFieldAsync(cacheName, dictionaryName, field);
         Assert.True(response is CacheDictionaryGetFieldResponse.Miss, $"Unexpected response: {response}");
@@ -479,7 +479,7 @@ public class DictionaryTest : TestBase
         var content = new Dictionary<byte[], byte[]>() { { field, value } };
 
         await client.DictionarySetFieldsAsync(cacheName, dictionaryName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(2)));
-        await client.DictionarySetFieldsAsync(cacheName, dictionaryName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.updatedRefreshTtl)));
+        await client.DictionarySetFieldsAsync(cacheName, dictionaryName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.UpdatedRefreshTtl)));
         await Task.Delay(2000);
 
         CacheDictionaryGetFieldResponse response = await client.DictionaryGetFieldAsync(cacheName, dictionaryName, field);
@@ -538,11 +538,11 @@ public class DictionaryTest : TestBase
         var value = Utils.NewGuidString();
         var content = new Dictionary<string, string>() { { field, value } };
 
-        await client.DictionarySetFieldsAsync(cacheName, dictionaryName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.initialRefreshTtl)));
-        await Task.Delay(Utils.waitForItemToBeSet);
+        await client.DictionarySetFieldsAsync(cacheName, dictionaryName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.InitialRefreshTtl)));
+        await Task.Delay(Utils.WaitForItemToBeSet);
 
-        await client.DictionarySetFieldsAsync(cacheName, dictionaryName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.updatedRefreshTtl)).WithNoRefreshTtlOnUpdates());
-        await Task.Delay(Utils.waitForInitialItemToExpire);
+        await client.DictionarySetFieldsAsync(cacheName, dictionaryName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.UpdatedRefreshTtl)).WithNoRefreshTtlOnUpdates());
+        await Task.Delay(Utils.WaitForInitialItemToExpire);
 
         CacheDictionaryGetFieldResponse response = await client.DictionaryGetFieldAsync(cacheName, dictionaryName, field);
         Assert.True(response is CacheDictionaryGetFieldResponse.Miss, $"Unexpected response: {response}");
@@ -557,7 +557,7 @@ public class DictionaryTest : TestBase
         var content = new Dictionary<string, string>() { { field, value } };
 
         await client.DictionarySetFieldsAsync(cacheName, dictionaryName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(2)));
-        await client.DictionarySetFieldsAsync(cacheName, dictionaryName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.updatedRefreshTtl)));
+        await client.DictionarySetFieldsAsync(cacheName, dictionaryName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.UpdatedRefreshTtl)));
         await Task.Delay(2000);
 
         CacheDictionaryGetFieldResponse response = await client.DictionaryGetFieldAsync(cacheName, dictionaryName, field);
@@ -616,11 +616,11 @@ public class DictionaryTest : TestBase
         var value = Utils.NewGuidByteArray();
         var content = new Dictionary<string, byte[]>() { { field, value } };
 
-        await client.DictionarySetFieldsAsync(cacheName, dictionaryName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.initialRefreshTtl)).WithNoRefreshTtlOnUpdates());
-        await Task.Delay(Utils.waitForItemToBeSet);
+        await client.DictionarySetFieldsAsync(cacheName, dictionaryName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.InitialRefreshTtl)).WithNoRefreshTtlOnUpdates());
+        await Task.Delay(Utils.WaitForItemToBeSet);
 
-        await client.DictionarySetFieldsAsync(cacheName, dictionaryName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.updatedRefreshTtl)).WithNoRefreshTtlOnUpdates());
-        await Task.Delay(Utils.waitForInitialItemToExpire);
+        await client.DictionarySetFieldsAsync(cacheName, dictionaryName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.UpdatedRefreshTtl)).WithNoRefreshTtlOnUpdates());
+        await Task.Delay(Utils.WaitForInitialItemToExpire);
 
         CacheDictionaryGetFieldResponse response = await client.DictionaryGetFieldAsync(cacheName, dictionaryName, field);
         Assert.True(response is CacheDictionaryGetFieldResponse.Miss, $"Unexpected response: {response}");
@@ -635,7 +635,7 @@ public class DictionaryTest : TestBase
         var content = new Dictionary<string, byte[]>() { { field, value } };
 
         await client.DictionarySetFieldsAsync(cacheName, dictionaryName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(2)));
-        await client.DictionarySetFieldsAsync(cacheName, dictionaryName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.updatedRefreshTtl)));
+        await client.DictionarySetFieldsAsync(cacheName, dictionaryName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.UpdatedRefreshTtl)));
         await Task.Delay(2000);
 
         CacheDictionaryGetFieldResponse response = await client.DictionaryGetFieldAsync(cacheName, dictionaryName, field);

--- a/tests/Integration/Momento.Sdk.Tests/ListTest.cs
+++ b/tests/Integration/Momento.Sdk.Tests/ListTest.cs
@@ -285,11 +285,11 @@ public class ListTest : TestBase
         var listName = Utils.NewGuidString();
         byte[][] values = new byte[][] { Utils.NewGuidByteArray() };
 
-        await client.ListConcatenateFrontAsync(cacheName, listName, values, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.initialRefreshTtl)).WithNoRefreshTtlOnUpdates());
-        await Task.Delay(Utils.waitForItemToBeSet);
+        await client.ListConcatenateFrontAsync(cacheName, listName, values, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.InitialRefreshTtl)).WithNoRefreshTtlOnUpdates());
+        await Task.Delay(Utils.WaitForItemToBeSet);
 
-        await client.ListConcatenateFrontAsync(cacheName, listName, values, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.updatedRefreshTtl)).WithNoRefreshTtlOnUpdates());
-        await Task.Delay(Utils.waitForInitialItemToExpire);
+        await client.ListConcatenateFrontAsync(cacheName, listName, values, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.UpdatedRefreshTtl)).WithNoRefreshTtlOnUpdates());
+        await Task.Delay(Utils.WaitForInitialItemToExpire);
 
         CacheListFetchResponse response = await client.ListFetchAsync(cacheName, listName);
         Assert.True(response is CacheListFetchResponse.Miss, $"Unexpected response: {response}");
@@ -302,7 +302,7 @@ public class ListTest : TestBase
         byte[][] values = new byte[][] { Utils.NewGuidByteArray() };
 
         await client.ListConcatenateFrontAsync(cacheName, listName, values, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(2)).WithNoRefreshTtlOnUpdates());
-        await client.ListConcatenateFrontAsync(cacheName, listName, values, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.updatedRefreshTtl)));
+        await client.ListConcatenateFrontAsync(cacheName, listName, values, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.UpdatedRefreshTtl)));
         await Task.Delay(2000);
 
         CacheListFetchResponse response = await client.ListFetchAsync(cacheName, listName);
@@ -365,11 +365,11 @@ public class ListTest : TestBase
         var listName = Utils.NewGuidString();
         string[] values = new string[] { Utils.NewGuidString() };
 
-        await client.ListConcatenateFrontAsync(cacheName, listName, values, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.initialRefreshTtl)).WithNoRefreshTtlOnUpdates());
-        await Task.Delay(Utils.waitForItemToBeSet);
+        await client.ListConcatenateFrontAsync(cacheName, listName, values, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.InitialRefreshTtl)).WithNoRefreshTtlOnUpdates());
+        await Task.Delay(Utils.WaitForItemToBeSet);
 
-        await client.ListConcatenateFrontAsync(cacheName, listName, values, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.updatedRefreshTtl)).WithNoRefreshTtlOnUpdates());
-        await Task.Delay(Utils.waitForInitialItemToExpire);
+        await client.ListConcatenateFrontAsync(cacheName, listName, values, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.UpdatedRefreshTtl)).WithNoRefreshTtlOnUpdates());
+        await Task.Delay(Utils.WaitForInitialItemToExpire);
 
         CacheListFetchResponse response = await client.ListFetchAsync(cacheName, listName);
         Assert.True(response is CacheListFetchResponse.Miss, $"Unexpected response: {response}");
@@ -382,7 +382,7 @@ public class ListTest : TestBase
         string[] values = new string[] { Utils.NewGuidString() };
 
         await client.ListConcatenateFrontAsync(cacheName, listName, values, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(2)).WithNoRefreshTtlOnUpdates());
-        await client.ListConcatenateFrontAsync(cacheName, listName, values, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.updatedRefreshTtl)).WithRefreshTtlOnUpdates());
+        await client.ListConcatenateFrontAsync(cacheName, listName, values, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.UpdatedRefreshTtl)).WithRefreshTtlOnUpdates());
         await Task.Delay(2000);
 
         CacheListFetchResponse response = await client.ListFetchAsync(cacheName, listName);
@@ -461,10 +461,10 @@ public class ListTest : TestBase
         var listName = Utils.NewGuidString();
         byte[][] values = new byte[][] { Utils.NewGuidByteArray() };
 
-        await client.ListConcatenateBackAsync(cacheName, listName, values, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.initialRefreshTtl)).WithNoRefreshTtlOnUpdates());
-        await Task.Delay(Utils.waitForItemToBeSet);
-        await client.ListConcatenateBackAsync(cacheName, listName, values, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.updatedRefreshTtl)).WithNoRefreshTtlOnUpdates());
-        await Task.Delay(Utils.waitForInitialItemToExpire);
+        await client.ListConcatenateBackAsync(cacheName, listName, values, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.InitialRefreshTtl)).WithNoRefreshTtlOnUpdates());
+        await Task.Delay(Utils.WaitForItemToBeSet);
+        await client.ListConcatenateBackAsync(cacheName, listName, values, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.UpdatedRefreshTtl)).WithNoRefreshTtlOnUpdates());
+        await Task.Delay(Utils.WaitForInitialItemToExpire);
 
         CacheListFetchResponse response = await client.ListFetchAsync(cacheName, listName);
         Assert.True(response is CacheListFetchResponse.Miss, $"Unexpected response: {response}");
@@ -476,8 +476,8 @@ public class ListTest : TestBase
         var listName = Utils.NewGuidString();
         byte[][] values = new byte[][] { Utils.NewGuidByteArray() };
 
-        await client.ListConcatenateBackAsync(cacheName, listName, values, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.initialRefreshTtl)).WithNoRefreshTtlOnUpdates());
-        await client.ListConcatenateBackAsync(cacheName, listName, values, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.updatedRefreshTtl)).WithRefreshTtlOnUpdates());
+        await client.ListConcatenateBackAsync(cacheName, listName, values, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.InitialRefreshTtl)).WithNoRefreshTtlOnUpdates());
+        await client.ListConcatenateBackAsync(cacheName, listName, values, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.UpdatedRefreshTtl)).WithRefreshTtlOnUpdates());
         await Task.Delay(2000);
 
         CacheListFetchResponse response = await client.ListFetchAsync(cacheName, listName);
@@ -540,11 +540,11 @@ public class ListTest : TestBase
         var listName = Utils.NewGuidString();
         string[] values = new string[] { Utils.NewGuidString() };
 
-        await client.ListConcatenateBackAsync(cacheName, listName, values, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.initialRefreshTtl)).WithNoRefreshTtlOnUpdates());
-        await Task.Delay(Utils.waitForItemToBeSet);
+        await client.ListConcatenateBackAsync(cacheName, listName, values, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.InitialRefreshTtl)).WithNoRefreshTtlOnUpdates());
+        await Task.Delay(Utils.WaitForItemToBeSet);
 
-        await client.ListConcatenateBackAsync(cacheName, listName, values, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.updatedRefreshTtl)).WithNoRefreshTtlOnUpdates());
-        await Task.Delay(Utils.waitForInitialItemToExpire);
+        await client.ListConcatenateBackAsync(cacheName, listName, values, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.UpdatedRefreshTtl)).WithNoRefreshTtlOnUpdates());
+        await Task.Delay(Utils.WaitForInitialItemToExpire);
 
         CacheListFetchResponse response = await client.ListFetchAsync(cacheName, listName);
         Assert.True(response is CacheListFetchResponse.Miss, $"Unexpected response: {response}");
@@ -556,8 +556,8 @@ public class ListTest : TestBase
         var listName = Utils.NewGuidString();
         string[] values = new string[] { Utils.NewGuidString() };
 
-        await client.ListConcatenateBackAsync(cacheName, listName, values, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.initialRefreshTtl)).WithNoRefreshTtlOnUpdates());
-        await client.ListConcatenateBackAsync(cacheName, listName, values, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.updatedRefreshTtl)).WithNoRefreshTtlOnUpdates());
+        await client.ListConcatenateBackAsync(cacheName, listName, values, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.InitialRefreshTtl)).WithNoRefreshTtlOnUpdates());
+        await client.ListConcatenateBackAsync(cacheName, listName, values, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.UpdatedRefreshTtl)).WithNoRefreshTtlOnUpdates());
         await Task.Delay(2000);
 
         CacheListFetchResponse response = await client.ListFetchAsync(cacheName, listName);
@@ -629,11 +629,11 @@ public class ListTest : TestBase
         var listName = Utils.NewGuidString();
         var value = Utils.NewGuidByteArray();
 
-        await client.ListPushFrontAsync(cacheName, listName, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.initialRefreshTtl)).WithNoRefreshTtlOnUpdates());
-        await Task.Delay(Utils.waitForItemToBeSet);
+        await client.ListPushFrontAsync(cacheName, listName, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.InitialRefreshTtl)).WithNoRefreshTtlOnUpdates());
+        await Task.Delay(Utils.WaitForItemToBeSet);
 
-        await client.ListPushFrontAsync(cacheName, listName, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.updatedRefreshTtl)).WithNoRefreshTtlOnUpdates());
-        await Task.Delay(Utils.waitForInitialItemToExpire);
+        await client.ListPushFrontAsync(cacheName, listName, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.UpdatedRefreshTtl)).WithNoRefreshTtlOnUpdates());
+        await Task.Delay(Utils.WaitForInitialItemToExpire);
 
         CacheListFetchResponse response = await client.ListFetchAsync(cacheName, listName);
         Assert.True(response is CacheListFetchResponse.Miss, $"Unexpected response: {response}");
@@ -646,7 +646,7 @@ public class ListTest : TestBase
         var value = Utils.NewGuidByteArray();
 
         await client.ListPushFrontAsync(cacheName, listName, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(2)).WithNoRefreshTtlOnUpdates());
-        await client.ListPushFrontAsync(cacheName, listName, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.updatedRefreshTtl)));
+        await client.ListPushFrontAsync(cacheName, listName, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.UpdatedRefreshTtl)));
         await Task.Delay(2000);
 
         CacheListFetchResponse response = await client.ListFetchAsync(cacheName, listName);
@@ -716,11 +716,11 @@ public class ListTest : TestBase
         var listName = Utils.NewGuidString();
         var value = Utils.NewGuidString();
 
-        await client.ListPushFrontAsync(cacheName, listName, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.initialRefreshTtl)).WithNoRefreshTtlOnUpdates());
-        await Task.Delay(Utils.waitForItemToBeSet);
+        await client.ListPushFrontAsync(cacheName, listName, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.InitialRefreshTtl)).WithNoRefreshTtlOnUpdates());
+        await Task.Delay(Utils.WaitForItemToBeSet);
 
-        await client.ListPushFrontAsync(cacheName, listName, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.updatedRefreshTtl)).WithNoRefreshTtlOnUpdates());
-        await Task.Delay(Utils.waitForInitialItemToExpire);
+        await client.ListPushFrontAsync(cacheName, listName, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.UpdatedRefreshTtl)).WithNoRefreshTtlOnUpdates());
+        await Task.Delay(Utils.WaitForInitialItemToExpire);
 
         CacheListFetchResponse response = await client.ListFetchAsync(cacheName, listName);
         Assert.True(response is CacheListFetchResponse.Miss, $"Unexpected response: {response}");
@@ -733,7 +733,7 @@ public class ListTest : TestBase
         var value = Utils.NewGuidString();
 
         await client.ListPushFrontAsync(cacheName, listName, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(2)).WithNoRefreshTtlOnUpdates());
-        await client.ListPushFrontAsync(cacheName, listName, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.updatedRefreshTtl)));
+        await client.ListPushFrontAsync(cacheName, listName, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.UpdatedRefreshTtl)));
         await Task.Delay(2000);
 
         CacheListFetchResponse response = await client.ListFetchAsync(cacheName, listName);
@@ -802,11 +802,11 @@ public class ListTest : TestBase
         var listName = Utils.NewGuidString();
         var value = Utils.NewGuidByteArray();
 
-        await client.ListPushBackAsync(cacheName, listName, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.initialRefreshTtl)).WithNoRefreshTtlOnUpdates());
-        await Task.Delay(Utils.waitForItemToBeSet);
+        await client.ListPushBackAsync(cacheName, listName, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.InitialRefreshTtl)).WithNoRefreshTtlOnUpdates());
+        await Task.Delay(Utils.WaitForItemToBeSet);
 
-        await client.ListPushBackAsync(cacheName, listName, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.updatedRefreshTtl)).WithNoRefreshTtlOnUpdates());
-        await Task.Delay(Utils.waitForInitialItemToExpire);
+        await client.ListPushBackAsync(cacheName, listName, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.UpdatedRefreshTtl)).WithNoRefreshTtlOnUpdates());
+        await Task.Delay(Utils.WaitForInitialItemToExpire);
 
         CacheListFetchResponse response = await client.ListFetchAsync(cacheName, listName);
         Assert.True(response is CacheListFetchResponse.Miss, $"Unexpected response: {response}");
@@ -819,7 +819,7 @@ public class ListTest : TestBase
         var value = Utils.NewGuidByteArray();
 
         await client.ListPushBackAsync(cacheName, listName, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(2)).WithNoRefreshTtlOnUpdates());
-        await client.ListPushBackAsync(cacheName, listName, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.updatedRefreshTtl)));
+        await client.ListPushBackAsync(cacheName, listName, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.UpdatedRefreshTtl)));
         await Task.Delay(2000);
 
         CacheListFetchResponse response = await client.ListFetchAsync(cacheName, listName);
@@ -961,10 +961,10 @@ public class ListTest : TestBase
         var value = Utils.NewGuidString();
 
         await client.ListPushBackAsync(cacheName, listName, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(2)).WithNoRefreshTtlOnUpdates());
-        await Task.Delay(Utils.waitForItemToBeSet);
+        await Task.Delay(Utils.WaitForItemToBeSet);
 
-        await client.ListPushBackAsync(cacheName, listName, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.updatedRefreshTtl)).WithNoRefreshTtlOnUpdates());
-        await Task.Delay(Utils.waitForInitialItemToExpire);
+        await client.ListPushBackAsync(cacheName, listName, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.UpdatedRefreshTtl)).WithNoRefreshTtlOnUpdates());
+        await Task.Delay(Utils.WaitForInitialItemToExpire);
 
         CacheListFetchResponse response = await client.ListFetchAsync(cacheName, listName);
         Assert.True(response is CacheListFetchResponse.Miss, $"Unexpected response: {response}");
@@ -977,7 +977,7 @@ public class ListTest : TestBase
         var value = Utils.NewGuidString();
 
         await client.ListPushBackAsync(cacheName, listName, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(2)));
-        await client.ListPushBackAsync(cacheName, listName, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.updatedRefreshTtl)));
+        await client.ListPushBackAsync(cacheName, listName, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.UpdatedRefreshTtl)));
         await Task.Delay(2000);
 
         CacheListFetchResponse response = await client.ListFetchAsync(cacheName, listName);

--- a/tests/Integration/Momento.Sdk.Tests/ListTest.cs
+++ b/tests/Integration/Momento.Sdk.Tests/ListTest.cs
@@ -285,11 +285,11 @@ public class ListTest : TestBase
         var listName = Utils.NewGuidString();
         byte[][] values = new byte[][] { Utils.NewGuidByteArray() };
 
-        await client.ListConcatenateFrontAsync(cacheName, listName, values, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(4)).WithNoRefreshTtlOnUpdates());
-        await Task.Delay(100);
+        await client.ListConcatenateFrontAsync(cacheName, listName, values, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.initialRefreshTtl)).WithNoRefreshTtlOnUpdates());
+        await Task.Delay(Utils.waitForItemToBeSet);
 
-        await client.ListConcatenateFrontAsync(cacheName, listName, values, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(10)).WithNoRefreshTtlOnUpdates());
-        await Task.Delay(4900);
+        await client.ListConcatenateFrontAsync(cacheName, listName, values, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.updatedRefreshTtl)).WithNoRefreshTtlOnUpdates());
+        await Task.Delay(Utils.waitForInitialItemToExpire);
 
         CacheListFetchResponse response = await client.ListFetchAsync(cacheName, listName);
         Assert.True(response is CacheListFetchResponse.Miss, $"Unexpected response: {response}");
@@ -302,7 +302,7 @@ public class ListTest : TestBase
         byte[][] values = new byte[][] { Utils.NewGuidByteArray() };
 
         await client.ListConcatenateFrontAsync(cacheName, listName, values, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(2)).WithNoRefreshTtlOnUpdates());
-        await client.ListConcatenateFrontAsync(cacheName, listName, values, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(10)));
+        await client.ListConcatenateFrontAsync(cacheName, listName, values, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.updatedRefreshTtl)));
         await Task.Delay(2000);
 
         CacheListFetchResponse response = await client.ListFetchAsync(cacheName, listName);
@@ -365,11 +365,11 @@ public class ListTest : TestBase
         var listName = Utils.NewGuidString();
         string[] values = new string[] { Utils.NewGuidString() };
 
-        await client.ListConcatenateFrontAsync(cacheName, listName, values, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(4)).WithNoRefreshTtlOnUpdates());
-        await Task.Delay(100);
+        await client.ListConcatenateFrontAsync(cacheName, listName, values, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.initialRefreshTtl)).WithNoRefreshTtlOnUpdates());
+        await Task.Delay(Utils.waitForItemToBeSet);
 
-        await client.ListConcatenateFrontAsync(cacheName, listName, values, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(10)).WithNoRefreshTtlOnUpdates());
-        await Task.Delay(4900);
+        await client.ListConcatenateFrontAsync(cacheName, listName, values, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.updatedRefreshTtl)).WithNoRefreshTtlOnUpdates());
+        await Task.Delay(Utils.waitForInitialItemToExpire);
 
         CacheListFetchResponse response = await client.ListFetchAsync(cacheName, listName);
         Assert.True(response is CacheListFetchResponse.Miss, $"Unexpected response: {response}");
@@ -382,7 +382,7 @@ public class ListTest : TestBase
         string[] values = new string[] { Utils.NewGuidString() };
 
         await client.ListConcatenateFrontAsync(cacheName, listName, values, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(2)).WithNoRefreshTtlOnUpdates());
-        await client.ListConcatenateFrontAsync(cacheName, listName, values, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(10)).WithRefreshTtlOnUpdates());
+        await client.ListConcatenateFrontAsync(cacheName, listName, values, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.updatedRefreshTtl)).WithRefreshTtlOnUpdates());
         await Task.Delay(2000);
 
         CacheListFetchResponse response = await client.ListFetchAsync(cacheName, listName);
@@ -461,10 +461,10 @@ public class ListTest : TestBase
         var listName = Utils.NewGuidString();
         byte[][] values = new byte[][] { Utils.NewGuidByteArray() };
 
-        await client.ListConcatenateBackAsync(cacheName, listName, values, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(4)).WithNoRefreshTtlOnUpdates());
-        await Task.Delay(100);
-        await client.ListConcatenateBackAsync(cacheName, listName, values, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(10)).WithNoRefreshTtlOnUpdates());
-        await Task.Delay(4900);
+        await client.ListConcatenateBackAsync(cacheName, listName, values, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.initialRefreshTtl)).WithNoRefreshTtlOnUpdates());
+        await Task.Delay(Utils.waitForItemToBeSet);
+        await client.ListConcatenateBackAsync(cacheName, listName, values, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.updatedRefreshTtl)).WithNoRefreshTtlOnUpdates());
+        await Task.Delay(Utils.waitForInitialItemToExpire);
 
         CacheListFetchResponse response = await client.ListFetchAsync(cacheName, listName);
         Assert.True(response is CacheListFetchResponse.Miss, $"Unexpected response: {response}");
@@ -476,8 +476,8 @@ public class ListTest : TestBase
         var listName = Utils.NewGuidString();
         byte[][] values = new byte[][] { Utils.NewGuidByteArray() };
 
-        await client.ListConcatenateBackAsync(cacheName, listName, values, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(4)).WithNoRefreshTtlOnUpdates());
-        await client.ListConcatenateBackAsync(cacheName, listName, values, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(10)).WithRefreshTtlOnUpdates());
+        await client.ListConcatenateBackAsync(cacheName, listName, values, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.initialRefreshTtl)).WithNoRefreshTtlOnUpdates());
+        await client.ListConcatenateBackAsync(cacheName, listName, values, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.updatedRefreshTtl)).WithRefreshTtlOnUpdates());
         await Task.Delay(2000);
 
         CacheListFetchResponse response = await client.ListFetchAsync(cacheName, listName);
@@ -540,11 +540,11 @@ public class ListTest : TestBase
         var listName = Utils.NewGuidString();
         string[] values = new string[] { Utils.NewGuidString() };
 
-        await client.ListConcatenateBackAsync(cacheName, listName, values, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(4)).WithNoRefreshTtlOnUpdates());
-        await Task.Delay(100);
+        await client.ListConcatenateBackAsync(cacheName, listName, values, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.initialRefreshTtl)).WithNoRefreshTtlOnUpdates());
+        await Task.Delay(Utils.waitForItemToBeSet);
 
-        await client.ListConcatenateBackAsync(cacheName, listName, values, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(10)).WithNoRefreshTtlOnUpdates());
-        await Task.Delay(4900);
+        await client.ListConcatenateBackAsync(cacheName, listName, values, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.updatedRefreshTtl)).WithNoRefreshTtlOnUpdates());
+        await Task.Delay(Utils.waitForInitialItemToExpire);
 
         CacheListFetchResponse response = await client.ListFetchAsync(cacheName, listName);
         Assert.True(response is CacheListFetchResponse.Miss, $"Unexpected response: {response}");
@@ -556,8 +556,8 @@ public class ListTest : TestBase
         var listName = Utils.NewGuidString();
         string[] values = new string[] { Utils.NewGuidString() };
 
-        await client.ListConcatenateBackAsync(cacheName, listName, values, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(4)).WithNoRefreshTtlOnUpdates());
-        await client.ListConcatenateBackAsync(cacheName, listName, values, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(10)).WithNoRefreshTtlOnUpdates());
+        await client.ListConcatenateBackAsync(cacheName, listName, values, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.initialRefreshTtl)).WithNoRefreshTtlOnUpdates());
+        await client.ListConcatenateBackAsync(cacheName, listName, values, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.updatedRefreshTtl)).WithNoRefreshTtlOnUpdates());
         await Task.Delay(2000);
 
         CacheListFetchResponse response = await client.ListFetchAsync(cacheName, listName);
@@ -629,11 +629,11 @@ public class ListTest : TestBase
         var listName = Utils.NewGuidString();
         var value = Utils.NewGuidByteArray();
 
-        await client.ListPushFrontAsync(cacheName, listName, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(4)).WithNoRefreshTtlOnUpdates());
-        await Task.Delay(100);
+        await client.ListPushFrontAsync(cacheName, listName, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.initialRefreshTtl)).WithNoRefreshTtlOnUpdates());
+        await Task.Delay(Utils.waitForItemToBeSet);
 
-        await client.ListPushFrontAsync(cacheName, listName, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(10)).WithNoRefreshTtlOnUpdates());
-        await Task.Delay(4900);
+        await client.ListPushFrontAsync(cacheName, listName, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.updatedRefreshTtl)).WithNoRefreshTtlOnUpdates());
+        await Task.Delay(Utils.waitForInitialItemToExpire);
 
         CacheListFetchResponse response = await client.ListFetchAsync(cacheName, listName);
         Assert.True(response is CacheListFetchResponse.Miss, $"Unexpected response: {response}");
@@ -646,7 +646,7 @@ public class ListTest : TestBase
         var value = Utils.NewGuidByteArray();
 
         await client.ListPushFrontAsync(cacheName, listName, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(2)).WithNoRefreshTtlOnUpdates());
-        await client.ListPushFrontAsync(cacheName, listName, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(10)));
+        await client.ListPushFrontAsync(cacheName, listName, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.updatedRefreshTtl)));
         await Task.Delay(2000);
 
         CacheListFetchResponse response = await client.ListFetchAsync(cacheName, listName);
@@ -716,11 +716,11 @@ public class ListTest : TestBase
         var listName = Utils.NewGuidString();
         var value = Utils.NewGuidString();
 
-        await client.ListPushFrontAsync(cacheName, listName, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(4)).WithNoRefreshTtlOnUpdates());
-        await Task.Delay(100);
+        await client.ListPushFrontAsync(cacheName, listName, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.initialRefreshTtl)).WithNoRefreshTtlOnUpdates());
+        await Task.Delay(Utils.waitForItemToBeSet);
 
-        await client.ListPushFrontAsync(cacheName, listName, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(10)).WithNoRefreshTtlOnUpdates());
-        await Task.Delay(4900);
+        await client.ListPushFrontAsync(cacheName, listName, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.updatedRefreshTtl)).WithNoRefreshTtlOnUpdates());
+        await Task.Delay(Utils.waitForInitialItemToExpire);
 
         CacheListFetchResponse response = await client.ListFetchAsync(cacheName, listName);
         Assert.True(response is CacheListFetchResponse.Miss, $"Unexpected response: {response}");
@@ -733,7 +733,7 @@ public class ListTest : TestBase
         var value = Utils.NewGuidString();
 
         await client.ListPushFrontAsync(cacheName, listName, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(2)).WithNoRefreshTtlOnUpdates());
-        await client.ListPushFrontAsync(cacheName, listName, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(10)));
+        await client.ListPushFrontAsync(cacheName, listName, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.updatedRefreshTtl)));
         await Task.Delay(2000);
 
         CacheListFetchResponse response = await client.ListFetchAsync(cacheName, listName);
@@ -802,11 +802,11 @@ public class ListTest : TestBase
         var listName = Utils.NewGuidString();
         var value = Utils.NewGuidByteArray();
 
-        await client.ListPushBackAsync(cacheName, listName, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(4)).WithNoRefreshTtlOnUpdates());
-        await Task.Delay(100);
+        await client.ListPushBackAsync(cacheName, listName, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.initialRefreshTtl)).WithNoRefreshTtlOnUpdates());
+        await Task.Delay(Utils.waitForItemToBeSet);
 
-        await client.ListPushBackAsync(cacheName, listName, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(10)).WithNoRefreshTtlOnUpdates());
-        await Task.Delay(4900);
+        await client.ListPushBackAsync(cacheName, listName, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.updatedRefreshTtl)).WithNoRefreshTtlOnUpdates());
+        await Task.Delay(Utils.waitForInitialItemToExpire);
 
         CacheListFetchResponse response = await client.ListFetchAsync(cacheName, listName);
         Assert.True(response is CacheListFetchResponse.Miss, $"Unexpected response: {response}");
@@ -819,7 +819,7 @@ public class ListTest : TestBase
         var value = Utils.NewGuidByteArray();
 
         await client.ListPushBackAsync(cacheName, listName, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(2)).WithNoRefreshTtlOnUpdates());
-        await client.ListPushBackAsync(cacheName, listName, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(10)));
+        await client.ListPushBackAsync(cacheName, listName, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.updatedRefreshTtl)));
         await Task.Delay(2000);
 
         CacheListFetchResponse response = await client.ListFetchAsync(cacheName, listName);
@@ -961,10 +961,10 @@ public class ListTest : TestBase
         var value = Utils.NewGuidString();
 
         await client.ListPushBackAsync(cacheName, listName, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(2)).WithNoRefreshTtlOnUpdates());
-        await Task.Delay(100);
+        await Task.Delay(Utils.waitForItemToBeSet);
 
-        await client.ListPushBackAsync(cacheName, listName, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(10)).WithNoRefreshTtlOnUpdates());
-        await Task.Delay(4900);
+        await client.ListPushBackAsync(cacheName, listName, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.updatedRefreshTtl)).WithNoRefreshTtlOnUpdates());
+        await Task.Delay(Utils.waitForInitialItemToExpire);
 
         CacheListFetchResponse response = await client.ListFetchAsync(cacheName, listName);
         Assert.True(response is CacheListFetchResponse.Miss, $"Unexpected response: {response}");
@@ -977,7 +977,7 @@ public class ListTest : TestBase
         var value = Utils.NewGuidString();
 
         await client.ListPushBackAsync(cacheName, listName, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(2)));
-        await client.ListPushBackAsync(cacheName, listName, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(10)));
+        await client.ListPushBackAsync(cacheName, listName, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.updatedRefreshTtl)));
         await Task.Delay(2000);
 
         CacheListFetchResponse response = await client.ListFetchAsync(cacheName, listName);

--- a/tests/Integration/Momento.Sdk.Tests/ListTest.cs
+++ b/tests/Integration/Momento.Sdk.Tests/ListTest.cs
@@ -285,10 +285,10 @@ public class ListTest : TestBase
         var listName = Utils.NewGuidString();
         byte[][] values = new byte[][] { Utils.NewGuidByteArray() };
 
-        await client.ListConcatenateFrontAsync(cacheName, listName, values, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(5)).WithNoRefreshTtlOnUpdates());
+        await client.ListConcatenateFrontAsync(cacheName, listName, values, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(4)).WithNoRefreshTtlOnUpdates());
         await Task.Delay(100);
 
-        await client.ListConcatenateFrontAsync(cacheName, listName, values, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(5)).WithNoRefreshTtlOnUpdates());
+        await client.ListConcatenateFrontAsync(cacheName, listName, values, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(10)).WithNoRefreshTtlOnUpdates());
         await Task.Delay(4900);
 
         CacheListFetchResponse response = await client.ListFetchAsync(cacheName, listName);
@@ -365,10 +365,10 @@ public class ListTest : TestBase
         var listName = Utils.NewGuidString();
         string[] values = new string[] { Utils.NewGuidString() };
 
-        await client.ListConcatenateFrontAsync(cacheName, listName, values, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(5)).WithNoRefreshTtlOnUpdates());
+        await client.ListConcatenateFrontAsync(cacheName, listName, values, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(4)).WithNoRefreshTtlOnUpdates());
         await Task.Delay(100);
 
-        await client.ListConcatenateFrontAsync(cacheName, listName, values, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(5)).WithNoRefreshTtlOnUpdates());
+        await client.ListConcatenateFrontAsync(cacheName, listName, values, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(10)).WithNoRefreshTtlOnUpdates());
         await Task.Delay(4900);
 
         CacheListFetchResponse response = await client.ListFetchAsync(cacheName, listName);
@@ -461,9 +461,9 @@ public class ListTest : TestBase
         var listName = Utils.NewGuidString();
         byte[][] values = new byte[][] { Utils.NewGuidByteArray() };
 
-        await client.ListConcatenateBackAsync(cacheName, listName, values, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(5)).WithNoRefreshTtlOnUpdates());
+        await client.ListConcatenateBackAsync(cacheName, listName, values, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(4)).WithNoRefreshTtlOnUpdates());
         await Task.Delay(100);
-        await client.ListConcatenateBackAsync(cacheName, listName, values, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(5)).WithNoRefreshTtlOnUpdates());
+        await client.ListConcatenateBackAsync(cacheName, listName, values, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(10)).WithNoRefreshTtlOnUpdates());
         await Task.Delay(4900);
 
         CacheListFetchResponse response = await client.ListFetchAsync(cacheName, listName);
@@ -476,7 +476,7 @@ public class ListTest : TestBase
         var listName = Utils.NewGuidString();
         byte[][] values = new byte[][] { Utils.NewGuidByteArray() };
 
-        await client.ListConcatenateBackAsync(cacheName, listName, values, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(5)).WithNoRefreshTtlOnUpdates());
+        await client.ListConcatenateBackAsync(cacheName, listName, values, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(4)).WithNoRefreshTtlOnUpdates());
         await client.ListConcatenateBackAsync(cacheName, listName, values, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(10)).WithRefreshTtlOnUpdates());
         await Task.Delay(2000);
 
@@ -540,10 +540,10 @@ public class ListTest : TestBase
         var listName = Utils.NewGuidString();
         string[] values = new string[] { Utils.NewGuidString() };
 
-        await client.ListConcatenateBackAsync(cacheName, listName, values, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(5)).WithNoRefreshTtlOnUpdates());
+        await client.ListConcatenateBackAsync(cacheName, listName, values, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(4)).WithNoRefreshTtlOnUpdates());
         await Task.Delay(100);
 
-        await client.ListConcatenateBackAsync(cacheName, listName, values, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(5)).WithNoRefreshTtlOnUpdates());
+        await client.ListConcatenateBackAsync(cacheName, listName, values, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(10)).WithNoRefreshTtlOnUpdates());
         await Task.Delay(4900);
 
         CacheListFetchResponse response = await client.ListFetchAsync(cacheName, listName);
@@ -556,7 +556,7 @@ public class ListTest : TestBase
         var listName = Utils.NewGuidString();
         string[] values = new string[] { Utils.NewGuidString() };
 
-        await client.ListConcatenateBackAsync(cacheName, listName, values, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(5)).WithNoRefreshTtlOnUpdates());
+        await client.ListConcatenateBackAsync(cacheName, listName, values, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(4)).WithNoRefreshTtlOnUpdates());
         await client.ListConcatenateBackAsync(cacheName, listName, values, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(10)).WithNoRefreshTtlOnUpdates());
         await Task.Delay(2000);
 
@@ -629,7 +629,7 @@ public class ListTest : TestBase
         var listName = Utils.NewGuidString();
         var value = Utils.NewGuidByteArray();
 
-        await client.ListPushFrontAsync(cacheName, listName, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(5)).WithNoRefreshTtlOnUpdates());
+        await client.ListPushFrontAsync(cacheName, listName, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(4)).WithNoRefreshTtlOnUpdates());
         await Task.Delay(100);
 
         await client.ListPushFrontAsync(cacheName, listName, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(10)).WithNoRefreshTtlOnUpdates());
@@ -716,7 +716,7 @@ public class ListTest : TestBase
         var listName = Utils.NewGuidString();
         var value = Utils.NewGuidString();
 
-        await client.ListPushFrontAsync(cacheName, listName, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(5)).WithNoRefreshTtlOnUpdates());
+        await client.ListPushFrontAsync(cacheName, listName, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(4)).WithNoRefreshTtlOnUpdates());
         await Task.Delay(100);
 
         await client.ListPushFrontAsync(cacheName, listName, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(10)).WithNoRefreshTtlOnUpdates());
@@ -802,7 +802,7 @@ public class ListTest : TestBase
         var listName = Utils.NewGuidString();
         var value = Utils.NewGuidByteArray();
 
-        await client.ListPushBackAsync(cacheName, listName, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(5)).WithNoRefreshTtlOnUpdates());
+        await client.ListPushBackAsync(cacheName, listName, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(4)).WithNoRefreshTtlOnUpdates());
         await Task.Delay(100);
 
         await client.ListPushBackAsync(cacheName, listName, value, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(10)).WithNoRefreshTtlOnUpdates());

--- a/tests/Integration/Momento.Sdk.Tests/SetTest.cs
+++ b/tests/Integration/Momento.Sdk.Tests/SetTest.cs
@@ -47,13 +47,13 @@ public class SetTest : TestBase
         var setName = Utils.NewGuidString();
         var element = Utils.NewGuidByteArray();
 
-        CacheSetAddElementResponse response = await client.SetAddElementAsync(cacheName, setName, element, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(4)).WithNoRefreshTtlOnUpdates());
+        CacheSetAddElementResponse response = await client.SetAddElementAsync(cacheName, setName, element, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.initialRefreshTtl)).WithNoRefreshTtlOnUpdates());
         Assert.True(response is CacheSetAddElementResponse.Success, $"Unexpected response: {response}");
-        await Task.Delay(100);
+        await Task.Delay(Utils.waitForItemToBeSet);
 
-        response = await client.SetAddElementAsync(cacheName, setName, element, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(10)).WithNoRefreshTtlOnUpdates());
+        response = await client.SetAddElementAsync(cacheName, setName, element, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.updatedRefreshTtl)).WithNoRefreshTtlOnUpdates());
         Assert.True(response is CacheSetAddElementResponse.Success, $"Unexpected response: {response}");
-        await Task.Delay(4900);
+        await Task.Delay(Utils.waitForInitialItemToExpire);
         CacheSetFetchResponse fetchResponse = await client.SetFetchAsync(cacheName, setName);
         Assert.True(fetchResponse is CacheSetFetchResponse.Miss, $"Unexpected response: {fetchResponse}");
     }
@@ -66,7 +66,7 @@ public class SetTest : TestBase
 
         CacheSetAddElementResponse response = await client.SetAddElementAsync(cacheName, setName, element, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(2)).WithNoRefreshTtlOnUpdates());
         Assert.True(response is CacheSetAddElementResponse.Success, $"Unexpected response: {response}");
-        await client.SetAddElementAsync(cacheName, setName, element, CollectionTtl.Of(TimeSpan.FromSeconds(10)));
+        await client.SetAddElementAsync(cacheName, setName, element, CollectionTtl.Of(TimeSpan.FromSeconds(Utils.updatedRefreshTtl)));
         await Task.Delay(2000);
 
         CacheSetFetchResponse fetchResponse = await client.SetFetchAsync(cacheName, setName);
@@ -108,13 +108,13 @@ public class SetTest : TestBase
         var setName = Utils.NewGuidString();
         var element = Utils.NewGuidString();
 
-        CacheSetAddElementResponse response = await client.SetAddElementAsync(cacheName, setName, element, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(4)).WithNoRefreshTtlOnUpdates());
+        CacheSetAddElementResponse response = await client.SetAddElementAsync(cacheName, setName, element, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.initialRefreshTtl)).WithNoRefreshTtlOnUpdates());
         Assert.True(response is CacheSetAddElementResponse.Success, $"Unexpected response: {response}");
-        await Task.Delay(100);
+        await Task.Delay(Utils.waitForItemToBeSet);
 
-        response = await client.SetAddElementAsync(cacheName, setName, element, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(10)).WithNoRefreshTtlOnUpdates());
+        response = await client.SetAddElementAsync(cacheName, setName, element, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.updatedRefreshTtl)).WithNoRefreshTtlOnUpdates());
         Assert.True(response is CacheSetAddElementResponse.Success, $"Unexpected response: {response}");
-        await Task.Delay(4900);
+        await Task.Delay(Utils.waitForInitialItemToExpire);
 
         CacheSetFetchResponse fetchResponse = await client.SetFetchAsync(cacheName, setName);
         Assert.True(fetchResponse is CacheSetFetchResponse.Miss, $"Unexpected response: {fetchResponse}");
@@ -128,7 +128,7 @@ public class SetTest : TestBase
 
         CacheSetAddElementResponse response = await client.SetAddElementAsync(cacheName, setName, element, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(2)).WithNoRefreshTtlOnUpdates());
         Assert.True(response is CacheSetAddElementResponse.Success, $"Unexpected response: {response}");
-        response = await client.SetAddElementAsync(cacheName, setName, element, CollectionTtl.Of(TimeSpan.FromSeconds(10)));
+        response = await client.SetAddElementAsync(cacheName, setName, element, CollectionTtl.Of(TimeSpan.FromSeconds(Utils.updatedRefreshTtl)));
         Assert.True(response is CacheSetAddElementResponse.Success, $"Unexpected response: {response}");
         await Task.Delay(2000);
 
@@ -185,13 +185,13 @@ public class SetTest : TestBase
         var element = Utils.NewGuidByteArray();
         var content = new List<byte[]>() { element };
 
-        CacheSetAddElementsResponse response = await client.SetAddElementsAsync(cacheName, setName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(4)).WithNoRefreshTtlOnUpdates());
+        CacheSetAddElementsResponse response = await client.SetAddElementsAsync(cacheName, setName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.initialRefreshTtl)).WithNoRefreshTtlOnUpdates());
         Assert.True(response is CacheSetAddElementsResponse.Success, $"Unexpected response: {response}");
-        await Task.Delay(100);
+        await Task.Delay(Utils.waitForItemToBeSet);
 
-        response = await client.SetAddElementsAsync(cacheName, setName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(10)).WithNoRefreshTtlOnUpdates());
+        response = await client.SetAddElementsAsync(cacheName, setName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.updatedRefreshTtl)).WithNoRefreshTtlOnUpdates());
         Assert.True(response is CacheSetAddElementsResponse.Success, $"Unexpected response: {response}");
-        await Task.Delay(4900);
+        await Task.Delay(Utils.waitForInitialItemToExpire);
 
         CacheSetFetchResponse fetchResponse = await client.SetFetchAsync(cacheName, setName);
         Assert.True(fetchResponse is CacheSetFetchResponse.Miss, $"Unexpected response: {fetchResponse}");
@@ -206,7 +206,7 @@ public class SetTest : TestBase
 
         CacheSetAddElementsResponse response = await client.SetAddElementsAsync(cacheName, setName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(2)).WithNoRefreshTtlOnUpdates());
         Assert.True(response is CacheSetAddElementsResponse.Success, $"Unexpected response: {response}");
-        await client.SetAddElementsAsync(cacheName, setName, content, CollectionTtl.Of(TimeSpan.FromSeconds(10)));
+        await client.SetAddElementsAsync(cacheName, setName, content, CollectionTtl.Of(TimeSpan.FromSeconds(Utils.updatedRefreshTtl)));
         await Task.Delay(2000);
 
         CacheSetFetchResponse fetchResponse = await client.SetFetchAsync(cacheName, setName);
@@ -265,13 +265,13 @@ public class SetTest : TestBase
         var element = Utils.NewGuidString();
         var content = new List<string>() { element };
 
-        CacheSetAddElementsResponse response = await client.SetAddElementsAsync(cacheName, setName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(4)).WithNoRefreshTtlOnUpdates());
+        CacheSetAddElementsResponse response = await client.SetAddElementsAsync(cacheName, setName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.initialRefreshTtl)).WithNoRefreshTtlOnUpdates());
         Assert.True(response is CacheSetAddElementsResponse.Success, $"Unexpected response: {response}");
-        await Task.Delay(100);
+        await Task.Delay(Utils.waitForItemToBeSet);
 
-        response = await client.SetAddElementsAsync(cacheName, setName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(10)).WithNoRefreshTtlOnUpdates());
+        response = await client.SetAddElementsAsync(cacheName, setName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.updatedRefreshTtl)).WithNoRefreshTtlOnUpdates());
         Assert.True(response is CacheSetAddElementsResponse.Success, $"Unexpected response: {response}");
-        await Task.Delay(4900);
+        await Task.Delay(Utils.waitForInitialItemToExpire);
 
         CacheSetFetchResponse fetchResponse = await client.SetFetchAsync(cacheName, setName);
         Assert.True(fetchResponse is CacheSetFetchResponse.Miss, $"Unexpected response: {fetchResponse}");
@@ -286,7 +286,7 @@ public class SetTest : TestBase
 
         CacheSetAddElementsResponse response = await client.SetAddElementsAsync(cacheName, setName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(2)).WithNoRefreshTtlOnUpdates());
         Assert.True(response is CacheSetAddElementsResponse.Success, $"Unexpected response: {response}");
-        response = await client.SetAddElementsAsync(cacheName, setName, content, CollectionTtl.Of(TimeSpan.FromSeconds(10)));
+        response = await client.SetAddElementsAsync(cacheName, setName, content, CollectionTtl.Of(TimeSpan.FromSeconds(Utils.updatedRefreshTtl)));
         Assert.True(response is CacheSetAddElementsResponse.Success, $"Unexpected response: {response}");
         await Task.Delay(2000);
 

--- a/tests/Integration/Momento.Sdk.Tests/SetTest.cs
+++ b/tests/Integration/Momento.Sdk.Tests/SetTest.cs
@@ -47,13 +47,13 @@ public class SetTest : TestBase
         var setName = Utils.NewGuidString();
         var element = Utils.NewGuidByteArray();
 
-        CacheSetAddElementResponse response = await client.SetAddElementAsync(cacheName, setName, element, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.initialRefreshTtl)).WithNoRefreshTtlOnUpdates());
+        CacheSetAddElementResponse response = await client.SetAddElementAsync(cacheName, setName, element, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.InitialRefreshTtl)).WithNoRefreshTtlOnUpdates());
         Assert.True(response is CacheSetAddElementResponse.Success, $"Unexpected response: {response}");
-        await Task.Delay(Utils.waitForItemToBeSet);
+        await Task.Delay(Utils.WaitForItemToBeSet);
 
-        response = await client.SetAddElementAsync(cacheName, setName, element, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.updatedRefreshTtl)).WithNoRefreshTtlOnUpdates());
+        response = await client.SetAddElementAsync(cacheName, setName, element, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.UpdatedRefreshTtl)).WithNoRefreshTtlOnUpdates());
         Assert.True(response is CacheSetAddElementResponse.Success, $"Unexpected response: {response}");
-        await Task.Delay(Utils.waitForInitialItemToExpire);
+        await Task.Delay(Utils.WaitForInitialItemToExpire);
         CacheSetFetchResponse fetchResponse = await client.SetFetchAsync(cacheName, setName);
         Assert.True(fetchResponse is CacheSetFetchResponse.Miss, $"Unexpected response: {fetchResponse}");
     }
@@ -66,7 +66,7 @@ public class SetTest : TestBase
 
         CacheSetAddElementResponse response = await client.SetAddElementAsync(cacheName, setName, element, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(2)).WithNoRefreshTtlOnUpdates());
         Assert.True(response is CacheSetAddElementResponse.Success, $"Unexpected response: {response}");
-        await client.SetAddElementAsync(cacheName, setName, element, CollectionTtl.Of(TimeSpan.FromSeconds(Utils.updatedRefreshTtl)));
+        await client.SetAddElementAsync(cacheName, setName, element, CollectionTtl.Of(TimeSpan.FromSeconds(Utils.UpdatedRefreshTtl)));
         await Task.Delay(2000);
 
         CacheSetFetchResponse fetchResponse = await client.SetFetchAsync(cacheName, setName);
@@ -108,13 +108,13 @@ public class SetTest : TestBase
         var setName = Utils.NewGuidString();
         var element = Utils.NewGuidString();
 
-        CacheSetAddElementResponse response = await client.SetAddElementAsync(cacheName, setName, element, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.initialRefreshTtl)).WithNoRefreshTtlOnUpdates());
+        CacheSetAddElementResponse response = await client.SetAddElementAsync(cacheName, setName, element, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.InitialRefreshTtl)).WithNoRefreshTtlOnUpdates());
         Assert.True(response is CacheSetAddElementResponse.Success, $"Unexpected response: {response}");
-        await Task.Delay(Utils.waitForItemToBeSet);
+        await Task.Delay(Utils.WaitForItemToBeSet);
 
-        response = await client.SetAddElementAsync(cacheName, setName, element, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.updatedRefreshTtl)).WithNoRefreshTtlOnUpdates());
+        response = await client.SetAddElementAsync(cacheName, setName, element, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.UpdatedRefreshTtl)).WithNoRefreshTtlOnUpdates());
         Assert.True(response is CacheSetAddElementResponse.Success, $"Unexpected response: {response}");
-        await Task.Delay(Utils.waitForInitialItemToExpire);
+        await Task.Delay(Utils.WaitForInitialItemToExpire);
 
         CacheSetFetchResponse fetchResponse = await client.SetFetchAsync(cacheName, setName);
         Assert.True(fetchResponse is CacheSetFetchResponse.Miss, $"Unexpected response: {fetchResponse}");
@@ -128,7 +128,7 @@ public class SetTest : TestBase
 
         CacheSetAddElementResponse response = await client.SetAddElementAsync(cacheName, setName, element, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(2)).WithNoRefreshTtlOnUpdates());
         Assert.True(response is CacheSetAddElementResponse.Success, $"Unexpected response: {response}");
-        response = await client.SetAddElementAsync(cacheName, setName, element, CollectionTtl.Of(TimeSpan.FromSeconds(Utils.updatedRefreshTtl)));
+        response = await client.SetAddElementAsync(cacheName, setName, element, CollectionTtl.Of(TimeSpan.FromSeconds(Utils.UpdatedRefreshTtl)));
         Assert.True(response is CacheSetAddElementResponse.Success, $"Unexpected response: {response}");
         await Task.Delay(2000);
 
@@ -185,13 +185,13 @@ public class SetTest : TestBase
         var element = Utils.NewGuidByteArray();
         var content = new List<byte[]>() { element };
 
-        CacheSetAddElementsResponse response = await client.SetAddElementsAsync(cacheName, setName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.initialRefreshTtl)).WithNoRefreshTtlOnUpdates());
+        CacheSetAddElementsResponse response = await client.SetAddElementsAsync(cacheName, setName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.InitialRefreshTtl)).WithNoRefreshTtlOnUpdates());
         Assert.True(response is CacheSetAddElementsResponse.Success, $"Unexpected response: {response}");
-        await Task.Delay(Utils.waitForItemToBeSet);
+        await Task.Delay(Utils.WaitForItemToBeSet);
 
-        response = await client.SetAddElementsAsync(cacheName, setName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.updatedRefreshTtl)).WithNoRefreshTtlOnUpdates());
+        response = await client.SetAddElementsAsync(cacheName, setName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.UpdatedRefreshTtl)).WithNoRefreshTtlOnUpdates());
         Assert.True(response is CacheSetAddElementsResponse.Success, $"Unexpected response: {response}");
-        await Task.Delay(Utils.waitForInitialItemToExpire);
+        await Task.Delay(Utils.WaitForInitialItemToExpire);
 
         CacheSetFetchResponse fetchResponse = await client.SetFetchAsync(cacheName, setName);
         Assert.True(fetchResponse is CacheSetFetchResponse.Miss, $"Unexpected response: {fetchResponse}");
@@ -206,7 +206,7 @@ public class SetTest : TestBase
 
         CacheSetAddElementsResponse response = await client.SetAddElementsAsync(cacheName, setName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(2)).WithNoRefreshTtlOnUpdates());
         Assert.True(response is CacheSetAddElementsResponse.Success, $"Unexpected response: {response}");
-        await client.SetAddElementsAsync(cacheName, setName, content, CollectionTtl.Of(TimeSpan.FromSeconds(Utils.updatedRefreshTtl)));
+        await client.SetAddElementsAsync(cacheName, setName, content, CollectionTtl.Of(TimeSpan.FromSeconds(Utils.UpdatedRefreshTtl)));
         await Task.Delay(2000);
 
         CacheSetFetchResponse fetchResponse = await client.SetFetchAsync(cacheName, setName);
@@ -265,13 +265,13 @@ public class SetTest : TestBase
         var element = Utils.NewGuidString();
         var content = new List<string>() { element };
 
-        CacheSetAddElementsResponse response = await client.SetAddElementsAsync(cacheName, setName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.initialRefreshTtl)).WithNoRefreshTtlOnUpdates());
+        CacheSetAddElementsResponse response = await client.SetAddElementsAsync(cacheName, setName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.InitialRefreshTtl)).WithNoRefreshTtlOnUpdates());
         Assert.True(response is CacheSetAddElementsResponse.Success, $"Unexpected response: {response}");
-        await Task.Delay(Utils.waitForItemToBeSet);
+        await Task.Delay(Utils.WaitForItemToBeSet);
 
-        response = await client.SetAddElementsAsync(cacheName, setName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.updatedRefreshTtl)).WithNoRefreshTtlOnUpdates());
+        response = await client.SetAddElementsAsync(cacheName, setName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(Utils.UpdatedRefreshTtl)).WithNoRefreshTtlOnUpdates());
         Assert.True(response is CacheSetAddElementsResponse.Success, $"Unexpected response: {response}");
-        await Task.Delay(Utils.waitForInitialItemToExpire);
+        await Task.Delay(Utils.WaitForInitialItemToExpire);
 
         CacheSetFetchResponse fetchResponse = await client.SetFetchAsync(cacheName, setName);
         Assert.True(fetchResponse is CacheSetFetchResponse.Miss, $"Unexpected response: {fetchResponse}");
@@ -286,7 +286,7 @@ public class SetTest : TestBase
 
         CacheSetAddElementsResponse response = await client.SetAddElementsAsync(cacheName, setName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(2)).WithNoRefreshTtlOnUpdates());
         Assert.True(response is CacheSetAddElementsResponse.Success, $"Unexpected response: {response}");
-        response = await client.SetAddElementsAsync(cacheName, setName, content, CollectionTtl.Of(TimeSpan.FromSeconds(Utils.updatedRefreshTtl)));
+        response = await client.SetAddElementsAsync(cacheName, setName, content, CollectionTtl.Of(TimeSpan.FromSeconds(Utils.UpdatedRefreshTtl)));
         Assert.True(response is CacheSetAddElementsResponse.Success, $"Unexpected response: {response}");
         await Task.Delay(2000);
 

--- a/tests/Integration/Momento.Sdk.Tests/SetTest.cs
+++ b/tests/Integration/Momento.Sdk.Tests/SetTest.cs
@@ -47,7 +47,7 @@ public class SetTest : TestBase
         var setName = Utils.NewGuidString();
         var element = Utils.NewGuidByteArray();
 
-        CacheSetAddElementResponse response = await client.SetAddElementAsync(cacheName, setName, element, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(5)).WithNoRefreshTtlOnUpdates());
+        CacheSetAddElementResponse response = await client.SetAddElementAsync(cacheName, setName, element, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(4)).WithNoRefreshTtlOnUpdates());
         Assert.True(response is CacheSetAddElementResponse.Success, $"Unexpected response: {response}");
         await Task.Delay(100);
 
@@ -108,7 +108,7 @@ public class SetTest : TestBase
         var setName = Utils.NewGuidString();
         var element = Utils.NewGuidString();
 
-        CacheSetAddElementResponse response = await client.SetAddElementAsync(cacheName, setName, element, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(5)).WithNoRefreshTtlOnUpdates());
+        CacheSetAddElementResponse response = await client.SetAddElementAsync(cacheName, setName, element, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(4)).WithNoRefreshTtlOnUpdates());
         Assert.True(response is CacheSetAddElementResponse.Success, $"Unexpected response: {response}");
         await Task.Delay(100);
 
@@ -185,7 +185,7 @@ public class SetTest : TestBase
         var element = Utils.NewGuidByteArray();
         var content = new List<byte[]>() { element };
 
-        CacheSetAddElementsResponse response = await client.SetAddElementsAsync(cacheName, setName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(5)).WithNoRefreshTtlOnUpdates());
+        CacheSetAddElementsResponse response = await client.SetAddElementsAsync(cacheName, setName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(4)).WithNoRefreshTtlOnUpdates());
         Assert.True(response is CacheSetAddElementsResponse.Success, $"Unexpected response: {response}");
         await Task.Delay(100);
 
@@ -265,7 +265,7 @@ public class SetTest : TestBase
         var element = Utils.NewGuidString();
         var content = new List<string>() { element };
 
-        CacheSetAddElementsResponse response = await client.SetAddElementsAsync(cacheName, setName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(5)).WithNoRefreshTtlOnUpdates());
+        CacheSetAddElementsResponse response = await client.SetAddElementsAsync(cacheName, setName, content, ttl: CollectionTtl.Of(TimeSpan.FromSeconds(4)).WithNoRefreshTtlOnUpdates());
         Assert.True(response is CacheSetAddElementsResponse.Success, $"Unexpected response: {response}");
         await Task.Delay(100);
 

--- a/tests/Integration/Momento.Sdk.Tests/TtlTest.cs
+++ b/tests/Integration/Momento.Sdk.Tests/TtlTest.cs
@@ -103,7 +103,7 @@ public class TtlTest : TestBase
         Assert.True(updateTtlResponse is CacheUpdateTtlResponse.Set, $"UpdateTtl call should have been Set but was: {response}");
 
         // Wait for the TTL to expire
-        await Task.Delay(1000);
+        await Task.Delay(2000);
 
         // Check it is gone
         existsResponse = await client.KeyExistsAsync(cacheName, key);

--- a/tests/Integration/Momento.Sdk.Tests/TtlTest.cs
+++ b/tests/Integration/Momento.Sdk.Tests/TtlTest.cs
@@ -76,7 +76,7 @@ public class TtlTest : TestBase
         Assert.True(updateTtlResponse is CacheUpdateTtlResponse.Set, $"UpdateTtl call should have been Set but was: {response}");
 
         // Wait for the TTL to expire
-        await Task.Delay(1000);
+        await Task.Delay(2000);
 
         // Check it is gone
         existsResponse = await client.KeyExistsAsync(cacheName, key);

--- a/tests/Integration/Momento.Sdk.Tests/Utils.cs
+++ b/tests/Integration/Momento.Sdk.Tests/Utils.cs
@@ -11,4 +11,12 @@ public static class Utils
     public static string NewGuidString() => Guid.NewGuid().ToString();
 
     public static byte[] NewGuidByteArray() => Guid.NewGuid().ToByteArray();
+
+    public static int initialRefreshTtl = 4;
+
+    public static int updatedRefreshTtl = 10;
+
+    public static int waitForItemToBeSet = 100;
+
+    public static int waitForInitialItemToExpire = 4900;
 }

--- a/tests/Integration/Momento.Sdk.Tests/Utils.cs
+++ b/tests/Integration/Momento.Sdk.Tests/Utils.cs
@@ -12,11 +12,11 @@ public static class Utils
 
     public static byte[] NewGuidByteArray() => Guid.NewGuid().ToByteArray();
 
-    public static int initialRefreshTtl = 4;
+    public static int InitialRefreshTtl { get; } = 4;
 
-    public static int updatedRefreshTtl = 10;
+    public static int UpdatedRefreshTtl { get; } = 10;
 
-    public static int waitForItemToBeSet = 100;
+    public static int WaitForItemToBeSet { get; } = 100;
 
-    public static int waitForInitialItemToExpire = 4900;
+    public static int WaitForInitialItemToExpire { get; } = 4900;
 }


### PR DESCRIPTION
When running these integration tests in region in an aws account, we were seeing flaky results. It seems to be due to the fact that we return keys/values even slightly after they are ttl'd out. This pr relaxes some of the integration test timeouts to allow some leniency in their timeouts/ttls.

Testing in fargate, these changes are passing now