### PR TITLE
feat: Add build for Unity platform

### DIFF
--- a/.github/workflows/on-push-to-release-branch.yaml
+++ b/.github/workflows/on-push-to-release-branch.yaml
@@ -65,7 +65,7 @@ jobs:
             rm -rf bin
             VERSION="${{ needs.release.outputs.version }}"
             echo "version: ${VERSION}"
-            dotnet build --configuration Release -f netframework20 -p:DefineConstants=USE_GRPC_WEB
+            dotnet build --configuration Release -f netstandard20 -p:DefineConstants=USE_GRPC_WEB
             DLL_FILE=./bin/Release/Momento.Sdk.${VERSION}.dll
             ARCHIVE_FILE_NAME=Momento.Sdk.Unity.${VERSION}.dll
             AUTH="Authorization: token ${{ secrets.MOMENTO_MACHINE_USER_GITHUB_TOKEN }}"

--- a/.github/workflows/on-push-to-release-branch.yaml
+++ b/.github/workflows/on-push-to-release-branch.yaml
@@ -57,3 +57,21 @@ jobs:
             dotnet pack -c Release -p:Version=${VERSION}
             dotnet nuget push ./bin/Release/Momento.Sdk.${VERSION}.nupkg --source https://api.nuget.org/v3/index.json --api-key=${{secrets.NUGET_API_KEY}}
           popd
+          
+      - name: Build for Unity
+        run: |
+          set -x
+          pushd src/Momento.Sdk
+            rm -rf bin
+            VERSION="${{ needs.release.outputs.version }}"
+            echo "version: ${VERSION}"
+            dotnet build --configuration Release -f netframework20 -p:DefineConstants=USE_GRPC_WEB
+            DLL_FILE=./bin/Release/Momento.Sdk.${VERSION}.dll
+            ARCHIVE_FILE_NAME=Momento.Sdk.Unity.${VERSION}.dll
+            AUTH="Authorization: token ${{ secrets.MOMENTO_MACHINE_USER_GITHUB_TOKEN }}"
+            LATEST_RELEASE=$(curl -sH "$AUTH" https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/tags/v${VERSION})
+            RELEASE_ID=$(echo $LATEST_RELEASE | jq -r .id)
+            GH_ASSET="https://uploads.github.com/repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}/assets?name=${ARCHIVE_FILE_NAME}"
+            echo $GH_ASSET
+            curl --data-binary @$DLL_FILE -H "$AUTH" -H "Content-Type: application/octet-stream" $GH_ASSET
+          popd

--- a/src/Momento.Sdk/Momento.Sdk.csproj
+++ b/src/Momento.Sdk/Momento.Sdk.csproj
@@ -64,7 +64,7 @@
 	  </PackageReference>
 	  <PackageReference Include="System.Threading" Version="4.3.0" />
 	</ItemGroup>
-	<ItemGroup Condition="'$(TargetFramework)' == 'net461'">
+	<ItemGroup Condition=" $(DefineConstants.Contains('USE_GRPC_WEB')) ">
 	  <!-- Because .NET Framework does not support HTTP/2, we fall back to gRPC-Web over HTTP/1.1 -->
 	  <PackageReference Include="Grpc.Net.Client.Web" Version="2.52.0" />
 	</ItemGroup>


### PR DESCRIPTION
This commit makes a small change to the csproj file that allows us
to specify DefineConstants=USE_GRPC_WEB for any target framework.
That allows us to do a netframework20 + grpc-web build, which is
necessary for compatibility with the Unity platform.

We also add a step to the release action to do a build with this
configuration, and attach it to the github release.
