### PR TITLE
feat: publish a zip file with the unity SDK version and dependencies

### DIFF
--- a/.github/workflows/on-push-to-release-branch.yaml
+++ b/.github/workflows/on-push-to-release-branch.yaml
@@ -65,13 +65,17 @@ jobs:
             rm -rf bin
             VERSION="${{ needs.release.outputs.version }}"
             echo "version: ${VERSION}"
-            dotnet build --configuration Release -f netstandard2.0 -p:DefineConstants=USE_GRPC_WEB
-            DLL_FILE=./bin/Release/netstandard2.0/Momento.Sdk.dll
-            ARCHIVE_FILE_NAME=Momento.Sdk.Unity.${VERSION}.dll
+            dotnet publish --configuration Release -f netstandard2.0 -p:DefineConstants=USE_GRPC_WEB
+            mkdir ./bin/Release/netstandard2.0/MomentoSdkUnity
+            cp -r ./bin/Release/netstandard2.0/publish/*.dll ./bin/Release/netstandard2.0/MomentoSdkUnity/
+            rm ./bin/Release/netstandard2.0/MomentoSdkUnity/Microsoft.CSharp.dll
+            zip -jr MomentoSdkUnity.zip bin/Release/netstandard2.0/MomentoSdkUnity/
+            ZIP_FILE=./MomentoSdkUnity.zip
+            ARCHIVE_FILE_NAME=MomentoSdkUnity-${VERSION}.zip
             AUTH="Authorization: token ${{ secrets.MOMENTO_MACHINE_USER_GITHUB_TOKEN }}"
             LATEST_RELEASE=$(curl -sH "$AUTH" https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/tags/v${VERSION})
             RELEASE_ID=$(echo $LATEST_RELEASE | jq -r .id)
             GH_ASSET="https://uploads.github.com/repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}/assets?name=${ARCHIVE_FILE_NAME}"
             echo $GH_ASSET
-            curl --data-binary @$DLL_FILE -H "$AUTH" -H "Content-Type: application/octet-stream" $GH_ASSET
+            curl --data-binary @$ZIP_FILE -H "$AUTH" -H "Content-Type: application/octet-stream" $GH_ASSET
           popd


### PR DESCRIPTION
Instead of publishing the dll of the Momento SDK for Unity, publish a zip file containing the dll and its dependencies. This can be unzipped into a unity environment and should run without needing to fetch other dependencies.