### PR TITLE
fix: fix configuration settings for maxConn and gRPC channels

### DIFF
--- a/src/Momento.Sdk/CacheClient.cs
+++ b/src/Momento.Sdk/CacheClient.cs
@@ -55,12 +55,38 @@ public class CacheClient : ICacheClient
         this.dataClients = new List<ScsDataClient>();
         int minNumGrpcChannels = this.config.TransportStrategy.GrpcConfig.MinNumGrpcChannels;
         int currentMaxConcurrentRequests = this.config.TransportStrategy.MaxConcurrentRequests;
+        /**
+        * Client Configuration Logic:
+        * 
+        * At the time of writing, customers have two client configurations affecting the number of gRPC connections spawned:
+        * 
+        * 1. MinNumGrpcChannels: Determines the number of unique data clients to create based on the provided value. 
+        *    Each client eagerly creates one unique connection.
+        * 
+        * 2. MaxConcurrentRequests: Configures each channel or data client to create a unique connection dynamically/lazily
+        *    when 100 client concurrent requests are hit.
+        * 
+        * For example, if we have 2 channels and a client provides a value of 200 for MaxConcurrentRequests, we can create a
+        * maximum of 2 * (200 / 100) ≈ 4 unique connections.
+        * 
+        * Understanding Client Expectations:
+        * 
+        * The client presumes that MaxConcurrentRequests is applied at a global level rather than per channel or data client.
+        * While some clients might utilize minNumGrpcChannels, it is expected that such clients are few and not the majority.
+        * 
+        * Logic Implementation:
+        * 
+        * This logic ensures that we honor the maxConcurrentRequests provided by a client if they also provide minNumGrpcChannels,
+        * and we internally "distribute" the max concurrent requests evenly over all the channels. This makes sure that
+         * we honor client's maxConcurrentRequests at a global level, and also create the number of channels they request.
+         * If they do not explicitly provide the number of channels, we default to 1 with the max concurrent requests
+         * applied to that single channel.
+        */
         if (minNumGrpcChannels > 1)
         {
-            
-            int newMaxConcurrentRequests = (currentMaxConcurrentRequests / minNumGrpcChannels);
-            ITransportStrategy transportStrategy = this.config.TransportStrategy;
-            transportStrategy = transportStrategy.WithMaxConcurrentRequests(newMaxConcurrentRequests);
+            int newMaxConcurrentRequests = Math.Max(1, currentMaxConcurrentRequests / minNumGrpcChannels);
+            ITransportStrategy transportStrategy = this.config.TransportStrategy
+                                                        .WithMaxConcurrentRequests(newMaxConcurrentRequests);
             this.config = this.config.WithTransportStrategy(transportStrategy);
             _logger.LogWarning("Overriding maxConcurrentRequests for each gRPC channel to {}." +
                                " Min gRPC channels: {}, total maxConcurrentRequests: {}", newMaxConcurrentRequests,

--- a/src/Momento.Sdk/Config/Configurations.cs
+++ b/src/Momento.Sdk/Config/Configurations.cs
@@ -54,7 +54,7 @@ public class Configurations
             IRetryStrategy retryStrategy = new FixedCountRetryStrategy(finalLoggerFactory, maxAttempts: 3);
             ITransportStrategy transportStrategy = new StaticTransportStrategy(
                 loggerFactory: finalLoggerFactory,
-                maxConcurrentRequests: 100,
+                maxConcurrentRequests: 200, // max of 2 connections https://github.com/momentohq/client-sdk-dotnet/issues/460
                 grpcConfig: new StaticGrpcConfiguration(deadline: TimeSpan.FromMilliseconds(15000))
             );
             return new Laptop(finalLoggerFactory, retryStrategy, transportStrategy);
@@ -107,7 +107,7 @@ public class Configurations
                 IRetryStrategy retryStrategy = new FixedCountRetryStrategy(finalLoggerFactory, maxAttempts: 3);
                 ITransportStrategy transportStrategy = new StaticTransportStrategy(
                     loggerFactory: finalLoggerFactory,
-                    maxConcurrentRequests: 200,
+                    maxConcurrentRequests: 400, // max of 4 connections https://github.com/momentohq/client-sdk-dotnet/issues/460
                     grpcConfig: new StaticGrpcConfiguration(deadline: TimeSpan.FromMilliseconds(1100)));
                 return new Default(finalLoggerFactory, retryStrategy, transportStrategy);
             }

--- a/src/Momento.Sdk/Config/Transport/ITransportStrategy.cs
+++ b/src/Momento.Sdk/Config/Transport/ITransportStrategy.cs
@@ -30,6 +30,8 @@ public interface ITransportStrategy
 
     /// <summary>
     /// Copy constructor to update the maximum number of concurrent requests.
+    /// For every 100 concurrent requests, a new gRPC connection gets created. This value essentially limits
+    /// the number of connections you will get for your gRPC client.
     /// </summary>
     /// <param name="maxConcurrentRequests"></param>
     /// <returns>A new ITransportStrategy with the specified maxConccurrentRequests</returns>

--- a/tests/Integration/Momento.Sdk.Tests/CacheEagerConnectionTest.cs
+++ b/tests/Integration/Momento.Sdk.Tests/CacheEagerConnectionTest.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.Logging;
 using Momento.Sdk.Auth;
 using Momento.Sdk.Config;
+using Momento.Sdk.Config.Transport;
 
 namespace Momento.Sdk.Tests.Integration;
 
@@ -37,6 +38,21 @@ public class CacheEagerConnectionTest
         var client = new CacheClient(config, authProvider, defaultTtl);
     }
 
+    [Fact]
+    public void CacheClientConstructor_WithChannelsAndMaxConn_Success()
+    {
+        var config = Configurations.Laptop.Latest(loggerFactory);
+        IGrpcConfiguration grpcConfiguration = config.TransportStrategy.GrpcConfig;
+        grpcConfiguration = grpcConfiguration.WithMinNumGrpcChannels(10);
+        config = config.WithTransportStrategy(config.TransportStrategy
+                                                    .WithGrpcConfig(grpcConfiguration)
+                                                    .WithMaxConcurrentRequests(500));
+        // still 500; clients shouldn't know we are doing 500/10 magic internally
+        Assert.Equal(500, config.TransportStrategy.MaxConcurrentRequests);
+        Assert.Equal(10, config.TransportStrategy.GrpcConfig.MinNumGrpcChannels);
+        // just validating that we can construct the client wh
+        var client = new CacheClient(config, authProvider, defaultTtl);
+    }
 
     [Fact]
     public void CacheClientConstructor_EagerConnection_BadEndpoint()

--- a/tests/Integration/Momento.Sdk.Tests/CacheEagerConnectionTest.cs
+++ b/tests/Integration/Momento.Sdk.Tests/CacheEagerConnectionTest.cs
@@ -46,12 +46,13 @@ public class CacheEagerConnectionTest
         grpcConfiguration = grpcConfiguration.WithMinNumGrpcChannels(10);
         config = config.WithTransportStrategy(config.TransportStrategy
                                                     .WithGrpcConfig(grpcConfiguration)
-                                                    .WithMaxConcurrentRequests(500));
-        // still 500; clients shouldn't know we are doing 500/10 magic internally
-        Assert.Equal(500, config.TransportStrategy.MaxConcurrentRequests);
-        Assert.Equal(10, config.TransportStrategy.GrpcConfig.MinNumGrpcChannels);
+                                                    .WithMaxConcurrentRequests(2));
+       
         // just validating that we can construct the client wh
         var client = new CacheClient(config, authProvider, defaultTtl);
+        // still 2; clients shouldn't know we are doing 2/10 magic internally
+        Assert.Equal(2, config.TransportStrategy.MaxConcurrentRequests);
+        Assert.Equal(10, config.TransportStrategy.GrpcConfig.MinNumGrpcChannels);
     }
 
     [Fact]

--- a/tests/Unit/Momento.Sdk.Tests/ConfigTest.cs
+++ b/tests/Unit/Momento.Sdk.Tests/ConfigTest.cs
@@ -2,6 +2,8 @@ using System;
 using Momento.Sdk.Config;
 using Momento.Sdk.Config.Transport;
 using Xunit;
+using Xunit.Abstractions;
+using Xunit.Sdk;
 
 public class ConfigTest
 {

--- a/tests/Unit/Momento.Sdk.Tests/ConfigTest.cs
+++ b/tests/Unit/Momento.Sdk.Tests/ConfigTest.cs
@@ -2,8 +2,6 @@ using System;
 using Momento.Sdk.Config;
 using Momento.Sdk.Config.Transport;
 using Xunit;
-using Xunit.Abstractions;
-using Xunit.Sdk;
 
 public class ConfigTest
 {


### PR DESCRIPTION
The dotnet SDK exposes two configurations to clients ```MaxConcurrentRequests``` and ```MinNumGRPCChannels```. Both these configurations essentially impacts the number of connections that we open to the Momento server. Before this PR, a user could provide 10 gRPC channels as minimum, and 20 as maxConn, assuming that 20 maxConn will be a global setting. However, because how we wire our middleware, each channel would get 20 max concurrent requests as the setting. This PR resolves the conflict between the interplay of these settings (more details inline on code comments). 