### PR TITLE
fix: clean up after MVI control tests

### DIFF
--- a/tests/Integration/Momento.Sdk.Tests/TtlTest.cs
+++ b/tests/Integration/Momento.Sdk.Tests/TtlTest.cs
@@ -63,7 +63,7 @@ public class TtlTest : TestBase
         // Add an item with a minute ttl
         byte[] key = Utils.NewGuidByteArray();
         var ttl = TimeSpan.FromSeconds(60);
-        var response = await client.SetAsync(cacheName, key, Utils.NewGuidByteArray());
+        var response = await client.SetAsync(cacheName, key, Utils.NewGuidByteArray(), ttl);
         Assert.True(response is CacheSetResponse.Success, $"Unexpected response: {response}");
 
         // Check it is there
@@ -90,7 +90,7 @@ public class TtlTest : TestBase
         // Add an item with a minute ttl
         string key = Utils.NewGuidString();
         var ttl = TimeSpan.FromSeconds(60);
-        var response = await client.SetAsync(cacheName, key, Utils.NewGuidString());
+        var response = await client.SetAsync(cacheName, key, Utils.NewGuidString(), ttl);
         Assert.True(response is CacheSetResponse.Success, $"Unexpected response: {response}");
 
         // Check it is there
@@ -123,7 +123,8 @@ public class TtlTest : TestBase
         var ttlResponse = await client.ItemGetTtlAsync(cacheName, key);
         Assert.True(ttlResponse is CacheItemGetTtlResponse.Hit, $"Unexpected response: {ttlResponse}");
         var theTtl = ((CacheItemGetTtlResponse.Hit)ttlResponse).Value;
-        Assert.True(theTtl.TotalMilliseconds < 60000 && theTtl.TotalMilliseconds > 55000);
+        Assert.True(theTtl.TotalMilliseconds < 60000,
+            $"TTL should be less than 60 seconds but was {theTtl.TotalMilliseconds}");
 
         await Task.Delay(1000);
 
@@ -131,7 +132,8 @@ public class TtlTest : TestBase
         Assert.True(ttlResponse2 is CacheItemGetTtlResponse.Hit, $"Unexpected response: {ttlResponse}");
         var theTtl2 = ((CacheItemGetTtlResponse.Hit)ttlResponse2).Value;
 
-        Assert.True(theTtl2.TotalMilliseconds <= theTtl.TotalMilliseconds - 1000);
+        Assert.True(theTtl2.TotalMilliseconds < theTtl.TotalMilliseconds,
+            $"TTL should be less than the previous TTL {theTtl.TotalMilliseconds} but was {theTtl2.TotalMilliseconds}");
     }
 
     [Fact]

--- a/tests/Integration/Momento.Sdk.Tests/VectorIndexControlTest.cs
+++ b/tests/Integration/Momento.Sdk.Tests/VectorIndexControlTest.cs
@@ -17,17 +17,22 @@ public class VectorIndexControlTest : IClassFixture<VectorIndexClientFixture>
     {
         var indexName = $"dotnet-integration-{Utils.NewGuidString()}";
         const int numDimensions = 3;
-        
-        var createResponse = await vectorIndexClient.CreateIndexAsync(indexName, numDimensions);
-        Assert.True(createResponse is CreateVectorIndexResponse.Success, $"Unexpected response: {createResponse}");
-        
-        var listResponse = await vectorIndexClient.ListIndexesAsync();
-        Assert.True(listResponse is ListVectorIndexesResponse.Success, $"Unexpected response: {listResponse}");
-        var listOk = (ListVectorIndexesResponse.Success)listResponse;
-        Assert.Contains(listOk.IndexNames, name => name == indexName);
-        
-        var deleteResponse = await vectorIndexClient.DeleteIndexesAsync(indexName);
-        Assert.True(deleteResponse is DeleteVectorIndexResponse.Success, $"Unexpected response: {deleteResponse}");
+
+        try
+        {
+            var createResponse = await vectorIndexClient.CreateIndexAsync(indexName, numDimensions);
+            Assert.True(createResponse is CreateVectorIndexResponse.Success, $"Unexpected response: {createResponse}");
+
+            var listResponse = await vectorIndexClient.ListIndexesAsync();
+            Assert.True(listResponse is ListVectorIndexesResponse.Success, $"Unexpected response: {listResponse}");
+            var listOk = (ListVectorIndexesResponse.Success)listResponse;
+            Assert.Contains(listOk.IndexNames, name => name == indexName);
+        }
+        finally
+        {
+            var deleteResponse = await vectorIndexClient.DeleteIndexesAsync(indexName);
+            Assert.True(deleteResponse is DeleteVectorIndexResponse.Success, $"Unexpected response: {deleteResponse}");
+        }
     }
 
     [Fact]
@@ -35,12 +40,20 @@ public class VectorIndexControlTest : IClassFixture<VectorIndexClientFixture>
     {
         var indexName = $"index-{Utils.NewGuidString()}";
         const int numDimensions = 3;
-        
-        var createResponse = await vectorIndexClient.CreateIndexAsync(indexName, numDimensions);
-        Assert.True(createResponse is CreateVectorIndexResponse.Success, $"Unexpected response: {createResponse}");
-        
-        var createAgainResponse = await vectorIndexClient.CreateIndexAsync(indexName, numDimensions);
-        Assert.True(createAgainResponse is CreateVectorIndexResponse.AlreadyExists, $"Unexpected response: {createAgainResponse}");
+
+        try
+        {
+            var createResponse = await vectorIndexClient.CreateIndexAsync(indexName, numDimensions);
+            Assert.True(createResponse is CreateVectorIndexResponse.Success, $"Unexpected response: {createResponse}");
+
+            var createAgainResponse = await vectorIndexClient.CreateIndexAsync(indexName, numDimensions);
+            Assert.True(createAgainResponse is CreateVectorIndexResponse.AlreadyExists, $"Unexpected response: {createAgainResponse}");
+        }
+        finally
+        {
+            var deleteResponse = await vectorIndexClient.DeleteIndexesAsync(indexName);
+            Assert.True(deleteResponse is DeleteVectorIndexResponse.Success, $"Unexpected response: {deleteResponse}");
+        }
     }
     
     [Fact]


### PR DESCRIPTION
Properly delete indexes in the MVI control tests.

Give intermittently failing TTL test more generous timing and add failure messages.