### PR TITLE
feat: add topics

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -50,10 +50,10 @@ jobs:
         run: dotnet build
 
       - name: Unit Test
-        run: dotnet test --verbosity normal -f ${{ matrix.target-framework }} tests/Unit/Momento.Sdk.Tests
+        run: dotnet test --logger "console;verbosity=detailed" -f ${{ matrix.target-framework }} tests/Unit/Momento.Sdk.Tests
 
       - name: Integration Test
-        run: dotnet test --verbosity normal -f ${{ matrix.target-framework }} tests/Integration/Momento.Sdk.Tests
+        run: dotnet test --logger "console;verbosity=detailed" -f ${{ matrix.target-framework }} tests/Integration/Momento.Sdk.Tests
 
   build_examples:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: ubuntu-latest
+          - os: macos-latest
             target-framework: net6.0
           - os: windows-latest
             target-framework: net461

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,7 +9,9 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: macos-latest
+          - os: ubuntu-latest
+            target-framework: net6.0
+          - os: windows-latest
             target-framework: net6.0
           - os: windows-latest
             target-framework: net461

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -50,10 +50,10 @@ jobs:
         run: dotnet build
 
       - name: Unit Test
-        run: dotnet test --verbosity detailed -f ${{ matrix.target-framework }} tests/Unit/Momento.Sdk.Tests
+        run: dotnet test --verbosity normal -f ${{ matrix.target-framework }} tests/Unit/Momento.Sdk.Tests
 
       - name: Integration Test
-        run: dotnet test --verbosity detailed -f ${{ matrix.target-framework }} tests/Integration/Momento.Sdk.Tests
+        run: dotnet test --verbosity normal -f ${{ matrix.target-framework }} tests/Integration/Momento.Sdk.Tests
 
   build_examples:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -50,10 +50,10 @@ jobs:
         run: dotnet build
 
       - name: Unit Test
-        run: dotnet test -f ${{ matrix.target-framework }} tests/Unit/Momento.Sdk.Tests
+        run: dotnet test --verbosity detailed -f ${{ matrix.target-framework }} tests/Unit/Momento.Sdk.Tests
 
       - name: Integration Test
-        run: dotnet test -f ${{ matrix.target-framework }} tests/Integration/Momento.Sdk.Tests
+        run: dotnet test --verbosity detailed -f ${{ matrix.target-framework }} tests/Integration/Momento.Sdk.Tests
 
   build_examples:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -53,7 +53,7 @@ jobs:
         run: dotnet test -f ${{ matrix.target-framework }} tests/Unit/Momento.Sdk.Tests
 
       - name: Integration Test
-        run: dotnet test -f ${{ matrix.target-framework }} --filter PublishAndSubscribe_ByteArray_Succeeds tests/Integration/Momento.Sdk.Tests
+        run: dotnet test -f ${{ matrix.target-framework }} tests/Integration/Momento.Sdk.Tests
 
   build_examples:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -53,7 +53,7 @@ jobs:
         run: dotnet test -f ${{ matrix.target-framework }} tests/Unit/Momento.Sdk.Tests
 
       - name: Integration Test
-        run: dotnet test -f ${{ matrix.target-framework }} tests/Integration/Momento.Sdk.Tests
+        run: dotnet test -f ${{ matrix.target-framework }} --filter PublishAndSubscribe_ByteArray_Succeeds tests/Integration/Momento.Sdk.Tests
 
   build_examples:
     runs-on: ubuntu-latest

--- a/src/Momento.Sdk/Config/ITopicConfiguration.cs
+++ b/src/Momento.Sdk/Config/ITopicConfiguration.cs
@@ -1,0 +1,23 @@
+using Microsoft.Extensions.Logging;
+using Momento.Sdk.Config.Transport;
+
+namespace Momento.Sdk.Config;
+
+
+/// <summary>
+/// Contract for Topic SDK configurables.
+/// </summary>
+public interface ITopicConfiguration
+{
+    /// <inheritdoc cref="Microsoft.Extensions.Logging.ILoggerFactory" />
+    public ILoggerFactory LoggerFactory { get; }
+    /// <inheritdoc cref="Momento.Sdk.Config.Transport.ITransportStrategy" />
+    public ITransportStrategy TransportStrategy { get; }
+
+    /// <summary>
+    /// Creates a new instance of the Configuration object, updated to use the specified transport strategy.
+    /// </summary>
+    /// <param name="transportStrategy">This is responsible for configuring network tunables.</param>
+    /// <returns>Configuration object with custom transport strategy provided</returns>
+    public ITopicConfiguration WithTransportStrategy(ITransportStrategy transportStrategy);
+}

--- a/src/Momento.Sdk/Config/ITopicConfiguration.cs
+++ b/src/Momento.Sdk/Config/ITopicConfiguration.cs
@@ -12,12 +12,12 @@ public interface ITopicConfiguration
     /// <inheritdoc cref="Microsoft.Extensions.Logging.ILoggerFactory" />
     public ILoggerFactory LoggerFactory { get; }
     /// <inheritdoc cref="Momento.Sdk.Config.Transport.ITransportStrategy" />
-    public ITransportStrategy TransportStrategy { get; }
+    public ITopicTransportStrategy TransportStrategy { get; }
 
     /// <summary>
     /// Creates a new instance of the Configuration object, updated to use the specified transport strategy.
     /// </summary>
     /// <param name="transportStrategy">This is responsible for configuring network tunables.</param>
     /// <returns>Configuration object with custom transport strategy provided</returns>
-    public ITopicConfiguration WithTransportStrategy(ITransportStrategy transportStrategy);
+    public ITopicConfiguration WithTransportStrategy(ITopicTransportStrategy transportStrategy);
 }

--- a/src/Momento.Sdk/Config/TopicConfiguration.cs
+++ b/src/Momento.Sdk/Config/TopicConfiguration.cs
@@ -1,0 +1,50 @@
+using Microsoft.Extensions.Logging;
+using Momento.Sdk.Config.Transport;
+
+namespace Momento.Sdk.Config;
+
+/// <inheritdoc cref="Momento.Sdk.Config.ITopicConfiguration" />
+public class TopicConfiguration : ITopicConfiguration
+{
+    /// <inheritdoc />
+    public ILoggerFactory LoggerFactory { get; }
+
+    /// <inheritdoc />
+    public ITransportStrategy TransportStrategy { get; }
+
+    /// <summary>
+    /// Create a new instance of a Topic Configuration object with provided arguments: <see cref="Momento.Sdk.Config.ITopicConfiguration.TransportStrategy"/>, and <see cref="Momento.Sdk.Config.ITopicConfiguration.LoggerFactory"/>
+    /// </summary>
+    /// <param name="transportStrategy">This is responsible for configuring network tunables.</param>
+    /// <param name="loggerFactory">This is responsible for configuring logging.</param>
+    public TopicConfiguration(ILoggerFactory loggerFactory, ITransportStrategy transportStrategy)
+    {
+        LoggerFactory = loggerFactory;
+        TransportStrategy = transportStrategy;
+    }
+
+    /// <inheritdoc />
+    public ITopicConfiguration WithTransportStrategy(ITransportStrategy transportStrategy)
+    {
+        return new TopicConfiguration(LoggerFactory, transportStrategy);
+    }
+
+    /// <inheritdoc />
+    public override bool Equals(object obj)
+    {
+        if ((obj == null) || !this.GetType().Equals(obj.GetType()))
+        {
+            return false;
+        }
+
+        var other = (Configuration)obj;
+        return TransportStrategy.Equals(other.TransportStrategy) &&
+               LoggerFactory.Equals(other.LoggerFactory);
+    }
+
+    /// <inheritdoc />
+    public override int GetHashCode()
+    {
+        return base.GetHashCode();
+    }
+}

--- a/src/Momento.Sdk/Config/TopicConfiguration.cs
+++ b/src/Momento.Sdk/Config/TopicConfiguration.cs
@@ -10,21 +10,21 @@ public class TopicConfiguration : ITopicConfiguration
     public ILoggerFactory LoggerFactory { get; }
 
     /// <inheritdoc />
-    public ITransportStrategy TransportStrategy { get; }
+    public ITopicTransportStrategy TransportStrategy { get; }
 
     /// <summary>
     /// Create a new instance of a Topic Configuration object with provided arguments: <see cref="Momento.Sdk.Config.ITopicConfiguration.TransportStrategy"/>, and <see cref="Momento.Sdk.Config.ITopicConfiguration.LoggerFactory"/>
     /// </summary>
     /// <param name="transportStrategy">This is responsible for configuring network tunables.</param>
     /// <param name="loggerFactory">This is responsible for configuring logging.</param>
-    public TopicConfiguration(ILoggerFactory loggerFactory, ITransportStrategy transportStrategy)
+    public TopicConfiguration(ILoggerFactory loggerFactory, ITopicTransportStrategy transportStrategy)
     {
         LoggerFactory = loggerFactory;
         TransportStrategy = transportStrategy;
     }
 
     /// <inheritdoc />
-    public ITopicConfiguration WithTransportStrategy(ITransportStrategy transportStrategy)
+    public ITopicConfiguration WithTransportStrategy(ITopicTransportStrategy transportStrategy)
     {
         return new TopicConfiguration(LoggerFactory, transportStrategy);
     }

--- a/src/Momento.Sdk/Config/TopicConfigurations.cs
+++ b/src/Momento.Sdk/Config/TopicConfigurations.cs
@@ -1,0 +1,73 @@
+using System;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Momento.Sdk.Config.Transport;
+
+namespace Momento.Sdk.Config;
+
+/// <summary>
+/// Provide pre-built topic configurations.
+/// </summary>
+public class TopicConfigurations
+{
+    /// <summary>
+    /// Laptop config provides defaults suitable for a medium-to-high-latency environment. Permissive timeouts, retries, and
+    /// relaxed latency and throughput targets.
+    /// </summary>
+    public class Laptop : TopicConfiguration
+    {
+        private Laptop(ILoggerFactory loggerFactory, ITopicTransportStrategy transportStrategy) : base(loggerFactory,
+            transportStrategy)
+        {
+        }
+
+        /// <summary>
+        /// Provides the latest recommended configuration for a Laptop environment.
+        /// </summary>
+        /// <remark>
+        /// This configuration may change in future releases to take advantage of
+        /// improvements we identify for default configurations.
+        /// </remark>
+        /// <param name="loggerFactory"></param>
+        /// <returns></returns>
+        public static ITopicConfiguration latest(ILoggerFactory? loggerFactory = null)
+        {
+            var finalLoggerFactory = loggerFactory ?? NullLoggerFactory.Instance;
+            ITopicTransportStrategy transportStrategy = new StaticTopicTransportStrategy(
+                loggerFactory: finalLoggerFactory,
+                grpcConfig: new StaticGrpcConfiguration(deadline: TimeSpan.FromMilliseconds(15000))
+            );
+            return new Laptop(finalLoggerFactory, transportStrategy);
+        }
+    }
+
+    /// <summary>
+    /// Mobile config provides defaults suitable for a medium-to-high-latency mobile environment.
+    /// </summary>
+    public class Mobile : TopicConfiguration
+    {
+        private Mobile(ILoggerFactory loggerFactory, ITopicTransportStrategy transportStrategy) : base(loggerFactory,
+            transportStrategy)
+        {
+        }
+
+        /// <summary>
+        /// Provides the latest recommended configuration for a Mobile environment.
+        /// </summary>
+        /// <remark>
+        /// This configuration may change in future releases to take advantage of
+        /// improvements we identify for default configurations.
+        /// </remark>
+        /// <param name="loggerFactory"></param>
+        /// <returns></returns>
+        public static ITopicConfiguration latest(ILoggerFactory? loggerFactory = null)
+        {
+            var finalLoggerFactory = loggerFactory ?? NullLoggerFactory.Instance;
+            ITopicTransportStrategy transportStrategy = new StaticTopicTransportStrategy(
+                loggerFactory: finalLoggerFactory,
+                grpcConfig: new StaticGrpcConfiguration(deadline: TimeSpan.FromMilliseconds(15000))
+            );
+            return new Mobile(finalLoggerFactory, transportStrategy);
+        }
+    }
+}

--- a/src/Momento.Sdk/Config/Transport/ITopicTransportStrategy.cs
+++ b/src/Momento.Sdk/Config/Transport/ITopicTransportStrategy.cs
@@ -1,0 +1,29 @@
+using System;
+
+namespace Momento.Sdk.Config.Transport;
+
+/// <summary>
+/// This is responsible for configuring network tunables for topics.
+/// </summary>
+public interface ITopicTransportStrategy
+{
+    /// <summary>
+    /// Configures the low-level gRPC settings for the Momento Topic client's communication
+    /// with the Momento server.
+    /// </summary>
+    public IGrpcConfiguration GrpcConfig { get; }
+
+    /// <summary>
+    /// Copy constructor to update the gRPC configuration
+    /// </summary>
+    /// <param name="grpcConfig"></param>
+    /// <returns>A new ITransportStrategy with the specified grpcConfig</returns>
+    public ITopicTransportStrategy WithGrpcConfig(IGrpcConfiguration grpcConfig);
+
+    /// <summary>
+    /// Copy constructor to update the client timeout for publishing
+    /// </summary>
+    /// <param name="clientTimeout"></param>
+    /// <returns>A new ITransportStrategy with the specified client timeout</returns>
+    public ITopicTransportStrategy WithClientTimeout(TimeSpan clientTimeout);
+}

--- a/src/Momento.Sdk/Config/Transport/StaticTopicTransportStrategy.cs
+++ b/src/Momento.Sdk/Config/Transport/StaticTopicTransportStrategy.cs
@@ -1,0 +1,64 @@
+using System;
+using Microsoft.Extensions.Logging;
+
+namespace Momento.Sdk.Config.Transport;
+
+/// <summary>
+/// The simplest way to configure the transport layer for the Momento Topic client.
+/// Provides static values for the gRPC configuration.
+/// </summary>
+public class StaticTopicTransportStrategy : ITopicTransportStrategy
+{
+    private readonly ILoggerFactory _loggerFactory;
+
+    /// <inheritdoc />
+    public IGrpcConfiguration GrpcConfig { get; }
+
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="loggerFactory"></param>
+    /// <param name="grpcConfig">Configures how Momento Topic client interacts with the Momento service via gRPC</param>
+    public StaticTopicTransportStrategy(ILoggerFactory loggerFactory, IGrpcConfiguration grpcConfig)
+    {
+        _loggerFactory = loggerFactory;
+        GrpcConfig = grpcConfig;
+    }
+
+    /// <inheritdoc/>
+    public ITopicTransportStrategy WithGrpcConfig(IGrpcConfiguration grpcConfig)
+    {
+        return new StaticTopicTransportStrategy(_loggerFactory, grpcConfig);
+    }
+
+    /// <inheritdoc/>
+    public ITopicTransportStrategy WithClientTimeout(TimeSpan clientTimeout)
+    {
+        return new StaticTopicTransportStrategy(_loggerFactory, GrpcConfig.WithDeadline(clientTimeout));
+    }
+
+    /// <summary>
+    /// Test equality by value.
+    /// </summary>
+    /// <param name="obj"></param>
+    /// <returns></returns>
+    public override bool Equals(object obj)
+    {
+        if ((obj == null) || !this.GetType().Equals(obj.GetType()))
+        {
+            return false;
+        }
+
+        var other = (StaticTransportStrategy)obj;
+        return GrpcConfig.Equals(other.GrpcConfig);
+    }
+
+    /// <summary>
+    /// Trivial hash code implementation.
+    /// </summary>
+    /// <returns></returns>
+    public override int GetHashCode()
+    {
+        return base.GetHashCode();
+    }
+}

--- a/src/Momento.Sdk/ITopicClient.cs
+++ b/src/Momento.Sdk/ITopicClient.cs
@@ -1,4 +1,7 @@
 using System;
+#if NETSTANDARD2_0_OR_GREATER
+
+
 using System.Threading.Tasks;
 using Momento.Sdk.Responses;
 
@@ -63,3 +66,4 @@ public interface ITopicClient : IDisposable
     /// </returns>
     public Task<TopicSubscribeResponse> SubscribeAsync(string cacheName, string topicName, ulong? resumeAtSequenceNumber = null);
 }
+#endif

--- a/src/Momento.Sdk/ITopicClient.cs
+++ b/src/Momento.Sdk/ITopicClient.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Threading.Tasks;
+using Momento.Sdk.Responses;
+
+namespace Momento.Sdk;
+
+/// <summary>
+/// Minimum viable functionality of a topic client.
+/// </summary>
+public interface ITopicClient : IDisposable
+{
+    /// <summary>
+    /// Publish a value to a topic in a cache.
+    /// </summary>
+    /// <param name="cacheName">Name of the cache containing the topic.</param>
+    /// <param name="topicName">Name of the topic.</param>
+    /// <param name="value">The value to be published.</param>
+    /// <returns>
+    /// Task object representing the result of the publish operation. The
+    /// response object is resolved to a type-safe object of one of
+    /// the following subtypes:
+    /// <list type="bullet">
+    /// <item><description>TopicPublishResponse.Success</description></item>
+    /// <item><description>TopicPublishResponse.Error</description></item>
+    /// </list>
+    /// Pattern matching can be used to operate on the appropriate subtype.
+    /// For example:
+    /// <code>
+    /// if (response is TopicPublishResponse.Error errorResponse)
+    /// {
+    ///     // handle error as appropriate
+    /// }
+    /// </code>
+    /// </returns>
+    public Task<TopicPublishResponse> PublishAsync(string cacheName, string topicName, byte[] value);
+    
+    /// <inheritdoc cref="PublishAsync(string, string, byte[])"/>
+    public Task<TopicPublishResponse> PublishAsync(string cacheName, string topicName, string value);
+
+    /// <summary>
+    /// Subscribe to a topic. The returned value can be used to iterate over newly published messages on the topic.
+    /// </summary>
+    /// <param name="cacheName">Name of the cache containing the topic.</param>
+    /// <param name="topicName">Name of the topic.</param>
+    /// <param name="resumeAtSequenceNumber">The sequence number of the last message.
+    /// If provided, the client will attempt to start the stream from that sequence number.</param>
+    /// <returns>
+    /// Task object representing the result of the subscribe operation. The
+    /// response object is resolved to a type-safe object of one of
+    /// the following subtypes:
+    /// <list type="bullet">
+    /// <item><description>TopicSubscribeResponse.Subscription</description></item>
+    /// <item><description>TopicSubscribeResponse.Error</description></item>
+    /// </list>
+    /// Pattern matching can be used to operate on the appropriate subtype.
+    /// For example:
+    /// <code>
+    /// if (response is TopicSubscribeResponse.Error errorResponse)
+    /// {
+    ///     // handle error as appropriate
+    /// }
+    /// </code>
+    /// </returns>
+    public Task<TopicSubscribeResponse> SubscribeAsync(string cacheName, string topicName, ulong? resumeAtSequenceNumber = null);
+}

--- a/src/Momento.Sdk/Internal/LoggingUtils.cs
+++ b/src/Momento.Sdk/Internal/LoggingUtils.cs
@@ -379,6 +379,75 @@ namespace Momento.Sdk.Internal
             }
             return success;
         }
+        
+        /// <summary>
+        /// Logs a message at TRACE level that indicates that a topic request is about to be executed.
+        /// </summary>
+        /// <param name="logger"></param>
+        /// <param name="requestType"></param>
+        /// <param name="cacheName"></param>
+        /// <param name="topicName"></param>
+        public static void LogTraceExecutingTopicRequest(this ILogger logger, string requestType, string cacheName, string topicName)
+        {
+            if (logger.IsEnabled(LogLevel.Trace))
+            {
+                logger.LogTrace("Executing '{}' request: cacheName: {}; topicName: {}", requestType, cacheName, topicName);
+            }
+        }
+        
+        /// <summary>
+        /// Logs a message at TRACE level that indicates that a topic request resulted in an error.
+        /// </summary>
+        /// <typeparam name="TError"></typeparam>
+        /// <param name="logger"></param>
+        /// <param name="requestType"></param>
+        /// <param name="cacheName"></param>
+        /// <param name="topicName"></param>
+        /// <param name="error"></param>
+        /// <returns></returns>
+        public static TError LogTraceTopicRequestError<TError>(this ILogger logger, string requestType, string cacheName, string topicName, TError error)
+        {
+            if (logger.IsEnabled(LogLevel.Trace))
+            {
+                logger.LogTrace("An error occurred while executing a '{}' request: cacheName: {}; topicName: {}; error: {}", requestType, cacheName, topicName, error);
+            }
+            return error;
+        }
+
+        /// <summary>
+        /// /// Logs a message at TRACE level that indicates that a topic request resulted in a success.
+        /// </summary>
+        /// <typeparam name="TSuccess"></typeparam>
+        /// <param name="logger"></param>
+        /// <param name="requestType"></param>
+        /// <param name="cacheName"></param>
+        /// <param name="topicName"></param>
+        /// <param name="success"></param>
+        /// <returns></returns>
+        public static TSuccess LogTraceTopicRequestSuccess<TSuccess>(this ILogger logger, string requestType, string cacheName, string topicName, TSuccess success)
+        {
+
+            if (logger.IsEnabled(LogLevel.Trace))
+            {
+                logger.LogTrace("Successfully executed '{}' request: cacheName: {}; topicName: {}; success: {}", requestType, cacheName, topicName, success);
+            }
+            return success;
+        }
+        
+        /// <summary>
+        /// Logs a message at TRACE level that indicates that a topic message was received.
+        /// </summary>
+        /// <param name="logger"></param>
+        /// <param name="messageType"></param>
+        /// <param name="cacheName"></param>
+        /// <param name="topicName"></param>
+        public static void LogTraceTopicMessageReceived(this ILogger logger, string messageType, string cacheName, string topicName)
+        {
+            if (logger.IsEnabled(LogLevel.Trace))
+            {
+                logger.LogTrace("Received '{}' message on: cacheName: {}; topicName: {}", messageType, cacheName, topicName);
+            }
+        }
 
         private static string ReadableByteString(ByteString? input)
         {

--- a/src/Momento.Sdk/Internal/LoggingUtils.cs
+++ b/src/Momento.Sdk/Internal/LoggingUtils.cs
@@ -380,6 +380,8 @@ namespace Momento.Sdk.Internal
             return success;
         }
         
+#if NETSTANDARD2_0_OR_GREATER
+
         /// <summary>
         /// Logs a message at TRACE level that indicates that a topic request is about to be executed.
         /// </summary>
@@ -448,6 +450,7 @@ namespace Momento.Sdk.Internal
                 logger.LogTrace("Received '{}' message on: cacheName: {}; topicName: {}", messageType, cacheName, topicName);
             }
         }
+#endif
 
         private static string ReadableByteString(ByteString? input)
         {

--- a/src/Momento.Sdk/Internal/ScsTopicClient.cs
+++ b/src/Momento.Sdk/Internal/ScsTopicClient.cs
@@ -21,7 +21,7 @@ public class ScsTopicClientBase : IDisposable
 
     protected readonly CacheExceptionMapper _exceptionMapper;
 
-    public ScsTopicClientBase(IConfiguration config, string authToken, string endpoint)
+    public ScsTopicClientBase(ITopicConfiguration config, string authToken, string endpoint)
     {
         this.grpcManager = new TopicGrpcManager(config, authToken, endpoint);
         this.dataClientOperationTimeout = config.TransportStrategy.GrpcConfig.Deadline;
@@ -49,7 +49,7 @@ internal sealed class ScsTopicClient : ScsTopicClientBase
 {
     private readonly ILogger _logger;
 
-    public ScsTopicClient(IConfiguration config, string authToken, string endpoint)
+    public ScsTopicClient(ITopicConfiguration config, string authToken, string endpoint)
         : base(config, authToken, endpoint)
     {
         this._logger = config.LoggerFactory.CreateLogger<ScsTopicClient>();

--- a/src/Momento.Sdk/Internal/ScsTopicClient.cs
+++ b/src/Momento.Sdk/Internal/ScsTopicClient.cs
@@ -131,7 +131,7 @@ internal sealed class ScsTopicClient : ScsTopicClientBase
         }
 
         var response = new TopicSubscribeResponse.Subscription(
-            token => MoveNextAsync(subscription, token, cacheName, topicName),
+            cancellationToken => MoveNextAsync(subscription, cancellationToken, cacheName, topicName),
             subscription.Dispose);
         return _logger.LogTraceTopicRequestSuccess(RequestTypeTopicPublish, cacheName, topicName,
             response);

--- a/src/Momento.Sdk/Internal/ScsTopicClient.cs
+++ b/src/Momento.Sdk/Internal/ScsTopicClient.cs
@@ -147,7 +147,7 @@ internal sealed class ScsTopicClient : ScsTopicClientBase
 
         try
         {
-            while (await subscription.ResponseStream.MoveNext(cancellationToken).ConfigureAwait(false))
+            while (await subscription.ResponseStream.MoveNext(cancellationToken))
             {
                 var message = subscription.ResponseStream.Current;
 

--- a/src/Momento.Sdk/Internal/ScsTopicClient.cs
+++ b/src/Momento.Sdk/Internal/ScsTopicClient.cs
@@ -1,3 +1,5 @@
+#if NETSTANDARD2_0_OR_GREATER
+
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -197,3 +199,4 @@ internal sealed class ScsTopicClient : ScsTopicClientBase
         return null;
     }
 }
+#endif

--- a/src/Momento.Sdk/Internal/ScsTopicClient.cs
+++ b/src/Momento.Sdk/Internal/ScsTopicClient.cs
@@ -152,8 +152,20 @@ internal sealed class ScsTopicClient : ScsTopicClientBase
                 switch (message.KindCase)
                 {
                     case _SubscriptionItem.KindOneofCase.Item:
-                        _logger.LogTraceTopicMessageReceived("item", cacheName, topicName);
-                        return new TopicMessage.Item(message.Item);
+                        switch (message.Item.Value.KindCase)
+                        {
+                            case _TopicValue.KindOneofCase.Text:
+                                _logger.LogTraceTopicMessageReceived("text", cacheName, topicName);
+                                return new TopicMessage.Text(message.Item);
+                            case _TopicValue.KindOneofCase.Binary:
+                                _logger.LogTraceTopicMessageReceived("binary", cacheName, topicName);
+                                return new TopicMessage.Binary(message.Item);
+                            case _TopicValue.KindOneofCase.None:
+                            default:
+                                _logger.LogTraceTopicMessageReceived("unknown", cacheName, topicName);
+                                break;
+                        }
+                        break;
                     case _SubscriptionItem.KindOneofCase.Discontinuity:
                         _logger.LogTraceTopicMessageReceived("discontinuity", cacheName, topicName);
                         break;

--- a/src/Momento.Sdk/Internal/ScsTopicClient.cs
+++ b/src/Momento.Sdk/Internal/ScsTopicClient.cs
@@ -132,7 +132,7 @@ internal sealed class ScsTopicClient : ScsTopicClientBase
 
         var response = new TopicSubscribeResponse.Subscription(
             token => MoveNextAsync(subscription, token, cacheName, topicName),
-            () => subscription.Dispose());
+            subscription.Dispose);
         return _logger.LogTraceTopicRequestSuccess(RequestTypeTopicPublish, cacheName, topicName,
             response);
     }

--- a/src/Momento.Sdk/Internal/ScsTopicClient.cs
+++ b/src/Momento.Sdk/Internal/ScsTopicClient.cs
@@ -80,6 +80,7 @@ internal sealed class ScsTopicClient : ScsTopicClientBase
     }
 
     private const string RequestTypeTopicPublish = "TOPIC_PUBLISH";
+    private const string RequestTypeTopicSubscribe = "TOPIC_SUBSCRIBE";
 
     private async Task<TopicPublishResponse> SendPublish(string cacheName, string topicName, _TopicValue value)
     {
@@ -121,23 +122,23 @@ internal sealed class ScsTopicClient : ScsTopicClientBase
         AsyncServerStreamingCall<_SubscriptionItem> subscription;
         try
         {
-            _logger.LogTraceExecutingTopicRequest(RequestTypeTopicPublish, cacheName, topicName);
+            _logger.LogTraceExecutingTopicRequest(RequestTypeTopicSubscribe, cacheName, topicName);
             subscription = grpcManager.Client.subscribe(request, new CallOptions());
         }
         catch (Exception e)
         {
-            return _logger.LogTraceTopicRequestError(RequestTypeTopicPublish, cacheName, topicName,
+            return _logger.LogTraceTopicRequestError(RequestTypeTopicSubscribe, cacheName, topicName,
                 new TopicSubscribeResponse.Error(_exceptionMapper.Convert(e)));
         }
 
         var response = new TopicSubscribeResponse.Subscription(
-            cancellationToken => MoveNextAsync(subscription, cancellationToken, cacheName, topicName),
+            cancellationToken => GetNextRelevantMessageFromGrpcStreamAsync(subscription, cancellationToken, cacheName, topicName),
             subscription.Dispose);
-        return _logger.LogTraceTopicRequestSuccess(RequestTypeTopicPublish, cacheName, topicName,
+        return _logger.LogTraceTopicRequestSuccess(RequestTypeTopicSubscribe, cacheName, topicName,
             response);
     }
 
-    private async ValueTask<TopicMessage?> MoveNextAsync(AsyncServerStreamingCall<_SubscriptionItem> subscription,
+    private async ValueTask<TopicMessage?> GetNextRelevantMessageFromGrpcStreamAsync(AsyncServerStreamingCall<_SubscriptionItem> subscription,
         CancellationToken cancellationToken, string cacheName, string topicName)
     {
         if (cancellationToken.IsCancellationRequested)
@@ -158,10 +159,10 @@ internal sealed class ScsTopicClient : ScsTopicClientBase
                         {
                             case _TopicValue.KindOneofCase.Text:
                                 _logger.LogTraceTopicMessageReceived("text", cacheName, topicName);
-                                return new TopicMessage.Text(message.Item);
+                                return new TopicMessage.Text(message.Item.Value);
                             case _TopicValue.KindOneofCase.Binary:
                                 _logger.LogTraceTopicMessageReceived("binary", cacheName, topicName);
-                                return new TopicMessage.Binary(message.Item);
+                                return new TopicMessage.Binary(message.Item.Value);
                             case _TopicValue.KindOneofCase.None:
                             default:
                                 _logger.LogTraceTopicMessageReceived("unknown", cacheName, topicName);

--- a/src/Momento.Sdk/Internal/ScsTopicClient.cs
+++ b/src/Momento.Sdk/Internal/ScsTopicClient.cs
@@ -165,6 +165,7 @@ internal sealed class ScsTopicClient : ScsTopicClientBase
                                 _logger.LogTraceTopicMessageReceived("unknown", cacheName, topicName);
                                 break;
                         }
+
                         break;
                     case _SubscriptionItem.KindOneofCase.Discontinuity:
                         _logger.LogTraceTopicMessageReceived("discontinuity", cacheName, topicName);
@@ -187,7 +188,10 @@ internal sealed class ScsTopicClient : ScsTopicClientBase
         }
         catch (Exception e)
         {
-            return new TopicMessage.Error(_exceptionMapper.Convert(e));
+            var sdkException = _exceptionMapper.Convert(e);
+            return sdkException.ErrorCode == MomentoErrorCode.CANCELLED_ERROR
+                ? null
+                : new TopicMessage.Error(sdkException);
         }
 
         return null;

--- a/src/Momento.Sdk/Internal/ScsTopicClient.cs
+++ b/src/Momento.Sdk/Internal/ScsTopicClient.cs
@@ -1,0 +1,183 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Grpc.Core;
+using Microsoft.Extensions.Logging;
+using Momento.Protos.CacheClient.Pubsub;
+using Momento.Sdk.Config;
+using Momento.Sdk.Exceptions;
+using Momento.Sdk.Internal.ExtensionMethods;
+using Momento.Sdk.Responses;
+
+namespace Momento.Sdk.Internal;
+
+public class ScsTopicClientBase : IDisposable
+{
+    protected readonly TopicGrpcManager grpcManager;
+    private readonly TimeSpan dataClientOperationTimeout;
+    private readonly ILogger _logger;
+
+    protected readonly CacheExceptionMapper _exceptionMapper;
+
+    public ScsTopicClientBase(IConfiguration config, string authToken, string endpoint)
+    {
+        this.grpcManager = new TopicGrpcManager(config, authToken, endpoint);
+        this.dataClientOperationTimeout = config.TransportStrategy.GrpcConfig.Deadline;
+        this._logger = config.LoggerFactory.CreateLogger<ScsDataClient>();
+        this._exceptionMapper = new CacheExceptionMapper(config.LoggerFactory);
+    }
+
+    protected Metadata MetadataWithCache(string cacheName)
+    {
+        return new Metadata() { { "cache", cacheName } };
+    }
+
+    protected DateTime CalculateDeadline()
+    {
+        return DateTime.UtcNow.Add(dataClientOperationTimeout);
+    }
+
+    public void Dispose()
+    {
+        this.grpcManager.Dispose();
+    }
+}
+
+internal sealed class ScsTopicClient : ScsTopicClientBase
+{
+    private readonly ILogger _logger;
+
+    public ScsTopicClient(IConfiguration config, string authToken, string endpoint)
+        : base(config, authToken, endpoint)
+    {
+        this._logger = config.LoggerFactory.CreateLogger<ScsTopicClient>();
+    }
+
+    public async Task<TopicPublishResponse> Publish(string cacheName, string topicName, byte[] value)
+    {
+        var topicValue = new _TopicValue
+        {
+            Binary = value.ToByteString()
+        };
+        return await SendPublish(cacheName, topicName, topicValue);
+    }
+
+    public async Task<TopicPublishResponse> Publish(string cacheName, string topicName, string value)
+    {
+        var topicValue = new _TopicValue
+        {
+            Text = value
+        };
+        return await SendPublish(cacheName, topicName, topicValue);
+    }
+
+    public async Task<TopicSubscribeResponse> Subscribe(string cacheName, string topicName,
+        ulong? resumeAtTopicSequenceNumber = null)
+    {
+        return await SendSubscribe(cacheName, topicName, resumeAtTopicSequenceNumber);
+    }
+
+    private const string RequestTypeTopicPublish = "TOPIC_PUBLISH";
+
+    private async Task<TopicPublishResponse> SendPublish(string cacheName, string topicName, _TopicValue value)
+    {
+        _PublishRequest request = new _PublishRequest
+        {
+            CacheName = cacheName,
+            Topic = topicName,
+            Value = value
+        };
+
+        try
+        {
+            _logger.LogTraceExecutingTopicRequest(RequestTypeTopicPublish, cacheName, topicName);
+            await grpcManager.Client.publish(request, new CallOptions(deadline: CalculateDeadline()));
+        }
+        catch (Exception e)
+        {
+            return _logger.LogTraceTopicRequestError(RequestTypeTopicPublish, cacheName, topicName,
+                new TopicPublishResponse.Error(_exceptionMapper.Convert(e)));
+        }
+
+        return _logger.LogTraceTopicRequestSuccess(RequestTypeTopicPublish, cacheName, topicName,
+            new TopicPublishResponse.Success());
+    }
+
+    private async Task<TopicSubscribeResponse> SendSubscribe(string cacheName, string topicName,
+        ulong? resumeAtTopicSequenceNumber)
+    {
+        var request = new _SubscriptionRequest
+        {
+            CacheName = cacheName,
+            Topic = topicName
+        };
+        if (resumeAtTopicSequenceNumber != null)
+        {
+            request.ResumeAtTopicSequenceNumber = resumeAtTopicSequenceNumber.Value;
+        }
+
+        AsyncServerStreamingCall<_SubscriptionItem> subscription;
+        try
+        {
+            _logger.LogTraceExecutingTopicRequest(RequestTypeTopicPublish, cacheName, topicName);
+            subscription = grpcManager.Client.subscribe(request, new CallOptions());
+        }
+        catch (Exception e)
+        {
+            return _logger.LogTraceTopicRequestError(RequestTypeTopicPublish, cacheName, topicName,
+                new TopicSubscribeResponse.Error(_exceptionMapper.Convert(e)));
+        }
+
+        var response = new TopicSubscribeResponse.Subscription(
+            token => MoveNextAsync(subscription, token, cacheName, topicName),
+            () => subscription.Dispose());
+        return _logger.LogTraceTopicRequestSuccess(RequestTypeTopicPublish, cacheName, topicName,
+            response);
+    }
+
+    private async ValueTask<TopicMessage?> MoveNextAsync(AsyncServerStreamingCall<_SubscriptionItem> subscription,
+        CancellationToken cancellationToken, string cacheName, string topicName)
+    {
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return null;
+        }
+
+        try
+        {
+            while (await subscription.ResponseStream.MoveNext(cancellationToken).ConfigureAwait(false))
+            {
+                var message = subscription.ResponseStream.Current;
+
+                switch (message.KindCase)
+                {
+                    case _SubscriptionItem.KindOneofCase.Item:
+                        _logger.LogTraceTopicMessageReceived("item", cacheName, topicName);
+                        return new TopicMessage.Item(message.Item);
+                    case _SubscriptionItem.KindOneofCase.Discontinuity:
+                        _logger.LogTraceTopicMessageReceived("discontinuity", cacheName, topicName);
+                        break;
+                    case _SubscriptionItem.KindOneofCase.Heartbeat:
+                        _logger.LogTraceTopicMessageReceived("heartbeat", cacheName, topicName);
+                        break;
+                    case _SubscriptionItem.KindOneofCase.None:
+                        _logger.LogTraceTopicMessageReceived("none", cacheName, topicName);
+                        break;
+                    default:
+                        _logger.LogTraceTopicMessageReceived("unknown", cacheName, topicName);
+                        break;
+                }
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            return null;
+        }
+        catch (Exception e)
+        {
+            return new TopicMessage.Error(_exceptionMapper.Convert(e));
+        }
+
+        return null;
+    }
+}

--- a/src/Momento.Sdk/Internal/TopicGrpcManager.cs
+++ b/src/Momento.Sdk/Internal/TopicGrpcManager.cs
@@ -12,7 +12,6 @@ using Grpc.Net.Client.Web;
 #endif
 using Microsoft.Extensions.Logging;
 using Momento.Protos.CacheClient.Pubsub;
-using Momento.Protos.CachePing;
 using Momento.Sdk.Config;
 using Momento.Sdk.Config.Middleware;
 using Momento.Sdk.Config.Retry;
@@ -118,27 +117,9 @@ public class TopicGrpcManager : IDisposable
         var middlewares = new List<IMiddleware>
         {
             new HeaderMiddleware(config.LoggerFactory, headers),
-            new MaxConcurrentRequestsMiddleware(config.LoggerFactory, config.TransportStrategy.MaxConcurrentRequests)
         };
 
         var client = new Pubsub.PubsubClient(invoker);
-
-        if (config.TransportStrategy.EagerConnectionTimeout != null)
-        {
-            var eagerConnectionTimeout = config.TransportStrategy.EagerConnectionTimeout.Value;
-            _logger.LogDebug("TransportStrategy EagerConnection is enabled; attempting to connect to server");
-            var pingClient = new Ping.PingClient(channel);
-            try
-            {
-                pingClient.Ping(new _PingRequest(),
-                    new CallOptions(deadline: DateTime.UtcNow.Add(eagerConnectionTimeout)));
-            }
-            catch (RpcException)
-            {
-                _logger.LogWarning(
-                    "Failed to eagerly connect to the server; continuing with execution in case failure is recoverable later.");
-            }
-        }
 
         Client = new PubsubClientWithMiddleware(client, middlewares, headerTuples);
     }

--- a/src/Momento.Sdk/Internal/TopicGrpcManager.cs
+++ b/src/Momento.Sdk/Internal/TopicGrpcManager.cs
@@ -1,0 +1,152 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Grpc.Core;
+using Grpc.Net.Client;
+#if USE_GRPC_WEB
+using System.Net.Http;
+using Grpc.Net.Client.Web;
+#endif
+using Microsoft.Extensions.Logging;
+using Momento.Protos.CacheClient;
+using Momento.Protos.CacheClient.Pubsub;
+using Momento.Protos.CachePing;
+using Momento.Sdk.Config;
+using Momento.Sdk.Config.Middleware;
+using Momento.Sdk.Config.Retry;
+using Momento.Sdk.Internal.Middleware;
+using static System.Reflection.Assembly;
+
+namespace Momento.Sdk.Internal;
+
+public interface IPubsubClient
+{
+    public Task<_Empty> publish(_PublishRequest request, CallOptions callOptions);
+    public AsyncServerStreamingCall<_SubscriptionItem> subscribe(_SubscriptionRequest request, CallOptions callOptions);
+}
+
+public class PubsubClientWithMiddleware : IPubsubClient
+{
+    private readonly Pubsub.PubsubClient _generatedClient;
+    private readonly IList<IMiddleware> _middlewares;
+    private readonly IList<Tuple<string, string>> _headers;
+
+    public PubsubClientWithMiddleware(Pubsub.PubsubClient generatedClient, IList<IMiddleware> middlewares,
+        IList<Tuple<string, string>> headers)
+    {
+        _generatedClient = generatedClient;
+        _middlewares = middlewares;
+        _headers = headers;
+    }
+
+    public async Task<_Empty> publish(_PublishRequest request, CallOptions callOptions)
+    {
+        var wrapped = await _middlewares.WrapRequest(request, callOptions, (r, o) => _generatedClient.PublishAsync(r, o));
+        return await wrapped.ResponseAsync;
+    }
+
+    public AsyncServerStreamingCall<_SubscriptionItem> subscribe(_SubscriptionRequest request, CallOptions callOptions)
+    {
+        // Middleware is not currently compatible with gRPC streaming calls,
+        // so we manually add the headers to ensure the call has the auth token.
+        var callHeaders = callOptions.Headers ?? new Metadata();
+        if (callOptions.Headers == null)
+        {
+            callOptions = callOptions.WithHeaders(new Metadata());
+        }
+        
+        foreach (var header in _headers)
+        {
+            callHeaders.Add(header.Item1, header.Item2);
+        }
+
+        return _generatedClient.Subscribe(request, callOptions.WithHeaders(callHeaders));
+    }
+}
+
+public class TopicGrpcManager : IDisposable
+{
+    private readonly GrpcChannel channel;
+
+    public readonly IPubsubClient Client;
+
+#if USE_GRPC_WEB
+    private static readonly string Moniker = "dotnet-web";
+#else
+    private static readonly string Moniker = "dotnet";
+#endif
+    private readonly string version =
+        $"{Moniker}:{GetAssembly(typeof(Responses.CacheGetResponse)).GetName().Version.ToString()}";
+
+    // Some System.Environment.Version remarks to be aware of
+    // https://learn.microsoft.com/en-us/dotnet/api/system.environment.version?view=netstandard-2.0#remarks
+    private readonly string runtimeVersion = $"{Moniker}:{Environment.Version}";
+    private readonly ILogger _logger;
+
+    internal TopicGrpcManager(IConfiguration config, string authToken, string endpoint)
+    {
+#if USE_GRPC_WEB
+        // Note: all web SDK requests are routed to a `web.` subdomain to allow us flexibility on the server
+        endpoint = $"web.{endpoint}";
+#endif
+        var uri = $"https://{endpoint}";
+        var channelOptions = config.TransportStrategy.GrpcConfig.GrpcChannelOptions;
+        if (channelOptions.LoggerFactory == null)
+        {
+            channelOptions.LoggerFactory = config.LoggerFactory;
+        }
+
+        channelOptions.Credentials = ChannelCredentials.SecureSsl;
+#if USE_GRPC_WEB
+        channelOptions.HttpHandler = new GrpcWebHandler(new HttpClientHandler());
+#endif
+
+        channel = GrpcChannel.ForAddress(uri, channelOptions);
+        var headerTuples = new List<Tuple<string, string>>
+        {
+            new(Header.AuthorizationKey, authToken), new(Header.AgentKey, version),
+            new(Header.RuntimeVersionKey, runtimeVersion)
+        };
+        var headers = headerTuples.Select(tuple => new Header(name: tuple.Item1, value: tuple.Item2)).ToList();
+
+        _logger = config.LoggerFactory.CreateLogger<TopicGrpcManager>();
+
+        var invoker = channel.CreateCallInvoker();
+        
+        var middlewares = config.Middlewares.Concat(
+            new List<IMiddleware> {
+                new RetryMiddleware(config.LoggerFactory, config.RetryStrategy),
+                new HeaderMiddleware(config.LoggerFactory, headers),
+                new MaxConcurrentRequestsMiddleware(config.LoggerFactory, config.TransportStrategy.MaxConcurrentRequests)
+            }
+        ).ToList();
+
+        var client = new Pubsub.PubsubClient(invoker);
+
+        if (config.TransportStrategy.EagerConnectionTimeout != null)
+        {
+            var eagerConnectionTimeout = config.TransportStrategy.EagerConnectionTimeout.Value;
+            _logger.LogDebug("TransportStrategy EagerConnection is enabled; attempting to connect to server");
+            var pingClient = new Ping.PingClient(channel);
+            try
+            {
+                pingClient.Ping(new _PingRequest(),
+                    new CallOptions(deadline: DateTime.UtcNow.Add(eagerConnectionTimeout)));
+            }
+            catch (RpcException)
+            {
+                _logger.LogWarning(
+                    "Failed to eagerly connect to the server; continuing with execution in case failure is recoverable later.");
+            }
+        }
+
+        Client = new PubsubClientWithMiddleware(client, middlewares, headerTuples);
+    }
+
+    public void Dispose()
+    {
+        channel.Dispose();
+        GC.SuppressFinalize(this);
+    }
+}

--- a/src/Momento.Sdk/Internal/TopicGrpcManager.cs
+++ b/src/Momento.Sdk/Internal/TopicGrpcManager.cs
@@ -1,3 +1,5 @@
+#if NETSTANDARD2_0_OR_GREATER
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -9,7 +11,6 @@ using System.Net.Http;
 using Grpc.Net.Client.Web;
 #endif
 using Microsoft.Extensions.Logging;
-using Momento.Protos.CacheClient;
 using Momento.Protos.CacheClient.Pubsub;
 using Momento.Protos.CachePing;
 using Momento.Sdk.Config;
@@ -150,3 +151,4 @@ public class TopicGrpcManager : IDisposable
         GC.SuppressFinalize(this);
     }
 }
+#endif

--- a/src/Momento.Sdk/Internal/TopicGrpcManager.cs
+++ b/src/Momento.Sdk/Internal/TopicGrpcManager.cs
@@ -85,7 +85,7 @@ public class TopicGrpcManager : IDisposable
     private readonly string runtimeVersion = $"{Moniker}:{Environment.Version}";
     private readonly ILogger _logger;
 
-    internal TopicGrpcManager(IConfiguration config, string authToken, string endpoint)
+    internal TopicGrpcManager(ITopicConfiguration config, string authToken, string endpoint)
     {
 #if USE_GRPC_WEB
         // Note: all web SDK requests are routed to a `web.` subdomain to allow us flexibility on the server
@@ -114,14 +114,12 @@ public class TopicGrpcManager : IDisposable
         _logger = config.LoggerFactory.CreateLogger<TopicGrpcManager>();
 
         var invoker = channel.CreateCallInvoker();
-        
-        var middlewares = config.Middlewares.Concat(
-            new List<IMiddleware> {
-                new RetryMiddleware(config.LoggerFactory, config.RetryStrategy),
-                new HeaderMiddleware(config.LoggerFactory, headers),
-                new MaxConcurrentRequestsMiddleware(config.LoggerFactory, config.TransportStrategy.MaxConcurrentRequests)
-            }
-        ).ToList();
+
+        var middlewares = new List<IMiddleware>
+        {
+            new HeaderMiddleware(config.LoggerFactory, headers),
+            new MaxConcurrentRequestsMiddleware(config.LoggerFactory, config.TransportStrategy.MaxConcurrentRequests)
+        };
 
         var client = new Pubsub.PubsubClient(invoker);
 

--- a/src/Momento.Sdk/Momento.Sdk.csproj
+++ b/src/Momento.Sdk/Momento.Sdk.csproj
@@ -54,7 +54,8 @@
 	</ItemGroup>
 	<ItemGroup>
 	  <PackageReference Include="Grpc.Net.Client" Version="2.49.0" />
-	  <PackageReference Include="Momento.Protos" Version="0.64.1" />
+	  <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
+	  <PackageReference Include="Momento.Protos" Version="0.77.0" />
 	  <PackageReference Include="JWT" Version="9.0.3" />
 	  <PackageReference Include="System.Threading.Channels" Version="6.0.0" />
 	  <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />

--- a/src/Momento.Sdk/Responses/TopicMessage.cs
+++ b/src/Momento.Sdk/Responses/TopicMessage.cs
@@ -36,40 +36,22 @@ namespace Momento.Sdk.Responses;
 public abstract class TopicMessage
 {
     /// <summary>
-    /// The binary value of this message, if present.
-    /// </summary>
-    public virtual byte[]? ValueByteArray => null;
-
-    /// <summary>
-    /// The text value of this message, if present.
-    /// </summary>
-    public virtual string? ValueString => null;
-
-    /// <summary>
     /// A topic message containing a text value.
     /// </summary>
     public class Text : TopicMessage
     {
-        public Text(_TopicItem topicItem)
+        /// <summary>
+        /// A topic message containing a text value.
+        /// </summary>
+        public Text(_TopicValue topicValue)
         {
-            Value = topicItem.Value.Text;
-            TopicSequenceNumber = topicItem.TopicSequenceNumber;
+            Value = topicValue.Text;
         }
 
         /// <summary>
         /// The text value of this message.
         /// </summary>
         public string Value { get; }
-        
-        /// <summary>
-        /// The text value of this message.
-        /// </summary>
-        public override string ValueString => Value;
-        
-        /// <summary>
-        /// The number of this message in the topic sequence.
-        /// </summary>
-        public ulong TopicSequenceNumber { get; }
     }
     
     /// <summary>
@@ -77,26 +59,18 @@ public abstract class TopicMessage
     /// </summary>
     public class Binary : TopicMessage
     {
-        public Binary(_TopicItem topicItem)
+        /// <summary>
+        /// A topic message containing a binary value.
+        /// </summary>
+        public Binary(_TopicValue topicValue)
         {
-            Value = topicItem.Value.Binary.ToByteArray();
-            TopicSequenceNumber = topicItem.TopicSequenceNumber;
+            Value = topicValue.Binary.ToByteArray();
         }
 
         /// <summary>
         /// The binary value of this message.
         /// </summary>
         public byte[] Value { get; }
-        
-        /// <summary>
-        /// The binary value of this message.
-        /// </summary>
-        public override byte[] ValueByteArray => Value;
-
-        /// <summary>
-        /// The number of this message in the topic sequence.
-        /// </summary>
-        public ulong TopicSequenceNumber { get; }
     }
 
     /// <include file="../docs.xml" path='docs/class[@name="Error"]/description/*' />

--- a/src/Momento.Sdk/Responses/TopicMessage.cs
+++ b/src/Momento.Sdk/Responses/TopicMessage.cs
@@ -13,9 +13,13 @@ namespace Momento.Sdk.Responses;
 /// Pattern matching can be used to operate on the appropriate subtype.
 /// For example:
 /// <code>
-/// if (message is TopicMessage.Item item)
+/// if (message is TopicMessage.Text text)
 /// {
-///     return item.ValueString();
+///     return text.Value();
+/// }
+/// else if (message is TopicMessage.Binary binary)
+/// {
+///     return text.Value();
 /// }
 /// else if (message is TopicMessage.Error error)
 /// {
@@ -30,37 +34,51 @@ namespace Momento.Sdk.Responses;
 public abstract class TopicMessage
 {
     /// <summary>
-    /// A topic message containing a value. If the value is a string, ValueString
-    /// will return it. If the value is binary, ValueByteArray will return it.
+    /// A topic message containing a text value.
     /// </summary>
-    public class Item : TopicMessage
+    public class Text : TopicMessage
     {
-        private readonly _TopicValue _value;
+        public Text(_TopicItem topicItem)
+        {
+            Value = topicItem.Value.Text;
+            TopicSequenceNumber = topicItem.TopicSequenceNumber;
+        }
 
         /// <summary>
-        /// Constructs an Item from an internal _TopicItem
+        /// The text value of this message.
         /// </summary>
-        /// <param name="topicItem">Containing the binary or string value.</param>
-        public Item(_TopicItem topicItem)
+        public string Value { get; }
+        
+        /// <summary>
+        /// The number of this message in the topic sequence.
+        /// </summary>
+        public ulong TopicSequenceNumber { get; }
+    }
+    
+    /// <summary>
+    /// A topic message containing a binary value.
+    /// </summary>
+    public class Binary : TopicMessage
+    {
+        private byte[] _value;
+        public Binary(_TopicItem topicItem)
         {
-            _value = topicItem.Value;
+            _value = topicItem.Value.Binary.ToByteArray();
             TopicSequenceNumber = topicItem.TopicSequenceNumber;
+        }
+
+        /// <summary>
+        /// The binary value of this message.
+        /// </summary>
+        public byte[] Value()
+        {
+            return _value;
         }
         
         /// <summary>
         /// The number of this message in the topic sequence.
         /// </summary>
         public ulong TopicSequenceNumber { get; }
-
-        /// <summary>
-        /// The binary value of this message, if present.
-        /// </summary>
-        public byte[] ValueByteArray => _value.Binary.ToByteArray();
-        
-        /// <summary>
-        /// The string value of this message, if present.
-        /// </summary>
-        public string ValueString => _value.Text;
     }
 
     /// <include file="../docs.xml" path='docs/class[@name="Error"]/description/*' />

--- a/src/Momento.Sdk/Responses/TopicMessage.cs
+++ b/src/Momento.Sdk/Responses/TopicMessage.cs
@@ -36,6 +36,16 @@ namespace Momento.Sdk.Responses;
 public abstract class TopicMessage
 {
     /// <summary>
+    /// The binary value of this message, if present.
+    /// </summary>
+    public virtual byte[]? ValueByteArray => null;
+
+    /// <summary>
+    /// The text value of this message, if present.
+    /// </summary>
+    public virtual string? ValueString => null;
+
+    /// <summary>
     /// A topic message containing a text value.
     /// </summary>
     public class Text : TopicMessage
@@ -50,6 +60,11 @@ public abstract class TopicMessage
         /// The text value of this message.
         /// </summary>
         public string Value { get; }
+        
+        /// <summary>
+        /// The text value of this message.
+        /// </summary>
+        public override string ValueString => Value;
         
         /// <summary>
         /// The number of this message in the topic sequence.
@@ -72,6 +87,11 @@ public abstract class TopicMessage
         /// The binary value of this message.
         /// </summary>
         public byte[] Value { get; }
+        
+        /// <summary>
+        /// The binary value of this message.
+        /// </summary>
+        public override byte[] ValueByteArray => Value;
 
         /// <summary>
         /// The number of this message in the topic sequence.

--- a/src/Momento.Sdk/Responses/TopicMessage.cs
+++ b/src/Momento.Sdk/Responses/TopicMessage.cs
@@ -62,21 +62,17 @@ public abstract class TopicMessage
     /// </summary>
     public class Binary : TopicMessage
     {
-        private byte[] _value;
         public Binary(_TopicItem topicItem)
         {
-            _value = topicItem.Value.Binary.ToByteArray();
+            Value = topicItem.Value.Binary.ToByteArray();
             TopicSequenceNumber = topicItem.TopicSequenceNumber;
         }
 
         /// <summary>
         /// The binary value of this message.
         /// </summary>
-        public byte[] Value()
-        {
-            return _value;
-        }
-        
+        public byte[] Value { get; }
+
         /// <summary>
         /// The number of this message in the topic sequence.
         /// </summary>

--- a/src/Momento.Sdk/Responses/TopicMessage.cs
+++ b/src/Momento.Sdk/Responses/TopicMessage.cs
@@ -1,0 +1,93 @@
+using Momento.Protos.CacheClient.Pubsub;
+using Momento.Sdk.Exceptions;
+
+namespace Momento.Sdk.Responses;
+
+/// <summary>
+/// Parent type for a topic message. The message is resolved to a type-safe
+/// object of one of the following subtypes:
+/// <list type="bullet">
+/// <item><description>TopicMessage.Item</description></item>
+/// <item><description>TopicMessage.Error</description></item>
+/// </list>
+/// Pattern matching can be used to operate on the appropriate subtype.
+/// For example:
+/// <code>
+/// if (message is TopicMessage.Item item)
+/// {
+///     return item.ValueString();
+/// }
+/// else if (message is TopicMessage.Error error)
+/// {
+///     // handle error as appropriate
+/// }
+/// else
+/// {
+///     // handle unexpected response
+/// }
+/// </code>
+/// </summary>
+public abstract class TopicMessage
+{
+    /// <summary>
+    /// A topic message containing a value. If the value is a string, ValueString
+    /// will return it. If the value is binary, ValueByteArray will return it.
+    /// </summary>
+    public class Item : TopicMessage
+    {
+        private readonly _TopicValue _value;
+
+        /// <summary>
+        /// Constructs an Item from an internal _TopicItem
+        /// </summary>
+        /// <param name="topicItem">Containing the binary or string value.</param>
+        public Item(_TopicItem topicItem)
+        {
+            _value = topicItem.Value;
+            TopicSequenceNumber = topicItem.TopicSequenceNumber;
+        }
+        
+        /// <summary>
+        /// The number of this message in the topic sequence.
+        /// </summary>
+        public ulong TopicSequenceNumber { get; }
+
+        /// <summary>
+        /// The binary value of this message, if present.
+        /// </summary>
+        public byte[] ValueByteArray => _value.Binary.ToByteArray();
+        
+        /// <summary>
+        /// The string value of this message, if present.
+        /// </summary>
+        public string ValueString => _value.Text;
+    }
+
+    /// <include file="../docs.xml" path='docs/class[@name="Error"]/description/*' />
+    public class Error : TopicMessage, IError
+    {
+        private readonly SdkException _error;
+
+        /// <include file="../docs.xml" path='docs/class[@name="Error"]/constructor/*' />
+        public Error(SdkException error)
+        {
+            _error = error;
+        }
+
+        /// <inheritdoc />
+        public SdkException InnerException => _error;
+
+        /// <inheritdoc />
+        public MomentoErrorCode ErrorCode => _error.ErrorCode;
+
+        /// <inheritdoc />
+        public string Message => $"{_error.MessageWrapper}: {_error.Message}";
+
+        /// <inheritdoc />
+        public override string ToString()
+        {
+            return $"{base.ToString()}: {this.Message}";
+        }
+
+    }
+}

--- a/src/Momento.Sdk/Responses/TopicMessage.cs
+++ b/src/Momento.Sdk/Responses/TopicMessage.cs
@@ -1,3 +1,5 @@
+#if NETSTANDARD2_0_OR_GREATER
+
 using Momento.Protos.CacheClient.Pubsub;
 using Momento.Sdk.Exceptions;
 
@@ -109,3 +111,4 @@ public abstract class TopicMessage
 
     }
 }
+#endif

--- a/src/Momento.Sdk/Responses/TopicPublishResponse.cs
+++ b/src/Momento.Sdk/Responses/TopicPublishResponse.cs
@@ -1,0 +1,62 @@
+using Momento.Sdk.Exceptions;
+
+namespace Momento.Sdk.Responses;
+
+/// <summary>
+/// Parent response type for a topic publish request. The
+/// response object is resolved to a type-safe object of one of
+/// the following subtypes:
+/// <list type="bullet">
+/// <item><description>TopicPublishResponse.Success</description></item>
+/// <item><description>TopicPublishResponse.Error</description></item>
+/// </list>
+/// Pattern matching can be used to operate on the appropriate subtype.
+/// For example:
+/// <code>
+/// if (response is TopicPublishResponse.Success successResponse)
+/// {
+///     // handle success as appropriate
+/// }
+/// else if (response is TopicPublishResponse.Error errorResponse)
+/// {
+///     // handle error as appropriate
+/// }
+/// else
+/// {
+///     // handle unexpected response
+/// }
+/// </code>
+/// </summary>
+public abstract class TopicPublishResponse
+{
+    /// <include file="../docs.xml" path='docs/class[@name="Success"]/description/*' />
+    public class Success : TopicPublishResponse {}
+
+    /// <include file="../docs.xml" path='docs/class[@name="Error"]/description/*' />
+    public class Error : TopicPublishResponse, IError
+    {
+        private readonly SdkException _error;
+
+        /// <include file="../docs.xml" path='docs/class[@name="Error"]/constructor/*' />
+        public Error(SdkException error)
+        {
+            _error = error;
+        }
+
+        /// <inheritdoc />
+        public SdkException InnerException => _error;
+
+        /// <inheritdoc />
+        public MomentoErrorCode ErrorCode => _error.ErrorCode;
+
+        /// <inheritdoc />
+        public string Message => $"{_error.MessageWrapper}: {_error.Message}";
+
+        /// <inheritdoc />
+        public override string ToString()
+        {
+            return $"{base.ToString()}: {this.Message}";
+        }
+
+    }
+}

--- a/src/Momento.Sdk/Responses/TopicPublishResponse.cs
+++ b/src/Momento.Sdk/Responses/TopicPublishResponse.cs
@@ -1,3 +1,5 @@
+#if NETSTANDARD2_0_OR_GREATER
+
 using Momento.Sdk.Exceptions;
 
 namespace Momento.Sdk.Responses;
@@ -60,3 +62,4 @@ public abstract class TopicPublishResponse
 
     }
 }
+#endif

--- a/src/Momento.Sdk/Responses/TopicSubscribeResponse.cs
+++ b/src/Momento.Sdk/Responses/TopicSubscribeResponse.cs
@@ -100,7 +100,8 @@ public abstract class TopicSubscribeResponse
             var nextMessage = await _moveNextFunction.Invoke(_cancellationToken);
             switch (nextMessage)
             {
-                case TopicMessage.Item:
+                case TopicMessage.Text:
+                case TopicMessage.Binary:
                     Current = nextMessage;
                     return true;
                 case TopicMessage.Error:

--- a/src/Momento.Sdk/Responses/TopicSubscribeResponse.cs
+++ b/src/Momento.Sdk/Responses/TopicSubscribeResponse.cs
@@ -1,0 +1,149 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Momento.Sdk.Exceptions;
+
+namespace Momento.Sdk.Responses;
+
+/// <summary>
+/// Parent response type for a topic subscribe request. The
+/// response object is resolved to a type-safe object of one of
+/// the following subtypes:
+/// <list type="bullet">
+/// <item><description>TopicSubscribeResponse.Subscription</description></item>
+/// <item><description>TopicSubscribeResponse.Error</description></item>
+/// </list>
+/// Pattern matching can be used to operate on the appropriate subtype.
+/// For example:
+/// <code>
+/// if (response is TopicSubscribeResponse.Subscription subscription)
+/// {
+///     await foreach (var item in subscription.WithCancellation(ct))
+///     {
+///         // iterate through the messages
+///     }
+/// }
+/// else if (response is TopicSubscribeResponse.Error error)
+/// {
+///     // handle error as appropriate
+/// }
+/// else
+/// {
+///     // handle unexpected response
+/// }
+/// </code>
+/// </summary>
+public abstract class TopicSubscribeResponse
+{
+    /// <summary>
+    /// A subscription to a Momento topic. As an IAsyncEnumerable, it can be iterated over to read messages from the
+    /// topic. The iterator will return a TopicMessage representing a message or error from the stream, or null if the
+    /// stream is closed.
+    /// </summary>
+    public class Subscription : TopicSubscribeResponse, IDisposable, IAsyncEnumerable<TopicMessage?>
+    {
+        private readonly Func<CancellationToken, ValueTask<TopicMessage?>> _moveNextFunction;
+        private readonly Action _disposalAction;
+
+        /// <summary>
+        /// Constructs a Subscription with a wrapped topic iterator and an action to dispose of it.
+        /// </summary>
+        public Subscription(Func<CancellationToken, ValueTask<TopicMessage?>> moveNextFunction, Action disposalAction)
+        {
+            _moveNextFunction = moveNextFunction;
+            _disposalAction = disposalAction;
+        }
+
+        /// <summary>
+        /// Gets the enumerator for this topic. This subscription represents a single view on a topic, so multiple
+        /// enumerators will interfere with each other.
+        /// </summary>
+        public IAsyncEnumerator<TopicMessage?> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new TopicMessageEnumerator(_moveNextFunction, _disposalAction, cancellationToken);
+        }
+
+
+        /// <summary>
+        /// Unsubscribe from this topic.
+        /// </summary>
+        public void Dispose()
+        {
+            _disposalAction.Invoke();
+        }
+    }
+
+    private class TopicMessageEnumerator : IAsyncEnumerator<TopicMessage?>
+    {
+        private readonly Func<CancellationToken, ValueTask<TopicMessage?>> _moveNextFunction;
+        private readonly Action _disposalAction;
+        private readonly CancellationToken _cancellationToken;
+
+        public TopicMessageEnumerator(Func<CancellationToken, ValueTask<TopicMessage?>> moveNextFunction, Action disposalAction, CancellationToken cancellationToken)
+        {
+            _moveNextFunction = moveNextFunction;
+            _disposalAction = disposalAction;
+            _cancellationToken = cancellationToken;
+        }
+
+        public TopicMessage? Current { get; private set; }
+
+        public async ValueTask<bool> MoveNextAsync()
+        {
+            if (_cancellationToken.IsCancellationRequested)
+            {
+                Current = null;
+                return false;
+            }
+            
+            var nextMessage = await _moveNextFunction.Invoke(_cancellationToken);
+            switch (nextMessage)
+            {
+                case TopicMessage.Item:
+                    Current = nextMessage;
+                    return true;
+                case TopicMessage.Error:
+                    Current = nextMessage;
+                    return true;
+                default:
+                    Current = null;
+                    return false;
+            }
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            _disposalAction.Invoke();
+
+            return new ValueTask();
+        }
+    }
+
+    /// <include file="../docs.xml" path='docs/class[@name="Error"]/description/*' />
+    public class Error : TopicSubscribeResponse, IError
+    {
+        private readonly SdkException _error;
+
+        /// <include file="../docs.xml" path='docs/class[@name="Error"]/constructor/*' />
+        public Error(SdkException error)
+        {
+            _error = error;
+        }
+
+        /// <inheritdoc />
+        public SdkException InnerException => _error;
+
+        /// <inheritdoc />
+        public MomentoErrorCode ErrorCode => _error.ErrorCode;
+
+        /// <inheritdoc />
+        public string Message => $"{_error.MessageWrapper}: {_error.Message}";
+
+        /// <inheritdoc />
+        public override string ToString()
+        {
+            return $"{base.ToString()}: {this.Message}";
+        }
+    }
+}

--- a/src/Momento.Sdk/Responses/TopicSubscribeResponse.cs
+++ b/src/Momento.Sdk/Responses/TopicSubscribeResponse.cs
@@ -1,3 +1,5 @@
+#if NETSTANDARD2_0_OR_GREATER
+
 using System;
 using System.Collections.Generic;
 using System.Threading;
@@ -148,3 +150,4 @@ public abstract class TopicSubscribeResponse
         }
     }
 }
+#endif

--- a/src/Momento.Sdk/TopicClient.cs
+++ b/src/Momento.Sdk/TopicClient.cs
@@ -1,3 +1,5 @@
+#if NETSTANDARD2_0_OR_GREATER
+
 using System;
 using System.Threading.Tasks;
 using Momento.Sdk.Auth;
@@ -79,3 +81,4 @@ public class TopicClient : ITopicClient
         scsTopicClient.Dispose();
     }
 }
+#endif

--- a/src/Momento.Sdk/TopicClient.cs
+++ b/src/Momento.Sdk/TopicClient.cs
@@ -21,9 +21,9 @@ public class TopicClient : ITopicClient
     /// <summary>
     /// Client to perform operations against Momento topics.
     /// </summary>
-    /// <param name="config">Configuration to use for the transport, retries, middlewares. See <see cref="Configurations"/> for out-of-the-box configuration choices, eg <see cref="Configurations.Laptop.Latest"/></param>
+    /// <param name="config">Configuration to use for the client.</param>
     /// <param name="authProvider">Momento auth provider.</param>
-    public TopicClient(IConfiguration config, ICredentialProvider authProvider)
+    public TopicClient(ITopicConfiguration config, ICredentialProvider authProvider)
     {
         scsTopicClient = new ScsTopicClient(config, authProvider.AuthToken, authProvider.CacheEndpoint);
     }

--- a/src/Momento.Sdk/TopicClient.cs
+++ b/src/Momento.Sdk/TopicClient.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Threading.Tasks;
+using Momento.Sdk.Auth;
+using Momento.Sdk.Config;
+using Momento.Sdk.Exceptions;
+using Momento.Sdk.Internal;
+using Momento.Sdk.Responses;
+
+namespace Momento.Sdk;
+
+/// <summary>
+/// Client to perform operations against Momento topics.
+/// </summary>
+public class TopicClient : ITopicClient
+{
+    private readonly ScsTopicClient scsTopicClient;
+    
+    
+    /// <summary>
+    /// Client to perform operations against Momento topics.
+    /// </summary>
+    /// <param name="config">Configuration to use for the transport, retries, middlewares. See <see cref="Configurations"/> for out-of-the-box configuration choices, eg <see cref="Configurations.Laptop.Latest"/></param>
+    /// <param name="authProvider">Momento auth provider.</param>
+    public TopicClient(IConfiguration config, ICredentialProvider authProvider)
+    {
+        scsTopicClient = new ScsTopicClient(config, authProvider.AuthToken, authProvider.CacheEndpoint);
+    }
+
+    /// <inheritdoc />
+    public async Task<TopicPublishResponse> PublishAsync(string cacheName, string topicName, byte[] value)
+    {
+        try
+        {
+            Utils.ArgumentNotNull(cacheName, nameof(cacheName));
+            Utils.ArgumentNotNull(topicName, nameof(topicName));
+            Utils.ArgumentNotNull(value, nameof(value));
+        }
+        catch (Exception e)
+        {
+            return new TopicPublishResponse.Error(new InvalidArgumentException(e.Message));
+        }
+        return await scsTopicClient.Publish(cacheName, topicName, value);
+    }
+
+    /// <inheritdoc />
+    public async Task<TopicPublishResponse> PublishAsync(string cacheName, string topicName, string value)
+    {
+        try
+        {
+            Utils.ArgumentNotNull(cacheName, nameof(cacheName));
+            Utils.ArgumentNotNull(topicName, nameof(topicName));
+            Utils.ArgumentNotNull(value, nameof(value));
+        }
+        catch (Exception e)
+        {
+            return new TopicPublishResponse.Error(new InvalidArgumentException(e.Message));
+        }
+        return await scsTopicClient.Publish(cacheName, topicName, value);
+    }
+
+    /// <inheritdoc />
+    public async Task<TopicSubscribeResponse> SubscribeAsync(string cacheName, string topicName, ulong? resumeAtSequenceNumber = null)
+    {
+        try
+        {
+            Utils.ArgumentNotNull(cacheName, nameof(cacheName));
+            Utils.ArgumentNotNull(topicName, nameof(topicName));
+        }
+        catch (Exception e)
+        {
+            return new TopicSubscribeResponse.Error(new InvalidArgumentException(e.Message));
+        }
+        return await scsTopicClient.Subscribe(cacheName, topicName, resumeAtSequenceNumber);
+    }
+    
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        scsTopicClient.Dispose();
+    }
+}

--- a/tests/Integration/Momento.Sdk.Tests/Fixtures.cs
+++ b/tests/Integration/Momento.Sdk.Tests/Fixtures.cs
@@ -44,6 +44,34 @@ public class CacheClientFixture : IDisposable
     }
 }
 
+public class TopicClientFixture : IDisposable
+{
+    public ITopicClient Client { get; private set; }
+    public ICredentialProvider AuthProvider { get; private set; }
+    
+    public TopicClientFixture()
+    {
+        AuthProvider = new EnvMomentoTokenProvider("TEST_AUTH_TOKEN");
+        Client = new TopicClient(Configurations.Laptop.Latest(LoggerFactory.Create(builder =>
+            {
+                builder.AddSimpleConsole(options =>
+                {
+                    options.IncludeScopes = true;
+                    options.SingleLine = true;
+                    options.TimestampFormat = "hh:mm:ss ";
+                });
+                builder.AddFilter("Grpc.Net.Client", LogLevel.Error);
+                builder.SetMinimumLevel(LogLevel.Information);
+            })),
+            AuthProvider);
+    }
+
+    public void Dispose()
+    {
+        Client.Dispose();
+    }
+}
+
 /// <summary>
 /// Register the fixture in xUnit.
 /// </summary>

--- a/tests/Integration/Momento.Sdk.Tests/Fixtures.cs
+++ b/tests/Integration/Momento.Sdk.Tests/Fixtures.cs
@@ -44,6 +44,16 @@ public class CacheClientFixture : IDisposable
     }
 }
 
+/// <summary>
+/// Register the fixture in xUnit.
+/// </summary>
+[CollectionDefinition("CacheClient")]
+public class CacheClientCollection : ICollectionFixture<CacheClientFixture>
+{
+
+}
+
+#if NET6_0_OR_GREATER
 public class TopicClientFixture : IDisposable
 {
     public ITopicClient Client { get; private set; }
@@ -75,8 +85,9 @@ public class TopicClientFixture : IDisposable
 /// <summary>
 /// Register the fixture in xUnit.
 /// </summary>
-[CollectionDefinition("CacheClient")]
-public class CacheClientCollection : ICollectionFixture<CacheClientFixture>
+[CollectionDefinition("TopicClient")]
+public class TopicClientCollection : ICollectionFixture<TopicClientFixture>
 {
 
 }
+#endif

--- a/tests/Integration/Momento.Sdk.Tests/Fixtures.cs
+++ b/tests/Integration/Momento.Sdk.Tests/Fixtures.cs
@@ -1,7 +1,6 @@
 using Microsoft.Extensions.Logging;
 using Momento.Sdk.Auth;
 using Momento.Sdk.Config;
-using Momento.Sdk.Config.Transport;
 
 namespace Momento.Sdk.Tests;
 
@@ -63,7 +62,7 @@ public class TopicClientFixture : IDisposable
     public TopicClientFixture()
     {
         AuthProvider = new EnvMomentoTokenProvider("TEST_AUTH_TOKEN");
-        var loggerFactory = LoggerFactory.Create(builder =>
+        Client = new TopicClient(TopicConfigurations.Laptop.latest(LoggerFactory.Create(builder =>
         {
             builder.AddSimpleConsole(options =>
             {
@@ -73,14 +72,7 @@ public class TopicClientFixture : IDisposable
             });
             builder.AddFilter("Grpc.Net.Client", LogLevel.Error);
             builder.SetMinimumLevel(LogLevel.Information);
-        });
-        var transportStrategy = new StaticTransportStrategy(
-            loggerFactory: loggerFactory,
-            maxConcurrentRequests: 200, // max of 2 connections https://github.com/momentohq/client-sdk-dotnet/issues/460
-            grpcConfig: new StaticGrpcConfiguration(deadline: TimeSpan.FromMilliseconds(15000))
-        );
-        var config = new TopicConfiguration(loggerFactory, transportStrategy);
-        Client = new TopicClient(config, AuthProvider);
+        })), AuthProvider);
     }
 
     public void Dispose()

--- a/tests/Integration/Momento.Sdk.Tests/Momento.Sdk.Tests.Integration.csproj
+++ b/tests/Integration/Momento.Sdk.Tests/Momento.Sdk.Tests.Integration.csproj
@@ -26,6 +26,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Integration/Momento.Sdk.Tests/Momento.Sdk.Tests.Integration.csproj
+++ b/tests/Integration/Momento.Sdk.Tests/Momento.Sdk.Tests.Integration.csproj
@@ -35,4 +35,7 @@
   <ItemGroup>
     <None Remove="Microsoft.Extensions.Logging.Console" />
   </ItemGroup>
+  <ItemGroup>
+    <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
 </Project>

--- a/tests/Integration/Momento.Sdk.Tests/TopicTest.cs
+++ b/tests/Integration/Momento.Sdk.Tests/TopicTest.cs
@@ -1,0 +1,236 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit.Abstractions;
+
+// ReSharper disable once CheckNamespace
+namespace Momento.Sdk.Tests;
+
+public class TopicTest : IClassFixture<CacheClientFixture>, IClassFixture<TopicClientFixture>
+{
+    private readonly ITestOutputHelper testOutputHelper;
+    private readonly string cacheName;
+    private readonly ITopicClient topicClient;
+
+    public TopicTest(CacheClientFixture cacheFixture, TopicClientFixture topicFixture,
+        ITestOutputHelper testOutputHelper)
+    {
+        this.testOutputHelper = testOutputHelper;
+        topicClient = topicFixture.Client;
+        cacheName = cacheFixture.CacheName;
+    }
+
+    [Theory]
+    [InlineData(null, "topic")]
+    [InlineData("cache", null)]
+    public async Task PublishAsync_NullChecksByteArray_IsError(string badCacheName, string badTopicName)
+    {
+        var response = await topicClient.PublishAsync(badCacheName, badTopicName, Array.Empty<byte>());
+        Assert.True(response is TopicPublishResponse.Error, $"Unexpected response: {response}");
+        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((TopicPublishResponse.Error)response).ErrorCode);
+    }
+
+    [Fact]
+    public async Task PublishAsync_PublishNullByteArray_IsError()
+    {
+        var response = await topicClient.PublishAsync(cacheName, "topic", (byte[])null!);
+        Assert.True(response is TopicPublishResponse.Error, $"Unexpected response: {response}");
+        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((TopicPublishResponse.Error)response).ErrorCode);
+    }
+
+    [Fact]
+    public async Task PublishAsync_BadCacheNameByteArray_IsError()
+    {
+        var response = await topicClient.PublishAsync("fake-" + cacheName, "topic", Array.Empty<byte>());
+        Assert.True(response is TopicPublishResponse.Error, $"Unexpected response: {response}");
+        Assert.Equal(MomentoErrorCode.NOT_FOUND_ERROR, ((TopicPublishResponse.Error)response).ErrorCode);
+    }
+
+    [Theory]
+    [InlineData(null, "topic")]
+    [InlineData("cache", null)]
+    public async Task PublishAsync_NullChecksString_IsError(string badCacheName, string badTopicName)
+    {
+        var response = await topicClient.PublishAsync(badCacheName, badTopicName, "value");
+        Assert.True(response is TopicPublishResponse.Error, $"Unexpected response: {response}");
+        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((TopicPublishResponse.Error)response).ErrorCode);
+    }
+
+    [Fact]
+    public async Task PublishAsync_PublishNullString_IsError()
+    {
+        var response = await topicClient.PublishAsync(cacheName, "topic", (string)null!);
+        Assert.True(response is TopicPublishResponse.Error, $"Unexpected response: {response}");
+        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((TopicPublishResponse.Error)response).ErrorCode);
+    }
+
+    [Fact]
+    public async Task PublishAsync_BadCacheNameString_IsError()
+    {
+        var response = await topicClient.PublishAsync("fake-" + cacheName, "topic", "value");
+        Assert.True(response is TopicPublishResponse.Error, $"Unexpected response: {response}");
+        Assert.Equal(MomentoErrorCode.NOT_FOUND_ERROR, ((TopicPublishResponse.Error)response).ErrorCode);
+    }
+
+    [Theory]
+    [InlineData(null, "topic")]
+    [InlineData("cache", null)]
+    public async Task SubscribeAsync_NullChecks_IsError(string badCacheName, string badTopicName)
+    {
+        var response = await topicClient.SubscribeAsync(badCacheName, badTopicName);
+        Assert.True(response is TopicSubscribeResponse.Error, $"Unexpected response: {response}");
+        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((TopicSubscribeResponse.Error)response).ErrorCode);
+    }
+
+    [Fact(Timeout = 5000)]
+    public async Task PublishAndSubscribe_ByteArray_Succeeds()
+    {
+        const string topicName = "topic_bytes";
+        var skipMessage = new byte[] { 0x00 };
+        var valuesToSend = new List<byte[]>
+        {
+            new byte[] { 0x01 },
+            new byte[] { 0x02 },
+            new byte[] { 0x03 },
+            new byte[] { 0x04 },
+            new byte[] { 0x05 }
+        };
+
+        var subscribeResponse = await topicClient.SubscribeAsync(cacheName, topicName);
+        Assert.True(subscribeResponse is TopicSubscribeResponse.Subscription,
+            $"Unexpected response: {subscribeResponse}");
+        var subscription = (TopicSubscribeResponse.Subscription)subscribeResponse;
+        
+        var testTask = Task.Run(async () =>
+        {
+            var messageCount = 0;
+            await foreach (var message in subscription)
+            {
+                Assert.NotNull(message);
+                Assert.True(message is TopicMessage.Item, $"Unexpected message: {message}");
+                if (((TopicMessage.Item)message).ValueByteArray!.SequenceEqual(skipMessage)) continue;
+                
+                Assert.Equal(valuesToSend[messageCount], ((TopicMessage.Item)message).ValueByteArray);
+
+                messageCount++;
+                if (messageCount == valuesToSend.Count)
+                {
+                    break;
+                }
+            }
+
+            subscription.Dispose();
+            return messageCount;
+        });
+        
+        // Send a few values to skip over to ensure the subscription received the messages under test
+        for (var i = 0; i < 5; i++)
+        {
+            await topicClient.PublishAsync(cacheName, topicName, skipMessage);
+            Thread.Sleep(100);
+        }
+        
+        foreach (var value in valuesToSend)
+        {
+            var publishResponse = await topicClient.PublishAsync(cacheName, topicName, value);
+            Assert.True(publishResponse is TopicPublishResponse.Success, $"Unexpected response: {publishResponse}");
+            Thread.Sleep(100);
+        }
+        foreach (var value in valuesToSend)
+        {
+            var publishResponse = await topicClient.PublishAsync(cacheName, topicName, value);
+            Assert.True(publishResponse is TopicPublishResponse.Success, $"Unexpected response: {publishResponse}");
+            Thread.Sleep(100);
+        }
+        
+        Assert.Equal(valuesToSend.Count, await testTask);
+    }
+
+    [Fact(Timeout = 5000)]
+    public async Task PublishAndSubscribe_String_Succeeds()
+    {
+        const string topicName = "topic_string";
+        var skipMessage = "skip";
+        var valuesToSend = new List<string>
+        {
+            "one",
+            "two",
+            "three",
+            "four",
+            "five"
+        };
+        
+        var subscribeResponse = await topicClient.SubscribeAsync(cacheName, topicName);
+        Assert.True(subscribeResponse is TopicSubscribeResponse.Subscription,
+            $"Unexpected response: {subscribeResponse}");
+        var subscription = (TopicSubscribeResponse.Subscription)subscribeResponse;
+        
+        var testTask = Task.Run(async () =>
+        {
+            var messageCount = 0;
+            await foreach (var message in subscription)
+            {
+                Assert.NotNull(message);
+                Assert.True(message is TopicMessage.Item, $"Unexpected message: {message}");
+                if (((TopicMessage.Item)message).ValueString!.Equals(skipMessage)) continue;
+                
+                Assert.Equal(valuesToSend[messageCount], ((TopicMessage.Item)message).ValueString);
+
+                messageCount++;
+                if (messageCount == valuesToSend.Count)
+                {
+                    break;
+                }
+            }
+
+            subscription.Dispose();
+            return messageCount;
+        });
+        
+        // Send a few values to skip over to ensure the subscription received the messages under test
+        for (var i = 0; i < 5; i++)
+        {
+            await topicClient.PublishAsync(cacheName, topicName, skipMessage);
+            Thread.Sleep(100);
+        }
+        
+        foreach (var value in valuesToSend)
+        {
+            var publishResponse = await topicClient.PublishAsync(cacheName, topicName, value);
+            Assert.True(publishResponse is TopicPublishResponse.Success, $"Unexpected response: {publishResponse}");
+            Thread.Sleep(100);
+        }
+        
+        Assert.Equal(valuesToSend.Count, await testTask);
+    }
+
+    [Fact(Timeout = 5000)]
+    public async Task Subscribe_EnumerateClosed_Succeeds()
+    {
+        const string topicName = "topic_closed";
+        const string messageValue = "value";
+
+        using var cts = new CancellationTokenSource();
+
+        var subscribeResponse = await topicClient.SubscribeAsync(cacheName, topicName);
+        Assert.True(subscribeResponse is TopicSubscribeResponse.Subscription,
+            $"Unexpected response: {subscribeResponse}");
+        var subscription = ((TopicSubscribeResponse.Subscription)subscribeResponse).WithCancellation(cts.Token);
+        testOutputHelper.WriteLine("subscribed");
+
+        var enumerator = subscription.GetAsyncEnumerator();
+        Assert.Null(enumerator.Current);
+        testOutputHelper.WriteLine("enumerator gotten");
+        
+        var publishResponse = await topicClient.PublishAsync(cacheName, topicName, messageValue);
+        Assert.True(publishResponse is TopicPublishResponse.Success, $"Unexpected response: {publishResponse}");
+        testOutputHelper.WriteLine("message published");
+
+        cts.Cancel();
+
+        Assert.False(await enumerator.MoveNextAsync());
+        
+        Assert.Null(enumerator.Current);
+    }
+}

--- a/tests/Integration/Momento.Sdk.Tests/TopicTest.cs
+++ b/tests/Integration/Momento.Sdk.Tests/TopicTest.cs
@@ -22,67 +22,67 @@ public class TopicTest : IClassFixture<CacheClientFixture>, IClassFixture<TopicC
         cacheName = cacheFixture.CacheName;
     }
 
-    [Theory]
-    [InlineData(null, "topic")]
-    [InlineData("cache", null)]
-    public async Task PublishAsync_NullChecksByteArray_IsError(string badCacheName, string badTopicName)
-    {
-        var response = await topicClient.PublishAsync(badCacheName, badTopicName, Array.Empty<byte>());
-        Assert.True(response is TopicPublishResponse.Error, $"Unexpected response: {response}");
-        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((TopicPublishResponse.Error)response).ErrorCode);
-    }
-
-    [Fact]
-    public async Task PublishAsync_PublishNullByteArray_IsError()
-    {
-        var response = await topicClient.PublishAsync(cacheName, "topic", (byte[])null!);
-        Assert.True(response is TopicPublishResponse.Error, $"Unexpected response: {response}");
-        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((TopicPublishResponse.Error)response).ErrorCode);
-    }
-
-    [Fact]
-    public async Task PublishAsync_BadCacheNameByteArray_IsError()
-    {
-        var response = await topicClient.PublishAsync("fake-" + cacheName, "topic", Array.Empty<byte>());
-        Assert.True(response is TopicPublishResponse.Error, $"Unexpected response: {response}");
-        Assert.Equal(MomentoErrorCode.NOT_FOUND_ERROR, ((TopicPublishResponse.Error)response).ErrorCode);
-    }
-
-    [Theory]
-    [InlineData(null, "topic")]
-    [InlineData("cache", null)]
-    public async Task PublishAsync_NullChecksString_IsError(string badCacheName, string badTopicName)
-    {
-        var response = await topicClient.PublishAsync(badCacheName, badTopicName, "value");
-        Assert.True(response is TopicPublishResponse.Error, $"Unexpected response: {response}");
-        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((TopicPublishResponse.Error)response).ErrorCode);
-    }
-
-    [Fact]
-    public async Task PublishAsync_PublishNullString_IsError()
-    {
-        var response = await topicClient.PublishAsync(cacheName, "topic", (string)null!);
-        Assert.True(response is TopicPublishResponse.Error, $"Unexpected response: {response}");
-        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((TopicPublishResponse.Error)response).ErrorCode);
-    }
-
-    [Fact]
-    public async Task PublishAsync_BadCacheNameString_IsError()
-    {
-        var response = await topicClient.PublishAsync("fake-" + cacheName, "topic", "value");
-        Assert.True(response is TopicPublishResponse.Error, $"Unexpected response: {response}");
-        Assert.Equal(MomentoErrorCode.NOT_FOUND_ERROR, ((TopicPublishResponse.Error)response).ErrorCode);
-    }
-
-    [Theory]
-    [InlineData(null, "topic")]
-    [InlineData("cache", null)]
-    public async Task SubscribeAsync_NullChecks_IsError(string badCacheName, string badTopicName)
-    {
-        var response = await topicClient.SubscribeAsync(badCacheName, badTopicName);
-        Assert.True(response is TopicSubscribeResponse.Error, $"Unexpected response: {response}");
-        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((TopicSubscribeResponse.Error)response).ErrorCode);
-    }
+    // [Theory]
+    // [InlineData(null, "topic")]
+    // [InlineData("cache", null)]
+    // public async Task PublishAsync_NullChecksByteArray_IsError(string badCacheName, string badTopicName)
+    // {
+    //     var response = await topicClient.PublishAsync(badCacheName, badTopicName, Array.Empty<byte>());
+    //     Assert.True(response is TopicPublishResponse.Error, $"Unexpected response: {response}");
+    //     Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((TopicPublishResponse.Error)response).ErrorCode);
+    // }
+    //
+    // [Fact]
+    // public async Task PublishAsync_PublishNullByteArray_IsError()
+    // {
+    //     var response = await topicClient.PublishAsync(cacheName, "topic", (byte[])null!);
+    //     Assert.True(response is TopicPublishResponse.Error, $"Unexpected response: {response}");
+    //     Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((TopicPublishResponse.Error)response).ErrorCode);
+    // }
+    //
+    // [Fact]
+    // public async Task PublishAsync_BadCacheNameByteArray_IsError()
+    // {
+    //     var response = await topicClient.PublishAsync("fake-" + cacheName, "topic", Array.Empty<byte>());
+    //     Assert.True(response is TopicPublishResponse.Error, $"Unexpected response: {response}");
+    //     Assert.Equal(MomentoErrorCode.NOT_FOUND_ERROR, ((TopicPublishResponse.Error)response).ErrorCode);
+    // }
+    //
+    // [Theory]
+    // [InlineData(null, "topic")]
+    // [InlineData("cache", null)]
+    // public async Task PublishAsync_NullChecksString_IsError(string badCacheName, string badTopicName)
+    // {
+    //     var response = await topicClient.PublishAsync(badCacheName, badTopicName, "value");
+    //     Assert.True(response is TopicPublishResponse.Error, $"Unexpected response: {response}");
+    //     Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((TopicPublishResponse.Error)response).ErrorCode);
+    // }
+    //
+    // [Fact]
+    // public async Task PublishAsync_PublishNullString_IsError()
+    // {
+    //     var response = await topicClient.PublishAsync(cacheName, "topic", (string)null!);
+    //     Assert.True(response is TopicPublishResponse.Error, $"Unexpected response: {response}");
+    //     Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((TopicPublishResponse.Error)response).ErrorCode);
+    // }
+    //
+    // [Fact]
+    // public async Task PublishAsync_BadCacheNameString_IsError()
+    // {
+    //     var response = await topicClient.PublishAsync("fake-" + cacheName, "topic", "value");
+    //     Assert.True(response is TopicPublishResponse.Error, $"Unexpected response: {response}");
+    //     Assert.Equal(MomentoErrorCode.NOT_FOUND_ERROR, ((TopicPublishResponse.Error)response).ErrorCode);
+    // }
+    //
+    // [Theory]
+    // [InlineData(null, "topic")]
+    // [InlineData("cache", null)]
+    // public async Task SubscribeAsync_NullChecks_IsError(string badCacheName, string badTopicName)
+    // {
+    //     var response = await topicClient.SubscribeAsync(badCacheName, badTopicName);
+    //     Assert.True(response is TopicSubscribeResponse.Error, $"Unexpected response: {response}");
+    //     Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((TopicSubscribeResponse.Error)response).ErrorCode);
+    // }
 
     [Fact(Timeout = 5000)]
     public async Task PublishAndSubscribe_ByteArray_Succeeds()
@@ -126,100 +126,100 @@ public class TopicTest : IClassFixture<CacheClientFixture>, IClassFixture<TopicC
             return messageCount;
         }, cts.Token);
 
-        Thread.Sleep(1000);
+        await Task.Delay(1000);
 
         foreach (var value in valuesToSend)
         {
             var publishResponse = await topicClient.PublishAsync(cacheName, topicName, value);
             Assert.True(publishResponse is TopicPublishResponse.Success, $"Unexpected response: {publishResponse}");
-            Thread.Sleep(100);
+            await Task.Delay(100);
         }
 
         Assert.Equal(valuesToSend.Count, await testTask);
     }
 
-    [Fact(Timeout = 5000)]
-    public async Task PublishAndSubscribe_String_Succeeds()
-    {
-        testOutputHelper.WriteLine("starting string publish and subscribe test");
-        const string topicName = "topic_string";
-        var valuesToSend = new List<string>
-        {
-            "one",
-            "two",
-            "three",
-            "four",
-            "five"
-        };
+    // [Fact(Timeout = 5000)]
+    // public async Task PublishAndSubscribe_String_Succeeds()
+    // {
+    //     testOutputHelper.WriteLine("starting string publish and subscribe test");
+    //     const string topicName = "topic_string";
+    //     var valuesToSend = new List<string>
+    //     {
+    //         "one",
+    //         "two",
+    //         "three",
+    //         "four",
+    //         "five"
+    //     };
+    //
+    //     using var cts = new CancellationTokenSource();
+    //     cts.CancelAfter(4000);
+    //
+    //     var subscribeResponse = await topicClient.SubscribeAsync(cacheName, topicName);
+    //     Assert.True(subscribeResponse is TopicSubscribeResponse.Subscription,
+    //         $"Unexpected response: {subscribeResponse}");
+    //     var subscription = ((TopicSubscribeResponse.Subscription)subscribeResponse).WithCancellation(cts.Token);
+    //
+    //     var testTask = Task.Run(async () =>
+    //     {
+    //         var messageCount = 0;
+    //         await foreach (var message in subscription)
+    //         {
+    //             Assert.NotNull(message);
+    //             Assert.True(message is TopicMessage.Text, $"Unexpected message: {message}");
+    //
+    //             Assert.Equal(valuesToSend[messageCount], ((TopicMessage.Text)message).Value);
+    //
+    //             messageCount++;
+    //             if (messageCount == valuesToSend.Count)
+    //             {
+    //                 break;
+    //             }
+    //         }
+    //
+    //         return messageCount;
+    //     }, cts.Token);
+    //
+    //     await Task.Delay(1000);
+    //
+    //     foreach (var value in valuesToSend)
+    //     {
+    //         var publishResponse = await topicClient.PublishAsync(cacheName, topicName, value);
+    //         Assert.True(publishResponse is TopicPublishResponse.Success, $"Unexpected response: {publishResponse}");
+    //         await Task.Delay(100);
+    //     }
+    //
+    //     Assert.Equal(valuesToSend.Count, await testTask);
+    // }
 
-        using var cts = new CancellationTokenSource();
-        cts.CancelAfter(4000);
-
-        var subscribeResponse = await topicClient.SubscribeAsync(cacheName, topicName);
-        Assert.True(subscribeResponse is TopicSubscribeResponse.Subscription,
-            $"Unexpected response: {subscribeResponse}");
-        var subscription = ((TopicSubscribeResponse.Subscription)subscribeResponse).WithCancellation(cts.Token);
-
-        var testTask = Task.Run(async () =>
-        {
-            var messageCount = 0;
-            await foreach (var message in subscription)
-            {
-                Assert.NotNull(message);
-                Assert.True(message is TopicMessage.Text, $"Unexpected message: {message}");
-
-                Assert.Equal(valuesToSend[messageCount], ((TopicMessage.Text)message).Value);
-
-                messageCount++;
-                if (messageCount == valuesToSend.Count)
-                {
-                    break;
-                }
-            }
-
-            return messageCount;
-        }, cts.Token);
-
-        Thread.Sleep(1000);
-
-        foreach (var value in valuesToSend)
-        {
-            var publishResponse = await topicClient.PublishAsync(cacheName, topicName, value);
-            Assert.True(publishResponse is TopicPublishResponse.Success, $"Unexpected response: {publishResponse}");
-            Thread.Sleep(100);
-        }
-
-        Assert.Equal(valuesToSend.Count, await testTask);
-    }
-
-    [Fact(Timeout = 5000)]
-    public async Task Subscribe_EnumerateClosed_Succeeds()
-    {
-        testOutputHelper.WriteLine("starting enumerate after closed test");
-        const string topicName = "topic_closed";
-        const string messageValue = "value";
-
-        using var cts = new CancellationTokenSource();
-
-        var subscribeResponse = await topicClient.SubscribeAsync(cacheName, topicName);
-        Assert.True(subscribeResponse is TopicSubscribeResponse.Subscription,
-            $"Unexpected response: {subscribeResponse}");
-        var subscription = ((TopicSubscribeResponse.Subscription)subscribeResponse).WithCancellation(cts.Token);
-        testOutputHelper.WriteLine("subscribed");
-
-        var enumerator = subscription.GetAsyncEnumerator();
-        Assert.Null(enumerator.Current);
-        testOutputHelper.WriteLine("enumerator gotten");
-
-        var publishResponse = await topicClient.PublishAsync(cacheName, topicName, messageValue);
-        Assert.True(publishResponse is TopicPublishResponse.Success, $"Unexpected response: {publishResponse}");
-        testOutputHelper.WriteLine("message published");
-
-        cts.Cancel();
-
-        Assert.False(await enumerator.MoveNextAsync());
-
-        Assert.Null(enumerator.Current);
-    }
+    // [Fact(Timeout = 5000)]
+    // public async Task Subscribe_EnumerateClosed_Succeeds()
+    // {
+    //     testOutputHelper.WriteLine("starting enumerate after closed test");
+    //     const string topicName = "topic_closed";
+    //     const string messageValue = "value";
+    //
+    //     using var cts = new CancellationTokenSource();
+    //
+    //     var subscribeResponse = await topicClient.SubscribeAsync(cacheName, topicName);
+    //     Assert.True(subscribeResponse is TopicSubscribeResponse.Subscription,
+    //         $"Unexpected response: {subscribeResponse}");
+    //     var subscription = ((TopicSubscribeResponse.Subscription)subscribeResponse).WithCancellation(cts.Token);
+    //     testOutputHelper.WriteLine("subscribed");
+    //
+    //     var enumerator = subscription.GetAsyncEnumerator();
+    //     Assert.Null(enumerator.Current);
+    //     testOutputHelper.WriteLine("enumerator gotten");
+    //
+    //     var publishResponse = await topicClient.PublishAsync(cacheName, topicName, messageValue);
+    //     Assert.True(publishResponse is TopicPublishResponse.Success, $"Unexpected response: {publishResponse}");
+    //     testOutputHelper.WriteLine("message published");
+    //
+    //     cts.Cancel();
+    //
+    //     Assert.False(await enumerator.MoveNextAsync());
+    //
+    //     Assert.Null(enumerator.Current);
+    // }
 }
 #endif

--- a/tests/Integration/Momento.Sdk.Tests/TopicTest.cs
+++ b/tests/Integration/Momento.Sdk.Tests/TopicTest.cs
@@ -108,13 +108,13 @@ public class TopicTest : IClassFixture<CacheClientFixture>, IClassFixture<TopicC
 
         Console.WriteLine("subscription created");
         // var taskCompletionSourceBool = new TaskCompletionSource<bool>();
-        var semaphoreSlim = new SemaphoreSlim(0, 1);
+        // var semaphoreSlim = new SemaphoreSlim(0, 1);
         var testTask = Task.Run(async () =>
         {
             // var messageCount = 0;
             var receivedSet = new HashSet<byte[]>();
             // taskCompletionSourceBool.SetResult(true);
-            semaphoreSlim.Release();
+            // semaphoreSlim.Release();
             await Task.Delay(2000);
             // await foreach (var message in subscription)
             // {
@@ -132,18 +132,18 @@ public class TopicTest : IClassFixture<CacheClientFixture>, IClassFixture<TopicC
             return receivedSet.Count;
         }, cts.Token);
 
-        // Console.WriteLine("enumerator task started");
-        // // await taskCompletionSourceBool.Task;
+        Console.WriteLine("enumerator task started");
+        // await taskCompletionSourceBool.Task;
         // await semaphoreSlim.WaitAsync(cts.Token);
-        // // await Task.Delay(1000);
-        //
-        // foreach (var value in valuesToSend)
-        // {
-        //     var publishResponse = await topicClient.PublishAsync(cacheName, topicName, value);
-        //     Assert.True(publishResponse is TopicPublishResponse.Success, $"Unexpected response: {publishResponse}");
-        //     await Task.Delay(100);
-        // }
-        // Console.WriteLine("messages sent");
+        // await Task.Delay(1000);
+
+        foreach (var value in valuesToSend)
+        {
+            var publishResponse = await topicClient.PublishAsync(cacheName, topicName, value);
+            Assert.True(publishResponse is TopicPublishResponse.Success, $"Unexpected response: {publishResponse}");
+            await Task.Delay(100);
+        }
+        Console.WriteLine("messages sent");
 
         int received = await testTask;
         Console.WriteLine("Found " + received);

--- a/tests/Integration/Momento.Sdk.Tests/TopicTest.cs
+++ b/tests/Integration/Momento.Sdk.Tests/TopicTest.cs
@@ -27,7 +27,7 @@ public class TopicTest : IClassFixture<CacheClientFixture>, IClassFixture<TopicC
         Assert.True(response is TopicPublishResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((TopicPublishResponse.Error)response).ErrorCode);
     }
-    
+
     [Fact]
     public async Task PublishAsync_PublishNullByteArray_IsError()
     {
@@ -35,7 +35,7 @@ public class TopicTest : IClassFixture<CacheClientFixture>, IClassFixture<TopicC
         Assert.True(response is TopicPublishResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((TopicPublishResponse.Error)response).ErrorCode);
     }
-    
+
     [Fact]
     public async Task PublishAsync_BadCacheNameByteArray_IsError()
     {
@@ -43,7 +43,7 @@ public class TopicTest : IClassFixture<CacheClientFixture>, IClassFixture<TopicC
         Assert.True(response is TopicPublishResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.NOT_FOUND_ERROR, ((TopicPublishResponse.Error)response).ErrorCode);
     }
-    
+
     [Theory]
     [InlineData(null, "topic")]
     [InlineData("cache", null)]
@@ -53,7 +53,7 @@ public class TopicTest : IClassFixture<CacheClientFixture>, IClassFixture<TopicC
         Assert.True(response is TopicPublishResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((TopicPublishResponse.Error)response).ErrorCode);
     }
-    
+
     [Fact]
     public async Task PublishAsync_PublishNullString_IsError()
     {
@@ -61,7 +61,7 @@ public class TopicTest : IClassFixture<CacheClientFixture>, IClassFixture<TopicC
         Assert.True(response is TopicPublishResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((TopicPublishResponse.Error)response).ErrorCode);
     }
-    
+
     [Fact]
     public async Task PublishAsync_BadCacheNameString_IsError()
     {
@@ -69,7 +69,7 @@ public class TopicTest : IClassFixture<CacheClientFixture>, IClassFixture<TopicC
         Assert.True(response is TopicPublishResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.NOT_FOUND_ERROR, ((TopicPublishResponse.Error)response).ErrorCode);
     }
-    
+
     [Theory]
     [InlineData(null, "topic")]
     [InlineData("cache", null)]
@@ -93,25 +93,24 @@ public class TopicTest : IClassFixture<CacheClientFixture>, IClassFixture<TopicC
             new byte[] { 0x04 },
             new byte[] { 0x05 }
         };
-        
+
         var produceCancellation = new CancellationTokenSource();
         produceCancellation.CancelAfter(2000);
 
         // we don't need to put this on a different thread
         var consumeTask = ConsumeMessages(topicName, produceCancellation.Token);
         await Task.Delay(500);
-        
+
         await ProduceMessages(topicName, valuesToSend);
         await Task.Delay(500);
-        
+
         produceCancellation.Cancel();
-        
+
         var consumedMessages = await consumeTask;
         Assert.Equal(valuesToSend.Count, consumedMessages.Count);
         for (var i = 0; i < valuesToSend.Count; ++i)
         {
-            var message = (TopicMessage.Binary)consumedMessages[i];
-            Assert.Equal(message.Value, valuesToSend[i]);
+            Assert.Equal(consumedMessages[i].ValueByteArray, valuesToSend[i]);
         }
     }
 
@@ -120,20 +119,20 @@ public class TopicTest : IClassFixture<CacheClientFixture>, IClassFixture<TopicC
     {
         const string topicName = "topic_string";
         var valuesToSend = new List<string>
-         {
-             "one",
-             "two",
-             "three",
-             "four",
-             "five"
-         };
+        {
+            "one",
+            "two",
+            "three",
+            "four",
+            "five"
+        };
 
         var produceCancellation = new CancellationTokenSource();
         produceCancellation.CancelAfter(2000);
 
         // we don't need to put this on a different thread
         var consumeTask = ConsumeMessages(topicName, produceCancellation.Token);
-        await Task.Delay(50);
+        await Task.Delay(500);
 
         await ProduceMessages(topicName, valuesToSend);
         await Task.Delay(500);
@@ -144,8 +143,7 @@ public class TopicTest : IClassFixture<CacheClientFixture>, IClassFixture<TopicC
         Assert.Equal(valuesToSend.Count, consumedMessages.Count);
         for (var i = 0; i < valuesToSend.Count; ++i)
         {
-            var message = (TopicMessage.Text)consumedMessages[i];
-            Assert.Equal(message.Value, valuesToSend[i]);
+            Assert.Equal(consumedMessages[i].ValueString, valuesToSend[i]);
         }
     }
 
@@ -164,7 +162,7 @@ public class TopicTest : IClassFixture<CacheClientFixture>, IClassFixture<TopicC
             }
         }
     }
-    
+
     private async Task ProduceMessages(string topicName, List<string> valuesToSend)
     {
         foreach (var value in valuesToSend)
@@ -180,7 +178,7 @@ public class TopicTest : IClassFixture<CacheClientFixture>, IClassFixture<TopicC
             }
         }
     }
-    
+
     private async Task<List<TopicMessage>> ConsumeMessages(string topicName, CancellationToken token)
     {
         var subscribeResponse = await topicClient.SubscribeAsync(cacheName, topicName);
@@ -201,6 +199,7 @@ public class TopicTest : IClassFixture<CacheClientFixture>, IClassFixture<TopicC
                             throw new Exception("bad message received");
                     }
                 }
+
                 subscription.Dispose();
                 return receivedSet;
             default:

--- a/tests/Integration/Momento.Sdk.Tests/TopicTest.cs
+++ b/tests/Integration/Momento.Sdk.Tests/TopicTest.cs
@@ -88,66 +88,67 @@ public class TopicTest : IClassFixture<CacheClientFixture>, IClassFixture<TopicC
     public async Task PublishAndSubscribe_ByteArray_Succeeds()
     {
         Console.WriteLine("starting binary publish and subscribe test");
-        const string topicName = "topic_bytes";
-        var valuesToSend = new HashSet<byte[]>
-        {
-            new byte[] { 0x01 },
-            new byte[] { 0x02 },
-            new byte[] { 0x03 },
-            new byte[] { 0x04 },
-            new byte[] { 0x05 }
-        };
-
-        using var cts = new CancellationTokenSource();
-        cts.CancelAfter(4000);
-
-        // var subscribeResponse = await topicClient.SubscribeAsync(cacheName, topicName);
-        // Assert.True(subscribeResponse is TopicSubscribeResponse.Subscription,
-        //     $"Unexpected response: {subscribeResponse}");
-        // var subscription = ((TopicSubscribeResponse.Subscription)subscribeResponse).WithCancellation(cts.Token);
-
-        Console.WriteLine("subscription created");
-        // var taskCompletionSourceBool = new TaskCompletionSource<bool>();
-        var semaphoreSlim = new SemaphoreSlim(0, 1);
-        var testTask = Task.Run(async () =>
-        {
-            // var messageCount = 0;
-            var receivedSet = new HashSet<byte[]>();
-            // taskCompletionSourceBool.SetResult(true);
-            semaphoreSlim.Release();
-            await Task.Delay(2000);
-            // await foreach (var message in subscription)
-            // {
-            //     Assert.NotNull(message);
-            //     Assert.True(message is TopicMessage.Binary, $"Unexpected message: {message}");
-            //     var value = ((TopicMessage.Binary)message).Value();
-            //     receivedSet.Add(value);
-            //
-            //     Assert.Contains(value, valuesToSend);
-            //     if (receivedSet.Count == valuesToSend.Count)
-            //     {
-            //         break;
-            //     }
-            // }
-            return receivedSet.Count;
-        }, cts.Token);
-
-        Console.WriteLine("enumerator task started");
-        // await taskCompletionSourceBool.Task;
-        await semaphoreSlim.WaitAsync(cts.Token);
-        // await Task.Delay(1000);
-
-        foreach (var value in valuesToSend)
-        {
-            var publishResponse = await topicClient.PublishAsync(cacheName, topicName, value);
-            Assert.True(publishResponse is TopicPublishResponse.Success, $"Unexpected response: {publishResponse}");
-            await Task.Delay(100);
-        }
-        Console.WriteLine("messages sent");
-
-        int received = await testTask;
-        Console.WriteLine("Found " + received);
-        // Assert.Equal(valuesToSend.Count, received);
+        Assert.Equal(1, 1);
+        // const string topicName = "topic_bytes";
+        // var valuesToSend = new HashSet<byte[]>
+        // {
+        //     new byte[] { 0x01 },
+        //     new byte[] { 0x02 },
+        //     new byte[] { 0x03 },
+        //     new byte[] { 0x04 },
+        //     new byte[] { 0x05 }
+        // };
+        //
+        // using var cts = new CancellationTokenSource();
+        // cts.CancelAfter(4000);
+        //
+        // // var subscribeResponse = await topicClient.SubscribeAsync(cacheName, topicName);
+        // // Assert.True(subscribeResponse is TopicSubscribeResponse.Subscription,
+        // //     $"Unexpected response: {subscribeResponse}");
+        // // var subscription = ((TopicSubscribeResponse.Subscription)subscribeResponse).WithCancellation(cts.Token);
+        //
+        // Console.WriteLine("subscription created");
+        // // var taskCompletionSourceBool = new TaskCompletionSource<bool>();
+        // var semaphoreSlim = new SemaphoreSlim(0, 1);
+        // var testTask = Task.Run(async () =>
+        // {
+        //     // var messageCount = 0;
+        //     var receivedSet = new HashSet<byte[]>();
+        //     // taskCompletionSourceBool.SetResult(true);
+        //     semaphoreSlim.Release();
+        //     await Task.Delay(2000);
+        //     // await foreach (var message in subscription)
+        //     // {
+        //     //     Assert.NotNull(message);
+        //     //     Assert.True(message is TopicMessage.Binary, $"Unexpected message: {message}");
+        //     //     var value = ((TopicMessage.Binary)message).Value();
+        //     //     receivedSet.Add(value);
+        //     //
+        //     //     Assert.Contains(value, valuesToSend);
+        //     //     if (receivedSet.Count == valuesToSend.Count)
+        //     //     {
+        //     //         break;
+        //     //     }
+        //     // }
+        //     return receivedSet.Count;
+        // }, cts.Token);
+        //
+        // Console.WriteLine("enumerator task started");
+        // // await taskCompletionSourceBool.Task;
+        // await semaphoreSlim.WaitAsync(cts.Token);
+        // // await Task.Delay(1000);
+        //
+        // foreach (var value in valuesToSend)
+        // {
+        //     var publishResponse = await topicClient.PublishAsync(cacheName, topicName, value);
+        //     Assert.True(publishResponse is TopicPublishResponse.Success, $"Unexpected response: {publishResponse}");
+        //     await Task.Delay(100);
+        // }
+        // Console.WriteLine("messages sent");
+        //
+        // int received = await testTask;
+        // Console.WriteLine("Found " + received);
+        // // Assert.Equal(valuesToSend.Count, received);
     }
 
     // [Fact(Timeout = 5000)]

--- a/tests/Integration/Momento.Sdk.Tests/TopicTest.cs
+++ b/tests/Integration/Momento.Sdk.Tests/TopicTest.cs
@@ -115,40 +115,40 @@ public class TopicTest : IClassFixture<CacheClientFixture>, IClassFixture<TopicC
         }
     }
 
-    // [Fact(Timeout = 5000)]
-    // public async Task PublishAndSubscribe_String_Succeeds()
-    // {
-    //     const string topicName = "topic_string";
-    //     var valuesToSend = new List<string>
-    //     {
-    //         "one",
-    //         "two",
-    //         "three",
-    //         "four",
-    //         "five"
-    //     };
-    //     
-    //     var produceCancellation = new CancellationTokenSource();
-    //     produceCancellation.CancelAfter(2000);
-    //
-    //     // we don't need to put this on a different thread
-    //     var consumeTask = ConsumeMessages(topicName, produceCancellation.Token);
-    //     await Task.Delay(50);
-    //     
-    //     await ProduceMessages(topicName, valuesToSend);
-    //     await Task.Delay(500);
-    //     
-    //     produceCancellation.Cancel();
-    //     
-    //     var consumedMessages = await consumeTask;
-    //     Assert.Equal(valuesToSend.Count, consumedMessages.Count);
-    //     for (var i = 0; i < valuesToSend.Count; ++i)
-    //     {
-    //         var message = (TopicMessage.Text)consumedMessages[i];
-    //         Assert.Equal(message.Value, valuesToSend[i]);
-    //     }
-    // }
-    
+    [Fact(Timeout = 5000)]
+    public async Task PublishAndSubscribe_String_Succeeds()
+    {
+        const string topicName = "topic_string";
+        var valuesToSend = new List<string>
+         {
+             "one",
+             "two",
+             "three",
+             "four",
+             "five"
+         };
+
+        var produceCancellation = new CancellationTokenSource();
+        produceCancellation.CancelAfter(2000);
+
+        // we don't need to put this on a different thread
+        var consumeTask = ConsumeMessages(topicName, produceCancellation.Token);
+        await Task.Delay(50);
+
+        await ProduceMessages(topicName, valuesToSend);
+        await Task.Delay(500);
+
+        produceCancellation.Cancel();
+
+        var consumedMessages = await consumeTask;
+        Assert.Equal(valuesToSend.Count, consumedMessages.Count);
+        for (var i = 0; i < valuesToSend.Count; ++i)
+        {
+            var message = (TopicMessage.Text)consumedMessages[i];
+            Assert.Equal(message.Value, valuesToSend[i]);
+        }
+    }
+
     private async Task ProduceMessages(string topicName, List<byte[]> valuesToSend)
     {
         foreach (var value in valuesToSend)

--- a/tests/Integration/Momento.Sdk.Tests/TopicTest.cs
+++ b/tests/Integration/Momento.Sdk.Tests/TopicTest.cs
@@ -85,6 +85,7 @@ public class TopicTest : IClassFixture<CacheClientFixture>, IClassFixture<TopicC
     [Fact(Timeout = 5000)]
     public async Task PublishAndSubscribe_ByteArray_Succeeds()
     {
+        testOutputHelper.WriteLine("starting binary publish and subscribe test");
         const string topicName = "topic_bytes";
         var valuesToSend = new List<byte[]>
         {
@@ -138,6 +139,7 @@ public class TopicTest : IClassFixture<CacheClientFixture>, IClassFixture<TopicC
     [Fact(Timeout = 5000)]
     public async Task PublishAndSubscribe_String_Succeeds()
     {
+        testOutputHelper.WriteLine("starting string publish and subscribe test");
         const string topicName = "topic_string";
         var valuesToSend = new List<string>
         {
@@ -191,6 +193,7 @@ public class TopicTest : IClassFixture<CacheClientFixture>, IClassFixture<TopicC
     [Fact(Timeout = 5000)]
     public async Task Subscribe_EnumerateClosed_Succeeds()
     {
+        testOutputHelper.WriteLine("starting enumerate after closed test");
         const string topicName = "topic_closed";
         const string messageValue = "value";
 

--- a/tests/Integration/Momento.Sdk.Tests/TopicTest.cs
+++ b/tests/Integration/Momento.Sdk.Tests/TopicTest.cs
@@ -115,39 +115,39 @@ public class TopicTest : IClassFixture<CacheClientFixture>, IClassFixture<TopicC
         }
     }
 
-    [Fact(Timeout = 5000)]
-    public async Task PublishAndSubscribe_String_Succeeds()
-    {
-        const string topicName = "topic_string";
-        var valuesToSend = new List<string>
-        {
-            "one",
-            "two",
-            "three",
-            "four",
-            "five"
-        };
-        
-        var produceCancellation = new CancellationTokenSource();
-        produceCancellation.CancelAfter(2000);
-
-        // we don't need to put this on a different thread
-        var consumeTask = ConsumeMessages(topicName, produceCancellation.Token);
-        await Task.Delay(50);
-        
-        await ProduceMessages(topicName, valuesToSend);
-        await Task.Delay(500);
-        
-        produceCancellation.Cancel();
-        
-        var consumedMessages = await consumeTask;
-        Assert.Equal(valuesToSend.Count, consumedMessages.Count);
-        for (var i = 0; i < valuesToSend.Count; ++i)
-        {
-            var message = (TopicMessage.Text)consumedMessages[i];
-            Assert.Equal(message.Value, valuesToSend[i]);
-        }
-    }
+    // [Fact(Timeout = 5000)]
+    // public async Task PublishAndSubscribe_String_Succeeds()
+    // {
+    //     const string topicName = "topic_string";
+    //     var valuesToSend = new List<string>
+    //     {
+    //         "one",
+    //         "two",
+    //         "three",
+    //         "four",
+    //         "five"
+    //     };
+    //     
+    //     var produceCancellation = new CancellationTokenSource();
+    //     produceCancellation.CancelAfter(2000);
+    //
+    //     // we don't need to put this on a different thread
+    //     var consumeTask = ConsumeMessages(topicName, produceCancellation.Token);
+    //     await Task.Delay(50);
+    //     
+    //     await ProduceMessages(topicName, valuesToSend);
+    //     await Task.Delay(500);
+    //     
+    //     produceCancellation.Cancel();
+    //     
+    //     var consumedMessages = await consumeTask;
+    //     Assert.Equal(valuesToSend.Count, consumedMessages.Count);
+    //     for (var i = 0; i < valuesToSend.Count; ++i)
+    //     {
+    //         var message = (TopicMessage.Text)consumedMessages[i];
+    //         Assert.Equal(message.Value, valuesToSend[i]);
+    //     }
+    // }
     
     private async Task ProduceMessages(string topicName, List<byte[]> valuesToSend)
     {

--- a/tests/Integration/Momento.Sdk.Tests/TopicTest.cs
+++ b/tests/Integration/Momento.Sdk.Tests/TopicTest.cs
@@ -1,3 +1,5 @@
+#if NET6_0_OR_GREATER
+
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -220,3 +222,4 @@ public class TopicTest : IClassFixture<CacheClientFixture>, IClassFixture<TopicC
         Assert.Null(enumerator.Current);
     }
 }
+#endif

--- a/tests/Integration/Momento.Sdk.Tests/TopicTest.cs
+++ b/tests/Integration/Momento.Sdk.Tests/TopicTest.cs
@@ -88,51 +88,50 @@ public class TopicTest : IClassFixture<CacheClientFixture>, IClassFixture<TopicC
     public async Task PublishAndSubscribe_ByteArray_Succeeds()
     {
         Console.WriteLine("starting binary publish and subscribe test");
-        Assert.Equal(1, 1);
-        // const string topicName = "topic_bytes";
-        // var valuesToSend = new HashSet<byte[]>
-        // {
-        //     new byte[] { 0x01 },
-        //     new byte[] { 0x02 },
-        //     new byte[] { 0x03 },
-        //     new byte[] { 0x04 },
-        //     new byte[] { 0x05 }
-        // };
-        //
-        // using var cts = new CancellationTokenSource();
-        // cts.CancelAfter(4000);
-        //
-        // // var subscribeResponse = await topicClient.SubscribeAsync(cacheName, topicName);
-        // // Assert.True(subscribeResponse is TopicSubscribeResponse.Subscription,
-        // //     $"Unexpected response: {subscribeResponse}");
-        // // var subscription = ((TopicSubscribeResponse.Subscription)subscribeResponse).WithCancellation(cts.Token);
-        //
-        // Console.WriteLine("subscription created");
-        // // var taskCompletionSourceBool = new TaskCompletionSource<bool>();
-        // var semaphoreSlim = new SemaphoreSlim(0, 1);
-        // var testTask = Task.Run(async () =>
-        // {
-        //     // var messageCount = 0;
-        //     var receivedSet = new HashSet<byte[]>();
-        //     // taskCompletionSourceBool.SetResult(true);
-        //     semaphoreSlim.Release();
-        //     await Task.Delay(2000);
-        //     // await foreach (var message in subscription)
-        //     // {
-        //     //     Assert.NotNull(message);
-        //     //     Assert.True(message is TopicMessage.Binary, $"Unexpected message: {message}");
-        //     //     var value = ((TopicMessage.Binary)message).Value();
-        //     //     receivedSet.Add(value);
-        //     //
-        //     //     Assert.Contains(value, valuesToSend);
-        //     //     if (receivedSet.Count == valuesToSend.Count)
-        //     //     {
-        //     //         break;
-        //     //     }
-        //     // }
-        //     return receivedSet.Count;
-        // }, cts.Token);
-        //
+        const string topicName = "topic_bytes";
+        var valuesToSend = new HashSet<byte[]>
+        {
+            new byte[] { 0x01 },
+            new byte[] { 0x02 },
+            new byte[] { 0x03 },
+            new byte[] { 0x04 },
+            new byte[] { 0x05 }
+        };
+
+        using var cts = new CancellationTokenSource();
+        cts.CancelAfter(4000);
+
+        // var subscribeResponse = await topicClient.SubscribeAsync(cacheName, topicName);
+        // Assert.True(subscribeResponse is TopicSubscribeResponse.Subscription,
+        //     $"Unexpected response: {subscribeResponse}");
+        // var subscription = ((TopicSubscribeResponse.Subscription)subscribeResponse).WithCancellation(cts.Token);
+
+        Console.WriteLine("subscription created");
+        // var taskCompletionSourceBool = new TaskCompletionSource<bool>();
+        var semaphoreSlim = new SemaphoreSlim(0, 1);
+        var testTask = Task.Run(async () =>
+        {
+            // var messageCount = 0;
+            var receivedSet = new HashSet<byte[]>();
+            // taskCompletionSourceBool.SetResult(true);
+            semaphoreSlim.Release();
+            await Task.Delay(2000);
+            // await foreach (var message in subscription)
+            // {
+            //     Assert.NotNull(message);
+            //     Assert.True(message is TopicMessage.Binary, $"Unexpected message: {message}");
+            //     var value = ((TopicMessage.Binary)message).Value();
+            //     receivedSet.Add(value);
+            //
+            //     Assert.Contains(value, valuesToSend);
+            //     if (receivedSet.Count == valuesToSend.Count)
+            //     {
+            //         break;
+            //     }
+            // }
+            return receivedSet.Count;
+        }, cts.Token);
+
         // Console.WriteLine("enumerator task started");
         // // await taskCompletionSourceBool.Task;
         // await semaphoreSlim.WaitAsync(cts.Token);
@@ -145,10 +144,10 @@ public class TopicTest : IClassFixture<CacheClientFixture>, IClassFixture<TopicC
         //     await Task.Delay(100);
         // }
         // Console.WriteLine("messages sent");
-        //
-        // int received = await testTask;
-        // Console.WriteLine("Found " + received);
-        // // Assert.Equal(valuesToSend.Count, received);
+
+        int received = await testTask;
+        Console.WriteLine("Found " + received);
+        // Assert.Equal(valuesToSend.Count, received);
     }
 
     // [Fact(Timeout = 5000)]

--- a/tests/Integration/Momento.Sdk.Tests/TopicTest.cs
+++ b/tests/Integration/Momento.Sdk.Tests/TopicTest.cs
@@ -3,91 +3,86 @@
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using Xunit.Abstractions;
 
 // ReSharper disable once CheckNamespace
 namespace Momento.Sdk.Tests;
 
 public class TopicTest : IClassFixture<CacheClientFixture>, IClassFixture<TopicClientFixture>
 {
-    private readonly ITestOutputHelper testOutputHelper;
     private readonly string cacheName;
     private readonly ITopicClient topicClient;
 
-    public TopicTest(CacheClientFixture cacheFixture, TopicClientFixture topicFixture,
-        ITestOutputHelper testOutputHelper)
+    public TopicTest(CacheClientFixture cacheFixture, TopicClientFixture topicFixture)
     {
-        this.testOutputHelper = testOutputHelper;
         topicClient = topicFixture.Client;
         cacheName = cacheFixture.CacheName;
     }
 
-    // [Theory]
-    // [InlineData(null, "topic")]
-    // [InlineData("cache", null)]
-    // public async Task PublishAsync_NullChecksByteArray_IsError(string badCacheName, string badTopicName)
-    // {
-    //     var response = await topicClient.PublishAsync(badCacheName, badTopicName, Array.Empty<byte>());
-    //     Assert.True(response is TopicPublishResponse.Error, $"Unexpected response: {response}");
-    //     Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((TopicPublishResponse.Error)response).ErrorCode);
-    // }
-    //
-    // [Fact]
-    // public async Task PublishAsync_PublishNullByteArray_IsError()
-    // {
-    //     var response = await topicClient.PublishAsync(cacheName, "topic", (byte[])null!);
-    //     Assert.True(response is TopicPublishResponse.Error, $"Unexpected response: {response}");
-    //     Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((TopicPublishResponse.Error)response).ErrorCode);
-    // }
-    //
-    // [Fact]
-    // public async Task PublishAsync_BadCacheNameByteArray_IsError()
-    // {
-    //     var response = await topicClient.PublishAsync("fake-" + cacheName, "topic", Array.Empty<byte>());
-    //     Assert.True(response is TopicPublishResponse.Error, $"Unexpected response: {response}");
-    //     Assert.Equal(MomentoErrorCode.NOT_FOUND_ERROR, ((TopicPublishResponse.Error)response).ErrorCode);
-    // }
-    //
-    // [Theory]
-    // [InlineData(null, "topic")]
-    // [InlineData("cache", null)]
-    // public async Task PublishAsync_NullChecksString_IsError(string badCacheName, string badTopicName)
-    // {
-    //     var response = await topicClient.PublishAsync(badCacheName, badTopicName, "value");
-    //     Assert.True(response is TopicPublishResponse.Error, $"Unexpected response: {response}");
-    //     Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((TopicPublishResponse.Error)response).ErrorCode);
-    // }
-    //
-    // [Fact]
-    // public async Task PublishAsync_PublishNullString_IsError()
-    // {
-    //     var response = await topicClient.PublishAsync(cacheName, "topic", (string)null!);
-    //     Assert.True(response is TopicPublishResponse.Error, $"Unexpected response: {response}");
-    //     Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((TopicPublishResponse.Error)response).ErrorCode);
-    // }
-    //
-    // [Fact]
-    // public async Task PublishAsync_BadCacheNameString_IsError()
-    // {
-    //     var response = await topicClient.PublishAsync("fake-" + cacheName, "topic", "value");
-    //     Assert.True(response is TopicPublishResponse.Error, $"Unexpected response: {response}");
-    //     Assert.Equal(MomentoErrorCode.NOT_FOUND_ERROR, ((TopicPublishResponse.Error)response).ErrorCode);
-    // }
-    //
-    // [Theory]
-    // [InlineData(null, "topic")]
-    // [InlineData("cache", null)]
-    // public async Task SubscribeAsync_NullChecks_IsError(string badCacheName, string badTopicName)
-    // {
-    //     var response = await topicClient.SubscribeAsync(badCacheName, badTopicName);
-    //     Assert.True(response is TopicSubscribeResponse.Error, $"Unexpected response: {response}");
-    //     Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((TopicSubscribeResponse.Error)response).ErrorCode);
-    // }
+    [Theory]
+    [InlineData(null, "topic")]
+    [InlineData("cache", null)]
+    public async Task PublishAsync_NullChecksByteArray_IsError(string badCacheName, string badTopicName)
+    {
+        var response = await topicClient.PublishAsync(badCacheName, badTopicName, Array.Empty<byte>());
+        Assert.True(response is TopicPublishResponse.Error, $"Unexpected response: {response}");
+        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((TopicPublishResponse.Error)response).ErrorCode);
+    }
+    
+    [Fact]
+    public async Task PublishAsync_PublishNullByteArray_IsError()
+    {
+        var response = await topicClient.PublishAsync(cacheName, "topic", (byte[])null!);
+        Assert.True(response is TopicPublishResponse.Error, $"Unexpected response: {response}");
+        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((TopicPublishResponse.Error)response).ErrorCode);
+    }
+    
+    [Fact]
+    public async Task PublishAsync_BadCacheNameByteArray_IsError()
+    {
+        var response = await topicClient.PublishAsync("fake-" + cacheName, "topic", Array.Empty<byte>());
+        Assert.True(response is TopicPublishResponse.Error, $"Unexpected response: {response}");
+        Assert.Equal(MomentoErrorCode.NOT_FOUND_ERROR, ((TopicPublishResponse.Error)response).ErrorCode);
+    }
+    
+    [Theory]
+    [InlineData(null, "topic")]
+    [InlineData("cache", null)]
+    public async Task PublishAsync_NullChecksString_IsError(string badCacheName, string badTopicName)
+    {
+        var response = await topicClient.PublishAsync(badCacheName, badTopicName, "value");
+        Assert.True(response is TopicPublishResponse.Error, $"Unexpected response: {response}");
+        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((TopicPublishResponse.Error)response).ErrorCode);
+    }
+    
+    [Fact]
+    public async Task PublishAsync_PublishNullString_IsError()
+    {
+        var response = await topicClient.PublishAsync(cacheName, "topic", (string)null!);
+        Assert.True(response is TopicPublishResponse.Error, $"Unexpected response: {response}");
+        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((TopicPublishResponse.Error)response).ErrorCode);
+    }
+    
+    [Fact]
+    public async Task PublishAsync_BadCacheNameString_IsError()
+    {
+        var response = await topicClient.PublishAsync("fake-" + cacheName, "topic", "value");
+        Assert.True(response is TopicPublishResponse.Error, $"Unexpected response: {response}");
+        Assert.Equal(MomentoErrorCode.NOT_FOUND_ERROR, ((TopicPublishResponse.Error)response).ErrorCode);
+    }
+    
+    [Theory]
+    [InlineData(null, "topic")]
+    [InlineData("cache", null)]
+    public async Task SubscribeAsync_NullChecks_IsError(string badCacheName, string badTopicName)
+    {
+        var response = await topicClient.SubscribeAsync(badCacheName, badTopicName);
+        Assert.True(response is TopicSubscribeResponse.Error, $"Unexpected response: {response}");
+        Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((TopicSubscribeResponse.Error)response).ErrorCode);
+    }
 
     [Fact(Timeout = 5000)]
     public async Task PublishAndSubscribe_ByteArray_Succeeds()
     {
-        Console.WriteLine("starting binary publish and subscribe test");
         const string topicName = "topic_bytes";
         var valuesToSend = new HashSet<byte[]>
         {
@@ -100,40 +95,94 @@ public class TopicTest : IClassFixture<CacheClientFixture>, IClassFixture<TopicC
         
         var produceCtx = new CancellationTokenSource();
 
-        var consumeTask = Task.Run(async () => await ConsumeItems(produceCtx.Token, topicName));
+        var consumeTask = Task.Run(async () => await ConsumeMessages(topicName, produceCtx.Token));
 
-        Console.Error.WriteLine("consume task created");
         await Task.Delay(500);
-        Console.Error.WriteLine("first delay finished");
-        await ProduceItems(topicName, valuesToSend);
-
-        Console.Error.WriteLine("messages produced");
-        await Task.Delay(500);
-        Console.Error.WriteLine("second delay finished");
-        produceCtx.Cancel();
-        Console.Error.WriteLine("consume task cancelled");
-        var producedItems = await consumeTask;
-        Assert.Equal(valuesToSend.Count, producedItems.Count);
+        
         foreach (var value in valuesToSend)
         {
-            Assert.Contains(value, valuesToSend);
+            var publishResponse = await topicClient.PublishAsync(cacheName, topicName, value);
+            switch (publishResponse)
+            {
+                case TopicPublishResponse.Success success:
+                    await Task.Delay(100);
+                    break;
+                default:
+                    Assert.Fail("Unable to send message");
+                    break;
+            }
+        }
+
+        await Task.Delay(500);
+        produceCtx.Cancel();
+        
+        var consumedMessages = await consumeTask;
+        Assert.Equal(valuesToSend.Count, consumedMessages.Count);
+        foreach (var message in consumedMessages)
+        {
+            Assert.Contains(((TopicMessage.Binary)message).Value, valuesToSend);
         }
     }
 
-    private async Task<HashSet<byte[]>> ConsumeItems(CancellationToken token, string topicName)
+    [Fact(Timeout = 5000)]
+    public async Task PublishAndSubscribe_String_Succeeds()
+    {
+        const string topicName = "topic_string";
+        var valuesToSend = new List<string>
+        {
+            "one",
+            "two",
+            "three",
+            "four",
+            "five"
+        };
+        
+        var produceCtx = new CancellationTokenSource();
+
+        var consumeTask = Task.Run(async () => await ConsumeMessages(topicName, produceCtx.Token));
+
+        await Task.Delay(500);
+        
+        foreach (var value in valuesToSend)
+        {
+            var publishResponse = await topicClient.PublishAsync(cacheName, topicName, value);
+            switch (publishResponse)
+            {
+                case TopicPublishResponse.Success success:
+                    await Task.Delay(100);
+                    break;
+                default:
+                    Assert.Fail("Unable to send message");
+                    break;
+            }
+        }
+
+        await Task.Delay(500);
+        produceCtx.Cancel();
+        
+        var consumedMessages = await consumeTask;
+        Assert.Equal(valuesToSend.Count, consumedMessages.Count);
+        foreach (var message in consumedMessages)
+        {
+            Assert.Contains(((TopicMessage.Text)message).Value, valuesToSend);
+        }
+    }
+    
+    private async Task<List<TopicMessage>> ConsumeMessages(string topicName, CancellationToken token)
     {
         var subscribeResponse = await topicClient.SubscribeAsync(cacheName, topicName);
         switch (subscribeResponse)
         {
             case TopicSubscribeResponse.Subscription subscription:
                 var cancellableSub = subscription.WithCancellation(token);
-                var receivedSet = new HashSet<byte[]>();
+                var receivedSet = new List<TopicMessage>();
                 await foreach (var message in cancellableSub)
                 {
                     switch (message)
                     {
-                        case TopicMessage.Binary binary:
-                            receivedSet.Add(binary.Value());
+                        case TopicMessage.Binary:
+                        case TopicMessage.Text:
+                            receivedSet.Add(message);
                             break;
                         default:
                             throw new Exception("bad message received");
@@ -145,105 +194,5 @@ public class TopicTest : IClassFixture<CacheClientFixture>, IClassFixture<TopicC
                 throw new Exception("subscription error");
         }
     }
-
-    private async Task ProduceItems(string topicName, HashSet<byte[]> itemsToSend)
-    {
-        foreach (var value in itemsToSend)
-        {
-            var publishResponse = await topicClient.PublishAsync(cacheName, topicName, value);
-            switch (publishResponse)
-            {
-                case TopicPublishResponse.Success success:
-                    await Task.Delay(100);
-                    break;
-                default:
-                    throw new Exception("publish error");
-            }
-        }
-    }
-
-    // [Fact(Timeout = 5000)]
-    // public async Task PublishAndSubscribe_String_Succeeds()
-    // {
-    //     testOutputHelper.WriteLine("starting string publish and subscribe test");
-    //     const string topicName = "topic_string";
-    //     var valuesToSend = new List<string>
-    //     {
-    //         "one",
-    //         "two",
-    //         "three",
-    //         "four",
-    //         "five"
-    //     };
-    //
-    //     using var cts = new CancellationTokenSource();
-    //     cts.CancelAfter(4000);
-    //
-    //     var subscribeResponse = await topicClient.SubscribeAsync(cacheName, topicName);
-    //     Assert.True(subscribeResponse is TopicSubscribeResponse.Subscription,
-    //         $"Unexpected response: {subscribeResponse}");
-    //     var subscription = ((TopicSubscribeResponse.Subscription)subscribeResponse).WithCancellation(cts.Token);
-    //
-    //     var testTask = Task.Run(async () =>
-    //     {
-    //         var messageCount = 0;
-    //         await foreach (var message in subscription)
-    //         {
-    //             Assert.NotNull(message);
-    //             Assert.True(message is TopicMessage.Text, $"Unexpected message: {message}");
-    //
-    //             Assert.Equal(valuesToSend[messageCount], ((TopicMessage.Text)message).Value);
-    //
-    //             messageCount++;
-    //             if (messageCount == valuesToSend.Count)
-    //             {
-    //                 break;
-    //             }
-    //         }
-    //
-    //         return messageCount;
-    //     }, cts.Token);
-    //
-    //     await Task.Delay(1000);
-    //
-    //     foreach (var value in valuesToSend)
-    //     {
-    //         var publishResponse = await topicClient.PublishAsync(cacheName, topicName, value);
-    //         Assert.True(publishResponse is TopicPublishResponse.Success, $"Unexpected response: {publishResponse}");
-    //         await Task.Delay(100);
-    //     }
-    //
-    //     Assert.Equal(valuesToSend.Count, await testTask);
-    // }
-
-    // [Fact(Timeout = 5000)]
-    // public async Task Subscribe_EnumerateClosed_Succeeds()
-    // {
-    //     testOutputHelper.WriteLine("starting enumerate after closed test");
-    //     const string topicName = "topic_closed";
-    //     const string messageValue = "value";
-    //
-    //     using var cts = new CancellationTokenSource();
-    //
-    //     var subscribeResponse = await topicClient.SubscribeAsync(cacheName, topicName);
-    //     Assert.True(subscribeResponse is TopicSubscribeResponse.Subscription,
-    //         $"Unexpected response: {subscribeResponse}");
-    //     var subscription = ((TopicSubscribeResponse.Subscription)subscribeResponse).WithCancellation(cts.Token);
-    //     testOutputHelper.WriteLine("subscribed");
-    //
-    //     var enumerator = subscription.GetAsyncEnumerator();
-    //     Assert.Null(enumerator.Current);
-    //     testOutputHelper.WriteLine("enumerator gotten");
-    //
-    //     var publishResponse = await topicClient.PublishAsync(cacheName, topicName, messageValue);
-    //     Assert.True(publishResponse is TopicPublishResponse.Success, $"Unexpected response: {publishResponse}");
-    //     testOutputHelper.WriteLine("message published");
-    //
-    //     cts.Cancel();
-    //
-    //     Assert.False(await enumerator.MoveNextAsync());
-    //
-    //     Assert.Null(enumerator.Current);
-    // }
 }
 #endif

--- a/tests/Integration/Momento.Sdk.Tests/TopicTest.cs
+++ b/tests/Integration/Momento.Sdk.Tests/TopicTest.cs
@@ -94,6 +94,7 @@ public class TopicTest : IClassFixture<CacheClientFixture>, IClassFixture<TopicC
         };
         
         var produceCtx = new CancellationTokenSource();
+        produceCtx.CancelAfter(2000);
 
         var consumeTask = Task.Run(async () => await ConsumeMessages(topicName, produceCtx.Token));
         await Task.Delay(500);
@@ -125,6 +126,7 @@ public class TopicTest : IClassFixture<CacheClientFixture>, IClassFixture<TopicC
         };
         
         var produceCtx = new CancellationTokenSource();
+        produceCtx.CancelAfter(2000);
 
         var consumeTask = Task.Run(async () => await ConsumeMessages(topicName, produceCtx.Token));
         await Task.Delay(500);
@@ -180,9 +182,9 @@ public class TopicTest : IClassFixture<CacheClientFixture>, IClassFixture<TopicC
         switch (subscribeResponse)
         {
             case TopicSubscribeResponse.Subscription subscription:
-                var cancellableSub = subscription.WithCancellation(token);
+                var cancellableSubscription = subscription.WithCancellation(token);
                 var receivedSet = new List<TopicMessage>();
-                await foreach (var message in cancellableSub)
+                await foreach (var message in cancellableSubscription)
                 {
                     switch (message)
                     {

--- a/tests/Integration/Momento.Sdk.Tests/TopicTest.cs
+++ b/tests/Integration/Momento.Sdk.Tests/TopicTest.cs
@@ -98,7 +98,7 @@ public class TopicTest : IClassFixture<CacheClientFixture>, IClassFixture<TopicC
         var consumeTask = Task.Run(async () => await ConsumeMessages(topicName, produceCtx.Token));
         await Task.Delay(500);
         
-        await Task.Run(async () => await ProduceMessages(topicName, valuesToSend));
+        await ProduceMessages(topicName, valuesToSend);
         await Task.Delay(500);
         
         produceCtx.Cancel();
@@ -129,7 +129,7 @@ public class TopicTest : IClassFixture<CacheClientFixture>, IClassFixture<TopicC
         var consumeTask = Task.Run(async () => await ConsumeMessages(topicName, produceCtx.Token));
         await Task.Delay(500);
         
-        await Task.Run(async () => await ProduceMessages(topicName, valuesToSend));
+        await ProduceMessages(topicName, valuesToSend);
         await Task.Delay(500);
         
         produceCtx.Cancel();

--- a/tests/Integration/Momento.Sdk.Tests/xunit.runner.json
+++ b/tests/Integration/Momento.Sdk.Tests/xunit.runner.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+  "parallelizeTestCollections": false
+}


### PR DESCRIPTION
Add the initial topics implementation. The entry point is TopicClient, which contains the publish and subscribe methods. Subscribe returns an IAsyncEnumerable<TopicMessage> that can be iterated over to read from the topic.