### PR TITLE
chore: get rid of TEST_CACHE environment variable

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,7 +16,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       TEST_AUTH_TOKEN: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
-      TEST_CACHE_NAME: client-sdk-dotnet-${{ github.sha }}-${{ matrix.target-framework }}
 
     steps:
       - name: Get current time

--- a/.github/workflows/on-push-to-main-branch.yaml
+++ b/.github/workflows/on-push-to-main-branch.yaml
@@ -16,7 +16,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       TEST_AUTH_TOKEN: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
-      TEST_CACHE_NAME: client-sdk-dotnet-${{ github.sha }}-${{ matrix.target-framework }}
 
     steps:
       - name: Get current time

--- a/tests/Integration/Momento.Sdk.Tests/CacheControlTest.cs
+++ b/tests/Integration/Momento.Sdk.Tests/CacheControlTest.cs
@@ -62,7 +62,7 @@ public class CacheControlTest : TestBase
     public async Task FlushCacheAsync_HappyPath()
     {
         string cacheName = Utils.TestCacheName();
-        await client.CreateCacheAsync(cacheName);
+        Utils.CreateCacheForTest(client, cacheName);
 
         try
         {
@@ -113,7 +113,7 @@ public class CacheControlTest : TestBase
     {
         // Create cache
         string cacheName = Utils.TestCacheName();
-        await client.CreateCacheAsync(cacheName);
+        Utils.CreateCacheForTest(client, cacheName);
 
         // Test cache exists
         ListCachesResponse result = await client.ListCachesAsync();
@@ -142,7 +142,7 @@ public class CacheControlTest : TestBase
         {
             String cacheName = Utils.TestCacheName();
             cacheNames.Add(cacheName);
-            await client.CreateCacheAsync(cacheName);
+            Utils.CreateCacheForTest(client, cacheName);
         }
         try
         {

--- a/tests/Integration/Momento.Sdk.Tests/Fixtures.cs
+++ b/tests/Integration/Momento.Sdk.Tests/Fixtures.cs
@@ -21,8 +21,7 @@ public class CacheClientFixture : IDisposable
     public CacheClientFixture()
     {
         AuthProvider = new EnvMomentoTokenProvider("TEST_AUTH_TOKEN");
-        CacheName = Environment.GetEnvironmentVariable("TEST_CACHE_NAME") ??
-            throw new NullReferenceException("TEST_CACHE_NAME environment variable must be set.");
+        CacheName = $"dotnet-integration-{Utils.NewGuidString()}";
         Client = new CacheClient(Configurations.Laptop.Latest(LoggerFactory.Create(builder =>
                 {
                     builder.AddSimpleConsole(options =>
@@ -35,8 +34,7 @@ public class CacheClientFixture : IDisposable
                     builder.SetMinimumLevel(LogLevel.Information);
                 })),
                 AuthProvider, defaultTtl: DefaultTtl);
-
-        var result = Client.CreateCacheAsync(CacheName).Result;
+        Utils.CreateCacheForTest(Client, CacheName);
     }
 
     public void Dispose()

--- a/tests/Integration/Momento.Sdk.Tests/Utils.cs
+++ b/tests/Integration/Momento.Sdk.Tests/Utils.cs
@@ -19,4 +19,13 @@ public static class Utils
     public static int WaitForItemToBeSet { get; } = 100;
 
     public static int WaitForInitialItemToExpire { get; } = 4900;
+
+    public static void CreateCacheForTest(ICacheClient cacheClient, string cacheName)
+    {
+        var result = cacheClient.CreateCacheAsync(cacheName).Result;
+        if (result is not (CreateCacheResponse.Success or CreateCacheResponse.CacheAlreadyExists))
+        {
+            throw new Exception($"Error when creating cache: {result}");
+        }
+    }
 }


### PR DESCRIPTION
Our tests currently require a TEST_CACHE environment variable, which
is not really useful and sets a pattern that other SDKs may need
to require this too in order to standardize on a way to launch them
(for example in the SDK canaries). The JS SDK does not work properly
if you set that environment variable, because it is intended for use
when running against a local mr2.

This commit removes the env var and dynamically creates a cache
name to use for the tests.
