### PR TITLE
feat: Add ListLength to list modification apis

### DIFF
--- a/src/Momento.Sdk/Internal/ScsDataClient.cs
+++ b/src/Momento.Sdk/Internal/ScsDataClient.cs
@@ -1169,7 +1169,7 @@ internal sealed class ScsDataClient : ScsDataClientBase
             return this._logger.LogTraceCollectionRequestError(REQUEST_TYPE_LIST_RETAIN, cacheName, listName, new CacheListRetainResponse.Error(_exceptionMapper.Convert(e, metadata)));
         }
 
-        return this._logger.LogTraceCollectionRequestSuccess(REQUEST_TYPE_LIST_RETAIN, cacheName, listName, new CacheListRetainResponse.Success());
+        return this._logger.LogTraceCollectionRequestSuccess(REQUEST_TYPE_LIST_RETAIN, cacheName, listName, new CacheListRetainResponse.Success(response));
     }
 
     const string REQUEST_TYPE_LIST_REMOVE_VALUE = "LIST_REMOVE_VALUE";
@@ -1180,19 +1180,20 @@ internal sealed class ScsDataClient : ScsDataClientBase
             ListName = listName.ToByteString(),
             AllElementsWithValue = value
         };
+        _ListRemoveResponse response;
         var metadata = MetadataWithCache(cacheName);
 
         try
         {
             this._logger.LogTraceExecutingCollectionRequest(REQUEST_TYPE_LIST_REMOVE_VALUE, cacheName, listName, value, null);
-            await this.grpcManager.Client.ListRemoveAsync(request, new CallOptions(headers: MetadataWithCache(cacheName), deadline: CalculateDeadline()));
+            response = await this.grpcManager.Client.ListRemoveAsync(request, new CallOptions(headers: MetadataWithCache(cacheName), deadline: CalculateDeadline()));
         }
         catch (Exception e)
         {
             return this._logger.LogTraceCollectionRequestError(REQUEST_TYPE_LIST_REMOVE_VALUE, cacheName, listName, value, null, new CacheListRemoveValueResponse.Error(_exceptionMapper.Convert(e, metadata)));
         }
 
-        return this._logger.LogTraceCollectionRequestSuccess(REQUEST_TYPE_LIST_REMOVE_VALUE, cacheName, listName, value, null, new CacheListRemoveValueResponse.Success());
+        return this._logger.LogTraceCollectionRequestSuccess(REQUEST_TYPE_LIST_REMOVE_VALUE, cacheName, listName, value, null, new CacheListRemoveValueResponse.Success(response));
     }
 
     const string REQUEST_TYPE_LIST_LENGTH = "LIST_LENGTH";

--- a/src/Momento.Sdk/Responses/CacheListFetchResponse.cs
+++ b/src/Momento.Sdk/Responses/CacheListFetchResponse.cs
@@ -51,6 +51,11 @@ public abstract class CacheListFetchResponse
 #pragma warning restore 1591
 
         /// <summary>
+        /// The length of the list.
+        /// </summary>
+        public int ListLength { get; private set; }
+
+        /// <summary>
         /// 
         /// </summary>
         /// <param name="response">The cache response.</param>
@@ -66,6 +71,8 @@ public abstract class CacheListFetchResponse
             {
                 return new List<string>(values.Select(v => v.ToStringUtf8()));
             });
+
+            ListLength = checked((int)values.Count);
         }
 
         /// <summary>
@@ -83,7 +90,7 @@ public abstract class CacheListFetchResponse
         {
             var stringRepresentation = String.Join(", ", ValueListString.Select(value => $"\"{value}\""));
             var byteArrayRepresentation = String.Join(", ", ValueListByteArray.Select(value => $"\"{value.ToPrettyHexString()}\""));
-            return $"{base.ToString()}: ValueListString: [{stringRepresentation.Truncate()}] ValueListByteArray: [{byteArrayRepresentation.Truncate()}]";
+            return $"{base.ToString()}: ValueListString: [{stringRepresentation.Truncate()}] ValueListByteArray: [{byteArrayRepresentation.Truncate()}] ListLength: {ListLength}";
         }
     }
 

--- a/src/Momento.Sdk/Responses/CacheListFetchResponse.cs
+++ b/src/Momento.Sdk/Responses/CacheListFetchResponse.cs
@@ -72,7 +72,7 @@ public abstract class CacheListFetchResponse
                 return new List<string>(values.Select(v => v.ToStringUtf8()));
             });
 
-            ListLength = checked((int)values.Count);
+            ListLength = values.Count;
         }
 
         /// <summary>

--- a/src/Momento.Sdk/Responses/CacheListLengthResponse.cs
+++ b/src/Momento.Sdk/Responses/CacheListLengthResponse.cs
@@ -46,7 +46,7 @@ public abstract class CacheListLengthResponse
         {
             if (response.ListCase == _ListLengthResponse.ListOneofCase.Found)
             {
-                Length = (int)response.Found.Length;
+                Length = checked((int)response.Found.Length);
             }
         }
 

--- a/src/Momento.Sdk/Responses/CacheListLengthResponse.cs
+++ b/src/Momento.Sdk/Responses/CacheListLengthResponse.cs
@@ -46,7 +46,7 @@ public abstract class CacheListLengthResponse
         {
             if (response.ListCase == _ListLengthResponse.ListOneofCase.Found)
             {
-                Length = checked((int)response.Found.Length);
+                Length = (int)response.Found.Length;
             }
         }
 

--- a/src/Momento.Sdk/Responses/CacheListPopBackResponse.cs
+++ b/src/Momento.Sdk/Responses/CacheListPopBackResponse.cs
@@ -45,12 +45,18 @@ public abstract class CacheListPopBackResponse
 #pragma warning restore 1591
 
         /// <summary>
+        /// The length of the list post-pop (and post-truncate, if that applies).
+        /// </summary>
+        public int ListLength { get; private set; }
+
+        /// <summary>
         /// 
         /// </summary>
         /// <param name="response">The cache response.</param>
         public Hit(_ListPopBackResponse response)
         {
             this.value = response.Found.Back;
+            ListLength = checked((int)response.Found.ListLength);
         }
 
         /// <summary>
@@ -69,7 +75,7 @@ public abstract class CacheListPopBackResponse
         /// <inheritdoc />
         public override string ToString()
         {
-            return $"{base.ToString()}: ValueString: \"{ValueString.Truncate()}\" ValueByteArray: \"{ValueByteArray.ToPrettyHexString().Truncate()}\"";
+            return $"{base.ToString()}: ValueString: \"{ValueString.Truncate()}\" ValueByteArray: \"{ValueByteArray.ToPrettyHexString().Truncate()}\" ListLength: {ListLength}";
         }
     }
 

--- a/src/Momento.Sdk/Responses/CacheListPopBackResponse.cs
+++ b/src/Momento.Sdk/Responses/CacheListPopBackResponse.cs
@@ -56,7 +56,7 @@ public abstract class CacheListPopBackResponse
         public Hit(_ListPopBackResponse response)
         {
             this.value = response.Found.Back;
-            ListLength = checked((int)response.Found.ListLength);
+            ListLength = (int)response.Found.ListLength;
         }
 
         /// <summary>

--- a/src/Momento.Sdk/Responses/CacheListPopBackResponse.cs
+++ b/src/Momento.Sdk/Responses/CacheListPopBackResponse.cs
@@ -56,7 +56,7 @@ public abstract class CacheListPopBackResponse
         public Hit(_ListPopBackResponse response)
         {
             this.value = response.Found.Back;
-            ListLength = (int)response.Found.ListLength;
+            ListLength = checked((int)response.Found.ListLength);
         }
 
         /// <summary>

--- a/src/Momento.Sdk/Responses/CacheListPopFrontResponse.cs
+++ b/src/Momento.Sdk/Responses/CacheListPopFrontResponse.cs
@@ -56,7 +56,7 @@ public abstract class CacheListPopFrontResponse
         public Hit(_ListPopFrontResponse response)
         {
             this.value = response.Found.Front;
-            ListLength = checked((int)response.Found.ListLength);
+            ListLength = (int)response.Found.ListLength;
         }
 
         /// <summary>

--- a/src/Momento.Sdk/Responses/CacheListPopFrontResponse.cs
+++ b/src/Momento.Sdk/Responses/CacheListPopFrontResponse.cs
@@ -56,7 +56,7 @@ public abstract class CacheListPopFrontResponse
         public Hit(_ListPopFrontResponse response)
         {
             this.value = response.Found.Front;
-            ListLength = (int)response.Found.ListLength;
+            ListLength = checked((int)response.Found.ListLength);
         }
 
         /// <summary>

--- a/src/Momento.Sdk/Responses/CacheListPopFrontResponse.cs
+++ b/src/Momento.Sdk/Responses/CacheListPopFrontResponse.cs
@@ -45,12 +45,18 @@ public abstract class CacheListPopFrontResponse
 #pragma warning restore 1591
 
         /// <summary>
+        /// The length of the list post-pop (and post-truncate, if that applies).
+        /// </summary>
+        public int ListLength { get; private set; }
+
+        /// <summary>
         /// 
         /// </summary>
         /// <param name="response">The cache response</param>
         public Hit(_ListPopFrontResponse response)
         {
             this.value = response.Found.Front;
+            ListLength = checked((int)response.Found.ListLength);
         }
 
         /// <summary>
@@ -69,7 +75,7 @@ public abstract class CacheListPopFrontResponse
         /// <inheritdoc />
         public override string ToString()
         {
-            return $"{base.ToString()}: ValueString: \"{ValueString.Truncate()}\" ValueByteArray: \"{ValueByteArray.ToPrettyHexString().Truncate()}\"";
+            return $"{base.ToString()}: ValueString: \"{ValueString.Truncate()}\" ValueByteArray: \"{ValueByteArray.ToPrettyHexString().Truncate()}\" ListLength: {ListLength}";
         }
     }
 

--- a/src/Momento.Sdk/Responses/CacheListRemoveValueResponse.cs
+++ b/src/Momento.Sdk/Responses/CacheListRemoveValueResponse.cs
@@ -44,7 +44,9 @@ public abstract class CacheListRemoveValueResponse
         /// <param name="response">The cache response</param>
         public Success(_ListRemoveResponse response)
         {
-            ListLength = checked((int)response.Found.ListLength);
+            if (response.ListCase == _ListRemoveResponse.ListOneofCase.Found) {
+                ListLength = checked((int)response.Found.ListLength);
+            }
         }
 
         /// <inheritdoc />

--- a/src/Momento.Sdk/Responses/CacheListRemoveValueResponse.cs
+++ b/src/Momento.Sdk/Responses/CacheListRemoveValueResponse.cs
@@ -1,4 +1,5 @@
-﻿using Momento.Sdk.Exceptions;
+﻿using Momento.Protos.CacheClient;
+using Momento.Sdk.Exceptions;
 
 namespace Momento.Sdk.Responses;
 
@@ -32,6 +33,25 @@ public abstract class CacheListRemoveValueResponse
     /// <include file="../docs.xml" path='docs/class[@name="Success"]/description/*' />
     public class Success : CacheListRemoveValueResponse
     {
+        /// <summary>
+        /// The length of the list post-remove operation.
+        /// </summary>
+        public int ListLength { get; private set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="response">The cache response</param>
+        public Success(_ListRemoveResponse response)
+        {
+            ListLength = checked((int)response.Found.ListLength);
+        }
+
+        /// <inheritdoc />
+        public override string ToString()
+        {
+            return $"{base.ToString()}: ListLength: {ListLength}";
+        }
     }
 
     /// <include file="../docs.xml" path='docs/class[@name="Error"]/description/*' />

--- a/src/Momento.Sdk/Responses/CacheListRetainResponse.cs
+++ b/src/Momento.Sdk/Responses/CacheListRetainResponse.cs
@@ -1,4 +1,5 @@
-﻿using Momento.Sdk.Exceptions;
+﻿using Momento.Protos.CacheClient;
+using Momento.Sdk.Exceptions;
 
 namespace Momento.Sdk.Responses;
 
@@ -32,6 +33,25 @@ public abstract class CacheListRetainResponse
     /// <include file="../docs.xml" path='docs/class[@name="Success"]/description/*' />
     public class Success : CacheListRetainResponse
     {
+        /// <summary>
+        /// The length of the list post-retain operation.
+        /// </summary>
+        public int ListLength { get; private set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="response">The cache response</param>
+        public Success(_ListRetainResponse response)
+        {
+            ListLength = checked((int)response.Found.ListLength);
+        }
+
+        /// <inheritdoc />
+        public override string ToString()
+        {
+            return $"{base.ToString()}: ListLength: {ListLength}";
+        }
     }
 
     /// <include file="../docs.xml" path='docs/class[@name="Error"]/description/*' />

--- a/src/Momento.Sdk/Responses/CacheListRetainResponse.cs
+++ b/src/Momento.Sdk/Responses/CacheListRetainResponse.cs
@@ -44,7 +44,7 @@ public abstract class CacheListRetainResponse
         /// <param name="response">The cache response</param>
         public Success(_ListRetainResponse response)
         {
-            ListLength = checked((int)response.Found.ListLength);
+            ListLength = (int)response.Found.ListLength;
         }
 
         /// <inheritdoc />

--- a/src/Momento.Sdk/Responses/CacheListRetainResponse.cs
+++ b/src/Momento.Sdk/Responses/CacheListRetainResponse.cs
@@ -44,7 +44,7 @@ public abstract class CacheListRetainResponse
         /// <param name="response">The cache response</param>
         public Success(_ListRetainResponse response)
         {
-            ListLength = (int)response.Found.ListLength;
+            ListLength = checked((int)response.Found.ListLength);
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
## PR Description:
- Add ListLength to list modification apis
- Reformat integration tests to cover ListLength methods

## Notes:
Adding checked after casting the `response.Found.Length` (which return a uint) to int because: uint in public APIs is discouraged in .NET as it is not CLS compliant

## Testing:
`make test-net6` to run the entire suite

## Issue
closes #414 