### PR TITLE
feat: Add support for Dictionary Length API

### DIFF
--- a/src/Momento.Sdk/CacheClient.cs
+++ b/src/Momento.Sdk/CacheClient.cs
@@ -727,6 +727,22 @@ public class CacheClient : ICacheClient
         return await this.DataClient.DictionaryRemoveFieldsAsync(cacheName, dictionaryName, fields);
     }
 
+     /// <inheritdoc />
+    public async Task<CacheDictionaryLengthResponse> DictionaryLengthAsync(string cacheName, string dictionaryName)
+    {
+        try
+        {
+            Utils.ArgumentNotNull(cacheName, nameof(cacheName));
+            Utils.ArgumentNotNull(dictionaryName, nameof(dictionaryName));
+        }
+        catch (ArgumentNullException e)
+        {
+            return new CacheDictionaryLengthResponse.Error(new InvalidArgumentException(e.Message));
+        }
+
+        return await this.DataClient.DictionaryLengthAsync(cacheName, dictionaryName);
+    }
+
     /// <inheritdoc />
     public async Task<CacheSetAddElementResponse> SetAddElementAsync(string cacheName, string setName, byte[] element, CollectionTtl ttl = default(CollectionTtl))
     {

--- a/src/Momento.Sdk/ICacheClient.cs
+++ b/src/Momento.Sdk/ICacheClient.cs
@@ -455,7 +455,6 @@ public interface ICacheClient : IDisposable
     /// <summary>
     /// Calculate the length of a dictionary in the cache.
     ///
-    /// A dictionary that does not exist is interpreted to have length 0.
     /// </summary>
     /// <param name="cacheName">Name of the cache to perform the lookup in.</param>
     /// <param name="dictionaryName">The dictionary to calculate length.</param>

--- a/src/Momento.Sdk/ICacheClient.cs
+++ b/src/Momento.Sdk/ICacheClient.cs
@@ -453,6 +453,16 @@ public interface ICacheClient : IDisposable
     public Task<CacheDictionaryRemoveFieldsResponse> DictionaryRemoveFieldsAsync(string cacheName, string dictionaryName, IEnumerable<string> fields);
 
     /// <summary>
+    /// Calculate the length of a dictionary in the cache.
+    ///
+    /// A dictionary that does not exist is interpreted to have length 0.
+    /// </summary>
+    /// <param name="cacheName">Name of the cache to perform the lookup in.</param>
+    /// <param name="dictionaryName">The dictionary to calculate length.</param>
+    /// <returns>Task representing the length of the dictionary.</returns>
+    public Task<CacheDictionaryLengthResponse> DictionaryLengthAsync(string cacheName, string dictionaryName);
+
+    /// <summary>
     /// Add an element to a set in the cache.
     ///
     /// After this operation, the set will contain the union

--- a/src/Momento.Sdk/Internal/DataGrpcManager.cs
+++ b/src/Momento.Sdk/Internal/DataGrpcManager.cs
@@ -34,6 +34,8 @@ public interface IDataClient
     public Task<_DictionaryGetResponse> DictionaryGetAsync(_DictionaryGetRequest request, CallOptions callOptions);
     public Task<_DictionaryFetchResponse> DictionaryFetchAsync(_DictionaryFetchRequest request, CallOptions callOptions);
     public Task<_DictionaryDeleteResponse> DictionaryDeleteAsync(_DictionaryDeleteRequest request, CallOptions callOptions);
+    public Task<_DictionaryLengthResponse> DictionaryLengthAsync(_DictionaryLengthRequest request, CallOptions callOptions);
+
     public Task<_SetUnionResponse> SetUnionAsync(_SetUnionRequest request, CallOptions callOptions);
     public Task<_SetDifferenceResponse> SetDifferenceAsync(_SetDifferenceRequest request, CallOptions callOptions);
     public Task<_SetFetchResponse> SetFetchAsync(_SetFetchRequest request, CallOptions callOptions);
@@ -138,6 +140,12 @@ public class DataClientWithMiddleware : IDataClient
     public async Task<_DictionaryDeleteResponse> DictionaryDeleteAsync(_DictionaryDeleteRequest request, CallOptions callOptions)
     {
         var wrapped = await _middlewares.WrapRequest(request, callOptions, (r, o) => _generatedClient.DictionaryDeleteAsync(r, o));
+        return await wrapped.ResponseAsync;
+    }
+
+    public async Task<_DictionaryLengthResponse> DictionaryLengthAsync(_DictionaryLengthRequest request, CallOptions callOptions)
+    {
+        var wrapped = await _middlewares.WrapRequest(request, callOptions, (r, o) => _generatedClient.DictionaryLengthAsync(r, o));
         return await wrapped.ResponseAsync;
     }
 

--- a/src/Momento.Sdk/Internal/Retry/DefaultRetryEligibilityStrategy.cs
+++ b/src/Momento.Sdk/Internal/Retry/DefaultRetryEligibilityStrategy.cs
@@ -47,6 +47,7 @@ namespace Momento.Sdk.Internal.Retry
             typeof(_DictionaryGetRequest),
             typeof(_DictionaryFetchRequest),
             typeof(_DictionaryDeleteRequest),
+            typeof(_DictionaryLengthRequest),
             typeof(_SetUnionRequest),
             typeof(_SetDifferenceRequest),
             typeof(_SetFetchRequest),

--- a/src/Momento.Sdk/Internal/ScsDataClient.cs
+++ b/src/Momento.Sdk/Internal/ScsDataClient.cs
@@ -258,6 +258,11 @@ internal sealed class ScsDataClient : ScsDataClientBase
         return await SendDictionaryRemoveFieldsAsync(cacheName, dictionaryName, fields.ToEnumerableByteString());
     }
 
+    public async Task<CacheDictionaryLengthResponse> DictionaryLengthAsync(string cacheName, string dictionaryName)
+    {
+        return await SendDictionaryLengthAsync(cacheName, dictionaryName);
+    }
+
     public async Task<CacheSetAddElementResponse> SetAddElementAsync(string cacheName, string setName, byte[] element, CollectionTtl ttl = default(CollectionTtl))
     {
         return await SendSetAddElementAsync(cacheName, setName, element.ToSingletonByteString(), ttl);
@@ -781,6 +786,31 @@ internal sealed class ScsDataClient : ScsDataClientBase
         }
 
         return this._logger.LogTraceCollectionRequestSuccess(REQUEST_TYPE_DICTIONARY_REMOVE_FIELDS, cacheName, dictionaryName, fields, null, new CacheDictionaryRemoveFieldsResponse.Success());
+    }
+
+    const string REQUEST_TYPE_DICTIONARY_LENGTH = "DICTIONARY_LENGTH";
+    private async Task<CacheDictionaryLengthResponse> SendDictionaryLengthAsync(string cacheName, string dictionaryName)
+    {
+        _DictionaryLengthRequest request = new() { DictionaryName = dictionaryName.ToByteString() };
+        _DictionaryLengthResponse response;
+        var metadata = MetadataWithCache(cacheName);
+
+        try
+        {
+            this._logger.LogTraceExecutingCollectionRequest(REQUEST_TYPE_DICTIONARY_LENGTH, cacheName, dictionaryName);
+            response = await this.grpcManager.Client.DictionaryLengthAsync(request, new CallOptions(headers: MetadataWithCache(cacheName), deadline: CalculateDeadline()));
+        }
+        catch (Exception e)
+        {
+            return this._logger.LogTraceCollectionRequestError(REQUEST_TYPE_DICTIONARY_LENGTH, cacheName, dictionaryName, new CacheDictionaryLengthResponse.Error(_exceptionMapper.Convert(e, metadata)));
+        }
+
+        if (response.DictionaryCase == _DictionaryLengthResponse.DictionaryOneofCase.Missing)
+        {
+            return this._logger.LogTraceCollectionRequestSuccess(REQUEST_TYPE_DICTIONARY_LENGTH, cacheName, dictionaryName, new CacheDictionaryLengthResponse.Miss());
+        }
+
+        return this._logger.LogTraceCollectionRequestSuccess(REQUEST_TYPE_DICTIONARY_LENGTH, cacheName, dictionaryName, new CacheDictionaryLengthResponse.Hit(response));
     }
 
     const string REQUEST_TYPE_SET_ADD_ELEMENT = "SET_ADD_ELEMENT";

--- a/src/Momento.Sdk/Momento.Sdk.csproj
+++ b/src/Momento.Sdk/Momento.Sdk.csproj
@@ -54,7 +54,7 @@
 	</ItemGroup>
 	<ItemGroup>
 	  <PackageReference Include="Grpc.Net.Client" Version="2.49.0" />
-	  <PackageReference Include="Momento.Protos" Version="0.60.1" />
+	  <PackageReference Include="Momento.Protos" Version="0.64.1" />
 	  <PackageReference Include="JWT" Version="9.0.3" />
 	  <PackageReference Include="System.Threading.Channels" Version="6.0.0" />
 	  <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />

--- a/src/Momento.Sdk/Responses/CacheDictionaryLengthResponse.cs
+++ b/src/Momento.Sdk/Responses/CacheDictionaryLengthResponse.cs
@@ -19,11 +19,11 @@ namespace Momento.Sdk.Responses;
 /// {
 ///     return hitResponse.Length;
 /// }
-/// else if (response is CacheListLengthResponse.Miss missResponse)
+/// else if (response is CacheDictionaryLengthResponse.Miss missResponse)
 /// {
 ///     // handle missResponse as appropriate
 /// }
-/// else if (response is CacheListLengthResponse.Error errorResponse)
+/// else if (response is CacheDictionaryLengthResponse.Error errorResponse)
 /// {
 ///     // handle error as appropriate
 /// }

--- a/src/Momento.Sdk/Responses/CacheDictionaryLengthResponse.cs
+++ b/src/Momento.Sdk/Responses/CacheDictionaryLengthResponse.cs
@@ -1,0 +1,105 @@
+using Momento.Protos.CacheClient;
+using Momento.Sdk.Exceptions;
+
+namespace Momento.Sdk.Responses;
+
+/// <summary>
+/// Parent response type for a cache dictionary length request. The
+/// response object is resolved to a type-safe object of one of
+/// the following subtypes:
+/// <list type="bullet">
+/// <item><description>CacheDictionaryLengthResponse.Hit</description></item>
+/// <item><description>CacheDictionaryLengthResponse.Miss</description></item>
+/// <item><description>CacheDictionaryLengthResponse.Error</description></item>
+/// </list>
+/// Pattern matching can be used to operate on the appropriate subtype.
+/// For example:
+/// <code>
+/// if (response is CacheDictionaryLengthResponse.Hit hitResponse)
+/// {
+///     return hitResponse.Length;
+/// }
+/// else if (response is CacheListLengthResponse.Miss missResponse)
+/// {
+///     // handle missResponse as appropriate
+/// }
+/// else if (response is CacheListLengthResponse.Error errorResponse)
+/// {
+///     // handle error as appropriate
+/// }
+/// else
+/// {
+///     // handle unexpected response
+/// }
+/// </code>
+/// </summary>
+public abstract class CacheDictionaryLengthResponse
+{
+    /// <include file="../docs.xml" path='docs/class[@name="Hit"]/description/*' />
+    public class Hit : CacheDictionaryLengthResponse
+    {
+        /// <summary>
+        /// The length of the dictionary. If the dictionary is missing or empty, the result is zero.
+        /// </summary>
+        public int Length { get; private set; } = 0;
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="response">The cache response.</param>
+        public Hit(_DictionaryLengthResponse response)
+        {
+            if(response.DictionaryCase == _DictionaryLengthResponse.DictionaryOneofCase.Found) {
+                Length = checked((int)response.Found.Length);
+            }
+        }
+
+        /// <inheritdoc />
+        public override string ToString()
+        {
+            return $"{base.ToString()}: Length: {Length}";
+        }
+    }
+
+    /// <include file="../docs.xml" path='docs/class[@name="Miss"]/description/*' />
+    public class Miss : CacheDictionaryLengthResponse
+    {
+
+    }
+
+    /// <include file="../docs.xml" path='docs/class[@name="Error"]/description/*' />
+    public class Error : CacheDictionaryLengthResponse, IError
+    {
+        private readonly SdkException _error;
+
+        /// <include file="../docs.xml" path='docs/class[@name="Error"]/constructor/*' />
+        public Error(SdkException error)
+        {
+            _error = error;
+        }
+
+        /// <inheritdoc />
+        public SdkException InnerException
+        {
+            get => _error;
+        }
+
+        /// <inheritdoc />
+        public MomentoErrorCode ErrorCode
+        {
+            get => _error.ErrorCode;
+        }
+
+        /// <inheritdoc />
+        public string Message
+        {
+            get => $"{_error.MessageWrapper}: {_error.Message}";
+        }
+
+        /// <inheritdoc />
+        public override string ToString()
+        {
+            return $"{base.ToString()}: {this.Message}";
+        }
+    }
+}

--- a/tests/Integration/Momento.Sdk.Tests/DictionaryTest.cs
+++ b/tests/Integration/Momento.Sdk.Tests/DictionaryTest.cs
@@ -1118,4 +1118,27 @@ public class DictionaryTest : TestBase
         Assert.True((await client.DictionaryGetFieldAsync(cacheName, dictionaryName, fields[1])) is CacheDictionaryGetFieldResponse.Miss);
         Assert.True((await client.DictionaryGetFieldAsync(cacheName, dictionaryName, otherField)) is CacheDictionaryGetFieldResponse.Hit);
     }
+
+    [Fact]
+    public async Task DictionaryLengthAsync_DictionaryIsMissing()
+    {
+        var dictionaryName = Utils.NewGuidString();
+        CacheDictionaryLengthResponse response = await client.DictionaryLengthAsync(cacheName, dictionaryName);
+        Assert.True(response is CacheDictionaryLengthResponse.Miss, $"Unexpected response: {response}");
+    }
+
+    [Fact]
+    public async Task DictionaryLengthAsync_HappyPath()
+    {
+        var dictionaryName = Utils.NewGuidString();
+        var field = Utils.NewGuidByteArray();
+        var value = Utils.NewGuidByteArray();
+
+        await client.DictionarySetFieldAsync(cacheName, dictionaryName, field, value);
+
+        CacheDictionaryLengthResponse lengthResponse = await client.DictionaryLengthAsync(cacheName, dictionaryName);
+        Assert.True(lengthResponse is CacheDictionaryLengthResponse.Hit, $"Unexpected response: {lengthResponse}");
+        var hitResponse = (CacheDictionaryLengthResponse.Hit)lengthResponse;
+        Assert.Equal(1, hitResponse.Length);
+    }
 }


### PR DESCRIPTION
## PR Description:
Add support for Dictionary Length API

## Testing
- Integration tests:
    - `TEST_CACHE_NAME="test-cache" dotnet test -f net6.0 --filter "DictionaryLengthAsync_HappyPath"`
    - `TEST_CACHE_NAME="test-cache" dotnet test -f net6.0 --filter "DictionaryLengthAsync_DictionaryIsMissing"`      
    
## Issue
closes #447                                             