### PR TITLE
chore: return an error from the subscribe method for a bad stream

### DIFF
--- a/src/Momento.Sdk/Exceptions/InternalServerException.cs
+++ b/src/Momento.Sdk/Exceptions/InternalServerException.cs
@@ -8,7 +8,7 @@ namespace Momento.Sdk.Exceptions;
 public class InternalServerException : SdkException
 {
     /// <include file="../docs.xml" path='docs/class[@name="SdkException"]/constructor/*' />
-    public InternalServerException(string message, MomentoErrorTransportDetails transportDetails, Exception? e = null) : base(MomentoErrorCode.INTERNAL_SERVER_ERROR, message, transportDetails, e)
+    public InternalServerException(string message, MomentoErrorTransportDetails? transportDetails = null, Exception? e = null) : base(MomentoErrorCode.INTERNAL_SERVER_ERROR, message, transportDetails, e)
     {
         this.MessageWrapper = "An unexpected error occurred while trying to fulfill the request; please contact us at support@momentohq.com";
     }

--- a/src/Momento.Sdk/Responses/TopicSubscribeResponse.cs
+++ b/src/Momento.Sdk/Responses/TopicSubscribeResponse.cs
@@ -113,7 +113,7 @@ public abstract class TopicSubscribeResponse
                     return true;
                 case TopicMessage.Error:
                     Current = nextMessage;
-                    return true;
+                    return false;
                 default:
                     Current = null;
                     return false;

--- a/tests/Integration/Momento.Sdk.Tests/AuthClientTopicTest.cs
+++ b/tests/Integration/Momento.Sdk.Tests/AuthClientTopicTest.cs
@@ -266,7 +266,7 @@ public class AuthClientTopicTest : IClassFixture<CacheClientFixture>, IClassFixt
         }
     }
 
-    [Fact(Skip = "Enable when SubscribeAsync returns an error")]
+    [Fact]
     public async Task GenerateDisposableTopicAuthToken_WriteOnly_CantSubscribe()
     {
         var writeOnlyTopicClient = await GetClientForTokenScope(
@@ -308,10 +308,9 @@ public class AuthClientTopicTest : IClassFixture<CacheClientFixture>, IClassFixt
         AssertPermissionError<TopicPublishResponse, TopicPublishResponse.Error>(response);
     }
 
-    [Fact(Skip = "Enable when SubscribeAsync returns an error")]
+    [Fact]
     public async Task GenerateDisposableTopicAuthToken_NoCachePerms_CantSubscribe()
     {
-        Assert.True(false);
         var noCachePermsClient = await GetClientForTokenScope(
             DisposableTokenScopes.TopicPublishSubscribe("notthecacheyourelookingfor", topicName)
         );
@@ -329,10 +328,9 @@ public class AuthClientTopicTest : IClassFixture<CacheClientFixture>, IClassFixt
         AssertPermissionError<TopicPublishResponse, TopicPublishResponse.Error>(response);
     }
 
-    [Fact(Skip = "Enable when SubscribeAsync returns an error")]
+    [Fact]
     public async Task GenerateDisposableTopicAuthToken_NoTopicPerms_CantSubscribe()
     {
-        Assert.True(false);
         var noCachePermsClient = await GetClientForTokenScope(
             DisposableTokenScopes.TopicPublishSubscribe(cacheName, "notthetopicyourelookingfor")
         );


### PR DESCRIPTION
Make the internal subscribe method get the first message and check it to ensure the stream can be read. Without this, certain topic errors won't be caught until the user attempts to iterate over the topic stream.

Break out of the subscription when it receives a permission or authentication error. These cannot be recovered from, so there is no point in reconnecting. This covers the case of a token that expires while being used to read a topic.

Enable the auth client topic tests covering cases that should return an error on subscribe.