### PR TITLE
chore: add topics and disposable token code snippets for dev docs

### DIFF
--- a/examples/DocExampleApis/DocExampleApis.csproj
+++ b/examples/DocExampleApis/DocExampleApis.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Momento.Sdk" Version="1.19.0" />
+    <PackageReference Include="Momento.Sdk" Version="1.21.1" />
   </ItemGroup>
 
 </Project>

--- a/examples/DocExampleApis/Program.cs
+++ b/examples/DocExampleApis/Program.cs
@@ -140,38 +140,71 @@ public class Program
 
     public static async Task Example_API_GenerateDisposableToken(IAuthClient authClient)
     {
-        var scope = new DisposableTokenScope(Permissions: new List<DisposableTokenPermission>
-        {
-            new DisposableToken.CacheItemPermission(
-                CacheRole.ReadWrite,
-                CacheSelector.ByName("cache"),
-                CacheItemSelector.AllCacheItems
-            ),
-            new DisposableToken.CachePermission(
-                CacheRole.ReadOnly,
-                CacheSelector.ByName("topsecret")
-            ),
-            new DisposableToken.TopicPermission(
-                TopicRole.PublishSubscribe,
-                CacheSelector.ByName("cache"),
-                TopicSelector.ByName("example-topic")
-            )
-        });
-        var tokenResponse = await authClient.GenerateDisposableTokenAsync(
-            scope,
-            ExpiresIn.Minutes(5)
+        // Generate a disposable token with read-write access to a specific key in one cache
+        var oneKeyOneCacheToken = await authClient.GenerateDisposableTokenAsync(
+            DisposableTokenScopes.CacheKeyReadWrite("squirrels", "mo"),
+            ExpiresIn.Minutes(30)
         );
-
-        if (tokenResponse is GenerateDisposableTokenResponse.Success token)
+        if (oneKeyOneCacheToken is GenerateDisposableTokenResponse.Success token1)
         {
-            Console.WriteLine("The generated disposable token is: " + token.AuthToken);
-            Console.WriteLine("The token endpoint is: " + token.Endpoint);
-            Console.WriteLine("The token expires at (epoch timestamp): " + token.ExpiresAt.Epoch());
+            
+            // logging only a substring of the tokens, because logging security credentials is not advisable :)
+            Console.WriteLine("The generated disposable token starts with: " + token1.AuthToken.Substring(0, 10));
+            Console.WriteLine("The token expires at (epoch timestamp): " + token1.ExpiresAt.Epoch());
         }
-        else if (tokenResponse is GenerateDisposableTokenResponse.Error err)
+        else if (oneKeyOneCacheToken is GenerateDisposableTokenResponse.Error err)
         {
             Console.WriteLine("Error generating disposable token: " + err.Message);
         }
+
+        // Generate a disposable token with read-write access to a specific key prefix in all caches
+        var keyPrefixAllCachesToken = await authClient.GenerateDisposableTokenAsync(
+            DisposableTokenScopes.CacheKeyPrefixReadWrite(CacheSelector.AllCaches, "squirrel"),
+            ExpiresIn.Minutes(30)
+        );
+        if (keyPrefixAllCachesToken is GenerateDisposableTokenResponse.Success token2)
+        {
+            // logging only a substring of the tokens, because logging security credentials is not advisable :)
+            Console.WriteLine("The generated disposable token starts with: " + token2.AuthToken.Substring(0, 10));
+            Console.WriteLine("The token expires at (epoch timestamp): " + token2.ExpiresAt.Epoch());
+        }
+        else if (keyPrefixAllCachesToken is GenerateDisposableTokenResponse.Error err)
+        {
+            Console.WriteLine("Error generating disposable token: " + err.Message);
+        }
+
+        // Generate a disposable token with read-only access to all topics in one cache
+        var allTopicsOneCacheToken = await authClient.GenerateDisposableTokenAsync(
+            DisposableTokenScopes.TopicSubscribeOnly(CacheSelector.ByName("squirrel"), TopicSelector.AllTopics),
+            ExpiresIn.Minutes(30)
+        );
+        if (allTopicsOneCacheToken is GenerateDisposableTokenResponse.Success token3)
+        {
+            // logging only a substring of the tokens, because logging security credentials is not advisable :)
+            Console.WriteLine("The generated disposable token starts with: " + token3.AuthToken.Substring(0, 10));
+            Console.WriteLine("The token expires at (epoch timestamp): " + token3.ExpiresAt.Epoch());
+        }
+        else if (allTopicsOneCacheToken is GenerateDisposableTokenResponse.Error err)
+        {
+            Console.WriteLine("Error generating disposable token: " + err.Message);
+        }
+
+        // Generate a disposable token with write-only access to a single topic in all caches
+        var oneTopicAllCachesToken = await authClient.GenerateDisposableTokenAsync(
+            DisposableTokenScopes.TopicPublishOnly(CacheSelector.AllCaches, "acorn"),
+            ExpiresIn.Minutes(30)
+        );
+        if (oneTopicAllCachesToken is GenerateDisposableTokenResponse.Success token4)
+        {
+            // logging only a substring of the tokens, because logging security credentials is not advisable :)
+            Console.WriteLine("The generated disposable token starts with: " + token4.AuthToken.Substring(0, 10));
+            Console.WriteLine("The token expires at (epoch timestamp): " + token4.ExpiresAt.Epoch());
+        }
+        else if (oneTopicAllCachesToken is GenerateDisposableTokenResponse.Error err)
+        {
+            Console.WriteLine("Error generating disposable token: " + err.Message);
+        }
+
     }
 
     public static async Task Example_API_InstantiateTopicClient()

--- a/examples/DocExampleApis/Program.cs
+++ b/examples/DocExampleApis/Program.cs
@@ -145,9 +145,9 @@ public class Program
             DisposableTokenScopes.CacheKeyReadWrite("squirrels", "mo"),
             ExpiresIn.Minutes(30)
         );
+
         if (oneKeyOneCacheToken is GenerateDisposableTokenResponse.Success token1)
         {
-            
             // logging only a substring of the tokens, because logging security credentials is not advisable :)
             Console.WriteLine("The generated disposable token starts with: " + token1.AuthToken.Substring(0, 10));
             Console.WriteLine("The token expires at (epoch timestamp): " + token1.ExpiresAt.Epoch());
@@ -162,6 +162,7 @@ public class Program
             DisposableTokenScopes.CacheKeyPrefixReadWrite(CacheSelector.AllCaches, "squirrel"),
             ExpiresIn.Minutes(30)
         );
+
         if (keyPrefixAllCachesToken is GenerateDisposableTokenResponse.Success token2)
         {
             // logging only a substring of the tokens, because logging security credentials is not advisable :)
@@ -178,6 +179,7 @@ public class Program
             DisposableTokenScopes.TopicSubscribeOnly(CacheSelector.ByName("squirrel"), TopicSelector.AllTopics),
             ExpiresIn.Minutes(30)
         );
+
         if (allTopicsOneCacheToken is GenerateDisposableTokenResponse.Success token3)
         {
             // logging only a substring of the tokens, because logging security credentials is not advisable :)
@@ -194,6 +196,7 @@ public class Program
             DisposableTokenScopes.TopicPublishOnly(CacheSelector.AllCaches, "acorn"),
             ExpiresIn.Minutes(30)
         );
+        
         if (oneTopicAllCachesToken is GenerateDisposableTokenResponse.Success token4)
         {
             // logging only a substring of the tokens, because logging security credentials is not advisable :)
@@ -225,7 +228,6 @@ public class Program
                 break;
             case TopicPublishResponse.Error error:
                 throw new Exception($"An error occurred while publishing topic message: {error.ErrorCode}: {error}");
-                break;
         }
     }
     public static async Task Example_API_TopicSubscribe(ITopicClient topicClient)
@@ -255,7 +257,6 @@ public class Program
                             break;
                         case TopicMessage.Error error:
                             throw new Exception($"An error occurred while receiving topic message: {error.ErrorCode}: {error}");
-                            break;
                         default:
                             throw new Exception("Bad message received");
                     }
@@ -264,7 +265,6 @@ public class Program
                 break;
             case TopicSubscribeResponse.Error error:
                 throw new Exception($"An error occurred subscribing to a topic: {error.ErrorCode}: {error}");
-                break;
         }
     }
 }

--- a/src/Momento.Sdk/Auth/AccessControl/DisposableTokenScopes.cs
+++ b/src/Momento.Sdk/Auth/AccessControl/DisposableTokenScopes.cs
@@ -202,6 +202,11 @@ public record DisposableTokenScopes(List<DisposableTokenPermission> Permissions)
         return TopicPublishSubscribe(cacheSelector, TopicSelector.ByName(topicName));
     }
 
+    public static DisposableTokenScope TopicPublishSubscribe(string cacheName, TopicSelector topicSelector)
+    {
+        return TopicPublishSubscribe(CacheSelector.ByName(cacheName), topicSelector);
+    }
+
     public static DisposableTokenScope TopicPublishSubscribe(CacheSelector cacheSelector, TopicSelector topicSelector)
     {
         return new DisposableTokenScope(Permissions: new List<DisposableTokenPermission>
@@ -225,6 +230,11 @@ public record DisposableTokenScopes(List<DisposableTokenPermission> Permissions)
         return TopicSubscribeOnly(cacheSelector, TopicSelector.ByName(topicName));
     }
 
+    public static DisposableTokenScope TopicSubscribeOnly(string cacheName, TopicSelector topicSelector)
+    {
+        return TopicSubscribeOnly(CacheSelector.ByName(cacheName), topicSelector);
+    }
+
     public static DisposableTokenScope TopicSubscribeOnly(CacheSelector cacheSelector, TopicSelector topicSelector)
     {
         return new DisposableTokenScope(Permissions: new List<DisposableTokenPermission>
@@ -245,6 +255,11 @@ public record DisposableTokenScopes(List<DisposableTokenPermission> Permissions)
     public static DisposableTokenScope TopicPublishOnly(CacheSelector cacheSelector, string topicName)
     {
         return TopicPublishOnly(cacheSelector, TopicSelector.ByName(topicName));
+    }
+
+    public static DisposableTokenScope TopicPublishOnly(string cacheName, TopicSelector topicSelector)
+    {
+        return TopicPublishOnly(CacheSelector.ByName(cacheName), topicSelector);
     }
 
     public static DisposableTokenScope TopicPublishOnly(CacheSelector cacheSelector, TopicSelector topicSelector)


### PR DESCRIPTION
Addresses [#453](https://github.com/momentohq/dev-eco-issue-tracker/issues/453) by adding code snippet for `GenerateDisposableToken` that will be pulled into the dev docs. This snippet can be used [here](https://docs.momentohq.com/develop/authentication/tokens) and [here](https://docs.momentohq.com/develop/api-reference/auth#generatedisposabletoken-api).

Addresses [#459](https://github.com/momentohq/dev-eco-issue-tracker/issues/459) by adding code snippets for instantiating a topic client, publishing to a topic, and subscribing to a topic. These examples will be used [on this page](https://docs.momentohq.com/develop/api-reference/topics).