### PR TITLE
chore: add ToString override for disposable token

### DIFF
--- a/src/Momento.Sdk/Responses/GenerateDisposableTokenResponse.cs
+++ b/src/Momento.Sdk/Responses/GenerateDisposableTokenResponse.cs
@@ -56,6 +56,11 @@ public abstract class GenerateDisposableTokenResponse
             Endpoint = response.Endpoint;
             ExpiresAt = ExpiresAt.FromEpoch((int)response.ValidUntil);
         }
+
+        public override string ToString()
+        {
+            return $"{AuthToken.Substring(0, 10)}...{AuthToken.Substring((AuthToken.Length - 10), 10)}";
+        }
     }
 
     /// <include file="../docs.xml" path='docs/class[@name="Error"]/description/*' />


### PR DESCRIPTION
This commit overrides `ToString` for the `GenerateDisposableTokenResponse.Success` class. Printing an object of this type now displays a truncated version of the token (e.g., `eyJlbmRwb2...03dVBYWSJ9`).