### PR TITLE
feat: update agent header and endpoint for gRPC web

### DIFF
--- a/src/Momento.Sdk/Internal/ControlGrpcManager.cs
+++ b/src/Momento.Sdk/Internal/ControlGrpcManager.cs
@@ -74,10 +74,16 @@ internal sealed class ControlGrpcManager : IDisposable
 {
     private readonly GrpcChannel channel;
     public IControlClient Client { get; }
-    private readonly string version = "dotnet:" + GetAssembly(typeof(Momento.Sdk.Responses.CacheGetResponse)).GetName().Version.ToString();
+
+#if USE_GRPC_WEB
+    private readonly static string moniker = "dotnet-web";
+#else
+    private readonly static string moniker = "dotnet";
+#endif
+    private readonly string version = $"{moniker}:{GetAssembly(typeof(Momento.Sdk.Responses.CacheGetResponse)).GetName().Version.ToString()}";
     // Some System.Environment.Version remarks to be aware of
     // https://learn.microsoft.com/en-us/dotnet/api/system.environment.version?view=netstandard-2.0#remarks
-    private readonly string runtimeVersion = "dotnet:" + System.Environment.Version;
+    private readonly string runtimeVersion = $"{moniker}:{System.Environment.Version}";
     private readonly ILogger _logger;
 
     public ControlGrpcManager(ILoggerFactory loggerFactory, string authToken, string endpoint)

--- a/src/Momento.Sdk/Internal/ControlGrpcManager.cs
+++ b/src/Momento.Sdk/Internal/ControlGrpcManager.cs
@@ -82,6 +82,10 @@ internal sealed class ControlGrpcManager : IDisposable
 
     public ControlGrpcManager(ILoggerFactory loggerFactory, string authToken, string endpoint)
     {
+#if USE_GRPC_WEB
+        // Note: all web SDK requests are routed to a `web.` subdomain to allow us flexibility on the server
+        endpoint = $"web.{endpoint}";
+#endif
         var uri = $"https://{endpoint}";
         this.channel = GrpcChannel.ForAddress(uri, new GrpcChannelOptions()
         {

--- a/src/Momento.Sdk/Internal/DataGrpcManager.cs
+++ b/src/Momento.Sdk/Internal/DataGrpcManager.cs
@@ -226,10 +226,15 @@ public class DataGrpcManager : IDisposable
 
     public readonly IDataClient Client;
 
-    private readonly string version = "dotnet:" + GetAssembly(typeof(Responses.CacheGetResponse)).GetName().Version.ToString();
+#if USE_GRPC_WEB
+    private readonly static string moniker = "dotnet-web";
+#else
+    private readonly static string moniker = "dotnet";
+#endif
+    private readonly string version = $"{moniker}:{GetAssembly(typeof(Responses.CacheGetResponse)).GetName().Version.ToString()}";
     // Some System.Environment.Version remarks to be aware of
     // https://learn.microsoft.com/en-us/dotnet/api/system.environment.version?view=netstandard-2.0#remarks
-    private readonly string runtimeVersion = "dotnet:" + Environment.Version;
+    private readonly string runtimeVersion = $"{moniker}:{Environment.Version}";
     private readonly ILogger _logger;
 
     internal DataGrpcManager(IConfiguration config, string authToken, string endpoint)


### PR DESCRIPTION
- feat: use web prefix for endpoints when using gRPC-web
- feat: use appropriate agent header moniker when using gRPC-web

closes #442 