### PR TITLE
chore: make sure all assert.true statements include message on failure

### DIFF
--- a/tests/Integration/Momento.Sdk.Tests/AuthClientCacheTest.cs
+++ b/tests/Integration/Momento.Sdk.Tests/AuthClientCacheTest.cs
@@ -27,7 +27,7 @@ public class AuthClientCacheTest : IClassFixture<CacheClientFixture>, IClassFixt
     private async Task<ICacheClient> GetClientForTokenScope(DisposableTokenScope scope)
     {
         var response = await authClient.GenerateDisposableTokenAsync(scope, ExpiresIn.Minutes(2));
-        Assert.True(response is GenerateDisposableTokenResponse.Success);
+        Assert.True(response is GenerateDisposableTokenResponse.Success, $"Unexpected response: {response}");
         string authToken = "";
         if (response is GenerateDisposableTokenResponse.Success token)
         {
@@ -41,13 +41,13 @@ public class AuthClientCacheTest : IClassFixture<CacheClientFixture>, IClassFixt
     private async Task SetCacheKey(string cacheName, string key, string value)
     {
         var setResponse = await cacheClient.SetAsync(cacheName, key, value);
-        Assert.True(setResponse is CacheSetResponse.Success);
+        Assert.True(setResponse is CacheSetResponse.Success, $"Unexpected response: {setResponse}");
     }
 
     private async Task VerifyCacheKey(string cacheName, string key, string value)
     {
         var getResponse = await cacheClient.GetAsync(cacheName, key);
-        Assert.True(getResponse is CacheGetResponse.Hit);
+        Assert.True(getResponse is CacheGetResponse.Hit, $"Unexpected response: {getResponse}");
         if (getResponse is CacheGetResponse.Hit hit)
         {
             Assert.Equal(value, hit.ValueString);
@@ -56,7 +56,7 @@ public class AuthClientCacheTest : IClassFixture<CacheClientFixture>, IClassFixt
 
     private void AssertPermissionError<TResp, TErrResp>(TResp response)
     {
-        Assert.True(response is TErrResp);
+        Assert.True(response is TErrResp, $"Unexpected response: {response}");
         if (response is IError err)
         {
             Assert.Equal(err.ErrorCode, MomentoErrorCode.PERMISSION_ERROR);
@@ -69,29 +69,29 @@ public class AuthClientCacheTest : IClassFixture<CacheClientFixture>, IClassFixt
         var response = await authClient.GenerateDisposableTokenAsync(
             DisposableTokenScopes.CacheReadWrite("cache"), ExpiresIn.Minutes(10)
         );
-        Assert.True(response is GenerateDisposableTokenResponse.Success);
+        Assert.True(response is GenerateDisposableTokenResponse.Success, $"Unexpected response: {response}");
         response = await authClient.GenerateDisposableTokenAsync(
             DisposableTokenScopes.CacheReadWrite(CacheSelector.ByName("cache")), ExpiresIn.Minutes(10)
         );
-        Assert.True(response is GenerateDisposableTokenResponse.Success);
+        Assert.True(response is GenerateDisposableTokenResponse.Success, $"Unexpected response: {response}");
 
         response = await authClient.GenerateDisposableTokenAsync(
             DisposableTokenScopes.CacheReadOnly("cache"), ExpiresIn.Minutes(10)
         );
-        Assert.True(response is GenerateDisposableTokenResponse.Success);
+        Assert.True(response is GenerateDisposableTokenResponse.Success, $"Unexpected response: {response}");
         response = await authClient.GenerateDisposableTokenAsync(
             DisposableTokenScopes.CacheReadOnly(CacheSelector.ByName("cache")), ExpiresIn.Minutes(10)
         );
-        Assert.True(response is GenerateDisposableTokenResponse.Success);
+        Assert.True(response is GenerateDisposableTokenResponse.Success, $"Unexpected response: {response}");
 
         response = await authClient.GenerateDisposableTokenAsync(
             DisposableTokenScopes.CacheWriteOnly("cache"), ExpiresIn.Minutes(10)
         );
-        Assert.True(response is GenerateDisposableTokenResponse.Success);
+        Assert.True(response is GenerateDisposableTokenResponse.Success, $"Unexpected response: {response}");
         response = await authClient.GenerateDisposableTokenAsync(
             DisposableTokenScopes.CacheWriteOnly(CacheSelector.ByName("cache")), ExpiresIn.Minutes(10)
         );
-        Assert.True(response is GenerateDisposableTokenResponse.Success);
+        Assert.True(response is GenerateDisposableTokenResponse.Success, $"Unexpected response: {response}");
     }
 
     [Theory]
@@ -102,21 +102,21 @@ public class AuthClientCacheTest : IClassFixture<CacheClientFixture>, IClassFixt
             DisposableTokenScopes.CacheReadWrite(cacheName),
             ExpiresIn.Minutes(10)
         );
-        Assert.True(response is GenerateDisposableTokenResponse.Error);
+        Assert.True(response is GenerateDisposableTokenResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, 
             ((GenerateDisposableTokenResponse.Error)response).ErrorCode);
         response = await authClient.GenerateDisposableTokenAsync(
             DisposableTokenScopes.CacheReadOnly(cacheName),
             ExpiresIn.Minutes(10)
         );
-        Assert.True(response is GenerateDisposableTokenResponse.Error);
+        Assert.True(response is GenerateDisposableTokenResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, 
             ((GenerateDisposableTokenResponse.Error)response).ErrorCode);
         response = await authClient.GenerateDisposableTokenAsync(
             DisposableTokenScopes.CacheWriteOnly(cacheName),
             ExpiresIn.Minutes(10)
         );
-        Assert.True(response is GenerateDisposableTokenResponse.Error);
+        Assert.True(response is GenerateDisposableTokenResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, 
             ((GenerateDisposableTokenResponse.Error)response).ErrorCode);
     }
@@ -128,21 +128,21 @@ public class AuthClientCacheTest : IClassFixture<CacheClientFixture>, IClassFixt
             DisposableTokenScopes.CacheReadWrite(""),
             ExpiresIn.Minutes(10)
         );
-        Assert.True(response is GenerateDisposableTokenResponse.Error);
+        Assert.True(response is GenerateDisposableTokenResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, 
             ((GenerateDisposableTokenResponse.Error)response).ErrorCode);
         response = await authClient.GenerateDisposableTokenAsync(
             DisposableTokenScopes.CacheReadOnly(""),
             ExpiresIn.Minutes(10)
         );
-        Assert.True(response is GenerateDisposableTokenResponse.Error);
+        Assert.True(response is GenerateDisposableTokenResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, 
             ((GenerateDisposableTokenResponse.Error)response).ErrorCode);
         response = await authClient.GenerateDisposableTokenAsync(
             DisposableTokenScopes.CacheWriteOnly(""),
             ExpiresIn.Minutes(10)
         );
-        Assert.True(response is GenerateDisposableTokenResponse.Error);
+        Assert.True(response is GenerateDisposableTokenResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, 
             ((GenerateDisposableTokenResponse.Error)response).ErrorCode);
     }
@@ -155,9 +155,9 @@ public class AuthClientCacheTest : IClassFixture<CacheClientFixture>, IClassFixt
             DisposableTokenScopes.CacheReadWrite(cacheName)
         );
         var setResponse = await readwriteCacheClient.SetAsync(cacheName, key, value);
-        Assert.True(setResponse is CacheSetResponse.Success);
+        Assert.True(setResponse is CacheSetResponse.Success, $"Unexpected response: {setResponse}");
         var getResponse = await readwriteCacheClient.GetAsync(cacheName, key);
-        Assert.True(getResponse is CacheGetResponse.Hit);
+        Assert.True(getResponse is CacheGetResponse.Hit, $"Unexpected response: {getResponse}");
         if (getResponse is CacheGetResponse.Hit hit)
         {
             Assert.Equal(value, hit.ValueString);
@@ -181,7 +181,7 @@ public class AuthClientCacheTest : IClassFixture<CacheClientFixture>, IClassFixt
         AssertPermissionError<CacheSetResponse, CacheSetResponse.Error>(setResponse);
         await SetCacheKey(cacheName, key, value);
         var getResponse = await readonlyCacheClient.GetAsync(cacheName, key);
-        Assert.True(getResponse is CacheGetResponse.Hit);
+        Assert.True(getResponse is CacheGetResponse.Hit, $"Unexpected response: {getResponse}");
         if (getResponse is CacheGetResponse.Hit hit)
         {
             Assert.Equal(value, hit.ValueString);
@@ -195,7 +195,7 @@ public class AuthClientCacheTest : IClassFixture<CacheClientFixture>, IClassFixt
             DisposableTokenScopes.CacheWriteOnly(cacheName)
         );
         var setResponse = await writeonlyCacheClient.SetAsync(cacheName, key, value);
-        Assert.True(setResponse is CacheSetResponse.Success);
+        Assert.True(setResponse is CacheSetResponse.Success, $"Unexpected response: {setResponse}");
         var getResponse = await writeonlyCacheClient.GetAsync(cacheName, key);
         AssertPermissionError<CacheGetResponse, CacheGetResponse.Error>(getResponse);
         await VerifyCacheKey(cacheName, key, value);
@@ -212,29 +212,29 @@ public class AuthClientCacheTest : IClassFixture<CacheClientFixture>, IClassFixt
         var response = await authClient.GenerateDisposableTokenAsync(
             DisposableTokenScopes.CacheKeyReadWrite("cache", "cacheKey"), ExpiresIn.Minutes(10)
         );
-        Assert.True(response is GenerateDisposableTokenResponse.Success);
+        Assert.True(response is GenerateDisposableTokenResponse.Success, $"Unexpected response: {response}");
         response = await authClient.GenerateDisposableTokenAsync(
             DisposableTokenScopes.CacheKeyReadWrite(CacheSelector.ByName("cache"), "cacheKey"), ExpiresIn.Minutes(10)
         );
-        Assert.True(response is GenerateDisposableTokenResponse.Success);
+        Assert.True(response is GenerateDisposableTokenResponse.Success, $"Unexpected response: {response}");
 
         response = await authClient.GenerateDisposableTokenAsync(
             DisposableTokenScopes.CacheKeyReadOnly("cache", "cacheKey"), ExpiresIn.Minutes(10)
         );
-        Assert.True(response is GenerateDisposableTokenResponse.Success);
+        Assert.True(response is GenerateDisposableTokenResponse.Success, $"Unexpected response: {response}");
         response = await authClient.GenerateDisposableTokenAsync(
             DisposableTokenScopes.CacheKeyReadOnly(CacheSelector.ByName("cache"), "cacheKey"), ExpiresIn.Minutes(10)
         );
-        Assert.True(response is GenerateDisposableTokenResponse.Success);
+        Assert.True(response is GenerateDisposableTokenResponse.Success, $"Unexpected response: {response}");
 
         response = await authClient.GenerateDisposableTokenAsync(
             DisposableTokenScopes.CacheKeyWriteOnly("cache", "cacheKey"), ExpiresIn.Minutes(10)
         );
-        Assert.True(response is GenerateDisposableTokenResponse.Success);
+        Assert.True(response is GenerateDisposableTokenResponse.Success, $"Unexpected response: {response}");
         response = await authClient.GenerateDisposableTokenAsync(
             DisposableTokenScopes.CacheKeyWriteOnly(CacheSelector.ByName("cache"), "cacheKey"), ExpiresIn.Minutes(10)
         );
-        Assert.True(response is GenerateDisposableTokenResponse.Success);
+        Assert.True(response is GenerateDisposableTokenResponse.Success, $"Unexpected response: {response}");
     }
 
     [Theory]
@@ -246,21 +246,21 @@ public class AuthClientCacheTest : IClassFixture<CacheClientFixture>, IClassFixt
             DisposableTokenScopes.CacheKeyReadWrite(cacheName, cacheKey),
             ExpiresIn.Minutes(10)
         );
-        Assert.True(response is GenerateDisposableTokenResponse.Error);
+        Assert.True(response is GenerateDisposableTokenResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, 
             ((GenerateDisposableTokenResponse.Error)response).ErrorCode);
         response = await authClient.GenerateDisposableTokenAsync(
             DisposableTokenScopes.CacheKeyReadOnly(cacheName, cacheKey),
             ExpiresIn.Minutes(10)
         );
-        Assert.True(response is GenerateDisposableTokenResponse.Error);
+        Assert.True(response is GenerateDisposableTokenResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, 
             ((GenerateDisposableTokenResponse.Error)response).ErrorCode);
         response = await authClient.GenerateDisposableTokenAsync(
             DisposableTokenScopes.CacheKeyWriteOnly(cacheName, cacheKey),
             ExpiresIn.Minutes(10)
         );
-        Assert.True(response is GenerateDisposableTokenResponse.Error);
+        Assert.True(response is GenerateDisposableTokenResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, 
             ((GenerateDisposableTokenResponse.Error)response).ErrorCode);
     }
@@ -274,21 +274,21 @@ public class AuthClientCacheTest : IClassFixture<CacheClientFixture>, IClassFixt
             DisposableTokenScopes.CacheKeyReadWrite(cacheName, cacheKey),
             ExpiresIn.Minutes(10)
         );
-        Assert.True(response is GenerateDisposableTokenResponse.Error);
+        Assert.True(response is GenerateDisposableTokenResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, 
             ((GenerateDisposableTokenResponse.Error)response).ErrorCode);
         response = await authClient.GenerateDisposableTokenAsync(
             DisposableTokenScopes.CacheKeyReadOnly(cacheName, cacheKey),
             ExpiresIn.Minutes(10)
         );
-        Assert.True(response is GenerateDisposableTokenResponse.Error);
+        Assert.True(response is GenerateDisposableTokenResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, 
             ((GenerateDisposableTokenResponse.Error)response).ErrorCode);
         response = await authClient.GenerateDisposableTokenAsync(
             DisposableTokenScopes.CacheKeyWriteOnly(cacheName, cacheKey),
             ExpiresIn.Minutes(10)
         );
-        Assert.True(response is GenerateDisposableTokenResponse.Error);
+        Assert.True(response is GenerateDisposableTokenResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, 
             ((GenerateDisposableTokenResponse.Error)response).ErrorCode);
     }
@@ -300,9 +300,9 @@ public class AuthClientCacheTest : IClassFixture<CacheClientFixture>, IClassFixt
             DisposableTokenScopes.CacheKeyReadWrite(cacheName, key)
         );
         var setResponse = await readwriteCacheClient.SetAsync(cacheName, key, value);
-        Assert.True(setResponse is CacheSetResponse.Success);
+        Assert.True(setResponse is CacheSetResponse.Success, $"Unexpected response: {setResponse}");
         var getResponse = await readwriteCacheClient.GetAsync(cacheName, key);
-        Assert.True(getResponse is CacheGetResponse.Hit);
+        Assert.True(getResponse is CacheGetResponse.Hit, $"Unexpected response: {getResponse}");
         if (getResponse is CacheGetResponse.Hit hit)
         {
             Assert.Equal(value, hit.ValueString);
@@ -333,7 +333,7 @@ public class AuthClientCacheTest : IClassFixture<CacheClientFixture>, IClassFixt
         AssertPermissionError<CacheSetResponse, CacheSetResponse.Error>(setResponse);
         await SetCacheKey(cacheName, key, value);
         var getResponse = await readonlyCacheClient.GetAsync(cacheName, key);
-        Assert.True(getResponse is CacheGetResponse.Hit);
+        Assert.True(getResponse is CacheGetResponse.Hit, $"Unexpected response: {getResponse}");
         if (getResponse is CacheGetResponse.Hit hit)
         {
             Assert.Equal(value, hit.ValueString);
@@ -357,7 +357,7 @@ public class AuthClientCacheTest : IClassFixture<CacheClientFixture>, IClassFixt
             DisposableTokenScopes.CacheKeyWriteOnly(cacheName, key)
         );
         var setResponse = await writeonlyCacheClient.SetAsync(cacheName, key, value);
-        Assert.True(setResponse is CacheSetResponse.Success);
+        Assert.True(setResponse is CacheSetResponse.Success, $"Unexpected response: {setResponse}");
         var getResponse = await writeonlyCacheClient.GetAsync(cacheName, key);
         AssertPermissionError<CacheGetResponse, CacheGetResponse.Error>(getResponse);
         await VerifyCacheKey(cacheName, key, value);
@@ -379,32 +379,32 @@ public class AuthClientCacheTest : IClassFixture<CacheClientFixture>, IClassFixt
         var response = await authClient.GenerateDisposableTokenAsync(
             DisposableTokenScopes.CacheKeyPrefixReadWrite("cache", "cacheKey"), ExpiresIn.Minutes(10)
         );
-        Assert.True(response is GenerateDisposableTokenResponse.Success);
+        Assert.True(response is GenerateDisposableTokenResponse.Success, $"Unexpected response: {response}");
         response = await authClient.GenerateDisposableTokenAsync(
             DisposableTokenScopes.CacheKeyPrefixReadWrite(CacheSelector.ByName("cache"), "cacheKey"), 
             ExpiresIn.Minutes(10)
         );
-        Assert.True(response is GenerateDisposableTokenResponse.Success);
+        Assert.True(response is GenerateDisposableTokenResponse.Success, $"Unexpected response: {response}");
 
         response = await authClient.GenerateDisposableTokenAsync(
             DisposableTokenScopes.CacheKeyPrefixReadOnly("cache", "cacheKey"), ExpiresIn.Minutes(10)
         );
-        Assert.True(response is GenerateDisposableTokenResponse.Success);
+        Assert.True(response is GenerateDisposableTokenResponse.Success, $"Unexpected response: {response}");
         response = await authClient.GenerateDisposableTokenAsync(
             DisposableTokenScopes.CacheKeyPrefixReadOnly(CacheSelector.ByName("cache"), "cacheKey"), 
             ExpiresIn.Minutes(10)
         );
-        Assert.True(response is GenerateDisposableTokenResponse.Success);
+        Assert.True(response is GenerateDisposableTokenResponse.Success, $"Unexpected response: {response}");
 
         response = await authClient.GenerateDisposableTokenAsync(
             DisposableTokenScopes.CacheKeyPrefixWriteOnly("cache", "cacheKey"), ExpiresIn.Minutes(10)
         );
-        Assert.True(response is GenerateDisposableTokenResponse.Success);
+        Assert.True(response is GenerateDisposableTokenResponse.Success, $"Unexpected response: {response}");
         response = await authClient.GenerateDisposableTokenAsync(
             DisposableTokenScopes.CacheKeyPrefixWriteOnly(CacheSelector.ByName("cache"), "cacheKey"), 
             ExpiresIn.Minutes(10)
         );
-        Assert.True(response is GenerateDisposableTokenResponse.Success);
+        Assert.True(response is GenerateDisposableTokenResponse.Success, $"Unexpected response: {response}");
     }
 
     [Theory]
@@ -416,21 +416,21 @@ public class AuthClientCacheTest : IClassFixture<CacheClientFixture>, IClassFixt
             DisposableTokenScopes.CacheKeyPrefixReadWrite(cacheName, cacheKeyPrefix),
             ExpiresIn.Minutes(10)
         );
-        Assert.True(response is GenerateDisposableTokenResponse.Error);
+        Assert.True(response is GenerateDisposableTokenResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, 
             ((GenerateDisposableTokenResponse.Error)response).ErrorCode);
         response = await authClient.GenerateDisposableTokenAsync(
             DisposableTokenScopes.CacheKeyPrefixReadOnly(cacheName, cacheKeyPrefix),
             ExpiresIn.Minutes(10)
         );
-        Assert.True(response is GenerateDisposableTokenResponse.Error);
+        Assert.True(response is GenerateDisposableTokenResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, 
             ((GenerateDisposableTokenResponse.Error)response).ErrorCode);
         response = await authClient.GenerateDisposableTokenAsync(
             DisposableTokenScopes.CacheKeyPrefixWriteOnly(cacheName, cacheKeyPrefix),
             ExpiresIn.Minutes(10)
         );
-        Assert.True(response is GenerateDisposableTokenResponse.Error);
+        Assert.True(response is GenerateDisposableTokenResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, 
             ((GenerateDisposableTokenResponse.Error)response).ErrorCode);
     }
@@ -444,21 +444,21 @@ public class AuthClientCacheTest : IClassFixture<CacheClientFixture>, IClassFixt
             DisposableTokenScopes.CacheKeyPrefixReadWrite(cacheName, cacheKeyPrefix),
             ExpiresIn.Minutes(10)
         );
-        Assert.True(response is GenerateDisposableTokenResponse.Error);
+        Assert.True(response is GenerateDisposableTokenResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, 
             ((GenerateDisposableTokenResponse.Error)response).ErrorCode);
         response = await authClient.GenerateDisposableTokenAsync(
             DisposableTokenScopes.CacheKeyPrefixReadOnly(cacheName, cacheKeyPrefix),
             ExpiresIn.Minutes(10)
         );
-        Assert.True(response is GenerateDisposableTokenResponse.Error);
+        Assert.True(response is GenerateDisposableTokenResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, 
             ((GenerateDisposableTokenResponse.Error)response).ErrorCode);
         response = await authClient.GenerateDisposableTokenAsync(
             DisposableTokenScopes.CacheKeyPrefixWriteOnly(cacheName, cacheKeyPrefix),
             ExpiresIn.Minutes(10)
         );
-        Assert.True(response is GenerateDisposableTokenResponse.Error);
+        Assert.True(response is GenerateDisposableTokenResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, 
             ((GenerateDisposableTokenResponse.Error)response).ErrorCode);
     }
@@ -470,9 +470,9 @@ public class AuthClientCacheTest : IClassFixture<CacheClientFixture>, IClassFixt
             DisposableTokenScopes.CacheKeyPrefixReadWrite(cacheName, keyPrefix)
         );
         var setResponse = await readwriteCacheClient.SetAsync(cacheName, key, value);
-        Assert.True(setResponse is CacheSetResponse.Success);
+        Assert.True(setResponse is CacheSetResponse.Success, $"Unexpected response: {setResponse}");
         var getResponse = await readwriteCacheClient.GetAsync(cacheName, key);
-        Assert.True(getResponse is CacheGetResponse.Hit);
+        Assert.True(getResponse is CacheGetResponse.Hit, $"Unexpected response: {getResponse}");
         if (getResponse is CacheGetResponse.Hit hit)
         {
             Assert.Equal(value, hit.ValueString);
@@ -503,7 +503,7 @@ public class AuthClientCacheTest : IClassFixture<CacheClientFixture>, IClassFixt
         AssertPermissionError<CacheSetResponse, CacheSetResponse.Error>(setResponse);
         await SetCacheKey(cacheName, key, value);
         var getResponse = await readonlyCacheClient.GetAsync(cacheName, key);
-        Assert.True(getResponse is CacheGetResponse.Hit);
+        Assert.True(getResponse is CacheGetResponse.Hit, $"Unexpected response: {getResponse}");
         if (getResponse is CacheGetResponse.Hit hit)
         {
             Assert.Equal(value, hit.ValueString);
@@ -531,7 +531,7 @@ public class AuthClientCacheTest : IClassFixture<CacheClientFixture>, IClassFixt
             DisposableTokenScopes.CacheKeyPrefixWriteOnly(cacheName, keyPrefix)
         );
         var setResponse = await writeonlyCacheClient.SetAsync(cacheName, key, value);
-        Assert.True(setResponse is CacheSetResponse.Success);
+        Assert.True(setResponse is CacheSetResponse.Success, $"Unexpected response: {setResponse}");
         var getResponse = await writeonlyCacheClient.GetAsync(cacheName, key);
         AssertPermissionError<CacheGetResponse, CacheGetResponse.Error>(getResponse);
         await VerifyCacheKey(cacheName, key, value);
@@ -572,18 +572,18 @@ public class AuthClientCacheTest : IClassFixture<CacheClientFixture>, IClassFixt
 
         // we can read/write our key and key prefix in the test cache
         var setResponse = await client.SetAsync(cacheName, "cow", "moo");
-        Assert.True(setResponse is CacheSetResponse.Success);
+        Assert.True(setResponse is CacheSetResponse.Success, $"Unexpected response: {setResponse}");
         var getResponse = await client.GetAsync(cacheName, "cow");
-        Assert.True(getResponse is CacheGetResponse.Hit);
+        Assert.True(getResponse is CacheGetResponse.Hit, $"Unexpected response: {getResponse}");
         if (getResponse is CacheGetResponse.Hit hit)
         {
             Assert.Equal(hit.ValueString, "moo");
         }
 
         setResponse = await client.SetAsync(cacheName, "pet-cat", "meow");
-        Assert.True(setResponse is CacheSetResponse.Success);
+        Assert.True(setResponse is CacheSetResponse.Success, $"Unexpected response: {setResponse}");
         getResponse = await client.GetAsync(cacheName, "pet-cat");
-        Assert.True(getResponse is CacheGetResponse.Hit);
+        Assert.True(getResponse is CacheGetResponse.Hit, $"Unexpected response: {getResponse}");
         if (getResponse is CacheGetResponse.Hit hit2)
         {
             Assert.Equal(hit2.ValueString, "meow");
@@ -627,7 +627,8 @@ public class AuthClientCacheTest : IClassFixture<CacheClientFixture>, IClassFixt
         try
         {
             // create a second cache
-            Assert.True(await cacheClient.CreateCacheAsync(cache2Name) is CreateCacheResponse.Success);
+            var response = await cacheClient.CreateCacheAsync(cache2Name);
+            Assert.True(response is CreateCacheResponse.Success, $"Unexpected response: {response}");
 
             var scope = new DisposableTokenScope(Permissions: new List<DisposableTokenPermission>{
                 new DisposableToken.CacheItemPermission(
@@ -658,13 +659,13 @@ public class AuthClientCacheTest : IClassFixture<CacheClientFixture>, IClassFixt
             await SetCacheKey(cache2Name, "dog", "woof");
 
             var getResponse = await client.GetAsync(cacheName, "cow");
-            Assert.True(getResponse is CacheGetResponse.Hit);
+            Assert.True(getResponse is CacheGetResponse.Hit, $"Unexpected response: {getResponse}");
             getResponse = await client.GetAsync(cacheName, "pet-koala");
-            Assert.True(getResponse is CacheGetResponse.Hit);
+            Assert.True(getResponse is CacheGetResponse.Hit, $"Unexpected response: {getResponse}");
             getResponse = await client.GetAsync(cache2Name, "cow");
-            Assert.True(getResponse is CacheGetResponse.Hit);
+            Assert.True(getResponse is CacheGetResponse.Hit, $"Unexpected response: {getResponse}");
             getResponse = await client.GetAsync(cache2Name, "pet-koala");
-            Assert.True(getResponse is CacheGetResponse.Hit);
+            Assert.True(getResponse is CacheGetResponse.Hit, $"Unexpected response: {getResponse}");
             getResponse = await client.GetAsync(cacheName, "dog");
             AssertPermissionError<CacheGetResponse, CacheGetResponse.Error>(getResponse);
             getResponse = await client.GetAsync(cache2Name, "dog");
@@ -673,7 +674,8 @@ public class AuthClientCacheTest : IClassFixture<CacheClientFixture>, IClassFixt
         finally
         {
             // delete the second cache
-            Assert.True(await cacheClient.DeleteCacheAsync(cache2Name) is DeleteCacheResponse.Success);
+            var response = await cacheClient.DeleteCacheAsync(cache2Name);
+            Assert.True(response is DeleteCacheResponse.Success, $"Unexpected response: {response}");
         }
     }
 
@@ -684,7 +686,8 @@ public class AuthClientCacheTest : IClassFixture<CacheClientFixture>, IClassFixt
         try
         {
             // create a second cache
-            Assert.True(await cacheClient.CreateCacheAsync(cache2Name) is CreateCacheResponse.Success);
+            var response = await cacheClient.CreateCacheAsync(cache2Name);
+            Assert.True(response is CreateCacheResponse.Success, $"Unexpected response: {response}");
 
             var scope = new DisposableTokenScope(Permissions: new List<DisposableTokenPermission>{
                 new DisposableToken.CacheItemPermission(
@@ -702,7 +705,7 @@ public class AuthClientCacheTest : IClassFixture<CacheClientFixture>, IClassFixt
 
             // we can write to only one key and not read in test cache
             var setResponse = await client.SetAsync(cacheName, "cow", "moo");
-            Assert.True(setResponse is CacheSetResponse.Success);
+            Assert.True(setResponse is CacheSetResponse.Success, $"Unexpected response: {setResponse}");
             var getResponse = await client.GetAsync(cacheName, "cow");
             AssertPermissionError<CacheGetResponse, CacheGetResponse.Error>(getResponse);
             setResponse = await client.SetAsync(cacheName, "parrot", "somethingaboutcrackers");
@@ -713,7 +716,7 @@ public class AuthClientCacheTest : IClassFixture<CacheClientFixture>, IClassFixt
             await SetCacheKey(cache2Name, "pet-armadillo", "thunk");
             await SetCacheKey(cache2Name, "snake", "hiss");
             getResponse = await client.GetAsync(cache2Name, "pet-armadillo");
-            Assert.True(getResponse is CacheGetResponse.Hit);
+            Assert.True(getResponse is CacheGetResponse.Hit, $"Unexpected response: {getResponse}");
             if (getResponse is CacheGetResponse.Hit hit)
             {
                 Assert.Equal(hit.ValueString, "thunk");
@@ -726,7 +729,8 @@ public class AuthClientCacheTest : IClassFixture<CacheClientFixture>, IClassFixt
         finally
         {
             // delete the second cache
-            Assert.True(await cacheClient.DeleteCacheAsync(cache2Name) is DeleteCacheResponse.Success);
+            var response = await cacheClient.DeleteCacheAsync(cache2Name);
+            Assert.True(response is DeleteCacheResponse.Success, $"Unexpected response: {response}");
         }
     }
 }

--- a/tests/Integration/Momento.Sdk.Tests/AuthClientTopicTest.cs
+++ b/tests/Integration/Momento.Sdk.Tests/AuthClientTopicTest.cs
@@ -423,8 +423,6 @@ public class AuthClientTopicTest : IClassFixture<CacheClientFixture>, IClassFixt
         await GenerateDisposableTopicAuthToken_WriteOnly_CanPublish_Common(writeOnlyTopicClient, messageValue);
     }
 
-    // TODO: this test is flaky and has been breaking build pipelines. Commenting it out until we have time to
-    //  root cause it. Chris 2023-10-30
     [Fact]
     public async Task GenerateDisposableTopicAuthToken_WriteOnly_NamePrefix_CanPublish()
     {

--- a/tests/Integration/Momento.Sdk.Tests/AuthClientTopicTest.cs
+++ b/tests/Integration/Momento.Sdk.Tests/AuthClientTopicTest.cs
@@ -33,7 +33,7 @@ public class AuthClientTopicTest : IClassFixture<CacheClientFixture>, IClassFixt
     private async Task<ITopicClient> GetClientForTokenScope(DisposableTokenScope scope)
     {
         var response = await authClient.GenerateDisposableTokenAsync(scope, ExpiresIn.Minutes(2));
-        Assert.True(response is GenerateDisposableTokenResponse.Success);
+        Assert.True(response is GenerateDisposableTokenResponse.Success, $"Unexpected response: {response}");
         string authToken = "";
         if (response is GenerateDisposableTokenResponse.Success token)
         {
@@ -48,7 +48,7 @@ public class AuthClientTopicTest : IClassFixture<CacheClientFixture>, IClassFixt
     {
         client ??= topicClient;
         var response = await client.PublishAsync(cache, topic, value);
-        Assert.True(response is TopicPublishResponse.Success);
+        Assert.True(response is TopicPublishResponse.Success, $"Unexpected response: {response}");
     }
 
     private async Task ExpectTextFromSubscription(
@@ -61,7 +61,7 @@ public class AuthClientTopicTest : IClassFixture<CacheClientFixture>, IClassFixt
         var gotText = false;
         await foreach (var message in cancellableSubscription)
         {
-            Assert.True(message is TopicMessage.Text);
+            Assert.True(message is TopicMessage.Text, $"Unexpected response: {message}");
             if (message is TopicMessage.Text textMsg) {
                 Assert.Equal(expectedText, textMsg.Value);
                 gotText = true;
@@ -76,7 +76,7 @@ public class AuthClientTopicTest : IClassFixture<CacheClientFixture>, IClassFixt
 
     private void AssertPermissionError<TResp, TErrResp>(TResp response)
     {
-        Assert.True(response is TErrResp);
+        Assert.True(response is TErrResp, $"Unexpected response: {response}");
         if (response is IError err)
         {
             Assert.Equal(err.ErrorCode, MomentoErrorCode.PERMISSION_ERROR);
@@ -89,152 +89,152 @@ public class AuthClientTopicTest : IClassFixture<CacheClientFixture>, IClassFixt
         var response = await authClient.GenerateDisposableTokenAsync(
             DisposableTokenScopes.TopicPublishSubscribe("cache", "topic"), ExpiresIn.Minutes(10)
         );
-        Assert.True(response is GenerateDisposableTokenResponse.Success);
+        Assert.True(response is GenerateDisposableTokenResponse.Success, $"Unexpected response: {response}");
         response = await authClient.GenerateDisposableTokenAsync(
             DisposableTokenScopes.TopicPublishSubscribe(
                 CacheSelector.ByName("cache"), "topic"),
                 ExpiresIn.Minutes(10)
         );
-        Assert.True(response is GenerateDisposableTokenResponse.Success);
+        Assert.True(response is GenerateDisposableTokenResponse.Success, $"Unexpected response: {response}");
         response = await authClient.GenerateDisposableTokenAsync(
             DisposableTokenScopes.TopicPublishSubscribe(
                 "cache", TopicSelector.ByName("topic")),
                 ExpiresIn.Minutes(10)
         );
-        Assert.True(response is GenerateDisposableTokenResponse.Success);
+        Assert.True(response is GenerateDisposableTokenResponse.Success, $"Unexpected response: {response}");
         response = await authClient.GenerateDisposableTokenAsync(
             DisposableTokenScopes.TopicPublishSubscribe(
                 CacheSelector.ByName("cache"), TopicSelector.ByName("topic")),
                 ExpiresIn.Minutes(10)
         );
-        Assert.True(response is GenerateDisposableTokenResponse.Success);
+        Assert.True(response is GenerateDisposableTokenResponse.Success, $"Unexpected response: {response}");
 
         response = await authClient.GenerateDisposableTokenAsync(
             DisposableTokenScopes.TopicPublishOnly("cache", "topic"), ExpiresIn.Minutes(10)
         );
-        Assert.True(response is GenerateDisposableTokenResponse.Success);
+        Assert.True(response is GenerateDisposableTokenResponse.Success, $"Unexpected response: {response}");
         response = await authClient.GenerateDisposableTokenAsync(
             DisposableTokenScopes.TopicPublishOnly(
                 CacheSelector.ByName("cache"), "topic"),
                 ExpiresIn.Minutes(10)
         );
-        Assert.True(response is GenerateDisposableTokenResponse.Success);
+        Assert.True(response is GenerateDisposableTokenResponse.Success, $"Unexpected response: {response}");
         response = await authClient.GenerateDisposableTokenAsync(
             DisposableTokenScopes.TopicPublishOnly(
                 "cache", TopicSelector.ByName("topic")),
                 ExpiresIn.Minutes(10)
         );
-        Assert.True(response is GenerateDisposableTokenResponse.Success);
+        Assert.True(response is GenerateDisposableTokenResponse.Success, $"Unexpected response: {response}");
         response = await authClient.GenerateDisposableTokenAsync(
             DisposableTokenScopes.TopicPublishOnly(
                 CacheSelector.ByName("cache"), TopicSelector.ByName("topic")),
                 ExpiresIn.Minutes(10)
         );
-        Assert.True(response is GenerateDisposableTokenResponse.Success);
+        Assert.True(response is GenerateDisposableTokenResponse.Success, $"Unexpected response: {response}");
 
         response = await authClient.GenerateDisposableTokenAsync(
             DisposableTokenScopes.TopicSubscribeOnly("cache", "topic"), ExpiresIn.Minutes(10)
         );
-        Assert.True(response is GenerateDisposableTokenResponse.Success);
+        Assert.True(response is GenerateDisposableTokenResponse.Success, $"Unexpected response: {response}");
         response = await authClient.GenerateDisposableTokenAsync(
             DisposableTokenScopes.TopicSubscribeOnly(
                 CacheSelector.ByName("cache"), "topic"),
                 ExpiresIn.Minutes(10)
         );
-        Assert.True(response is GenerateDisposableTokenResponse.Success);
+        Assert.True(response is GenerateDisposableTokenResponse.Success, $"Unexpected response: {response}");
         response = await authClient.GenerateDisposableTokenAsync(
             DisposableTokenScopes.TopicSubscribeOnly(
                 "cache", TopicSelector.ByName("topic")),
                 ExpiresIn.Minutes(10)
         );
-        Assert.True(response is GenerateDisposableTokenResponse.Success);
+        Assert.True(response is GenerateDisposableTokenResponse.Success, $"Unexpected response: {response}");
         response = await authClient.GenerateDisposableTokenAsync(
             DisposableTokenScopes.TopicSubscribeOnly(
                 CacheSelector.ByName("cache"), TopicSelector.ByName("topic")),
                 ExpiresIn.Minutes(10)
         );
-        Assert.True(response is GenerateDisposableTokenResponse.Success);
+        Assert.True(response is GenerateDisposableTokenResponse.Success, $"Unexpected response: {response}");
 
         response = await authClient.GenerateDisposableTokenAsync(
             DisposableTokenScopes.TopicNamePrefixPublishSubscribe("cache", "topic-"),
             ExpiresIn.Minutes(10)
         );
-        Assert.True(response is GenerateDisposableTokenResponse.Success);
+        Assert.True(response is GenerateDisposableTokenResponse.Success, $"Unexpected response: {response}");
         response = await authClient.GenerateDisposableTokenAsync(
             DisposableTokenScopes.TopicNamePrefixPublishSubscribe(
                 CacheSelector.ByName("cache"), "topic-"
             ),
             ExpiresIn.Minutes(10)
         );
-        Assert.True(response is GenerateDisposableTokenResponse.Success);
+        Assert.True(response is GenerateDisposableTokenResponse.Success, $"Unexpected response: {response}");
         response = await authClient.GenerateDisposableTokenAsync(
             DisposableTokenScopes.TopicNamePrefixPublishSubscribe(
                 "cache", TopicSelector.ByTopicNamePrefix("topic-")
             ),
             ExpiresIn.Minutes(10)
         );
-        Assert.True(response is GenerateDisposableTokenResponse.Success);
+        Assert.True(response is GenerateDisposableTokenResponse.Success, $"Unexpected response: {response}");
         response = await authClient.GenerateDisposableTokenAsync(
             DisposableTokenScopes.TopicNamePrefixPublishSubscribe(
                 CacheSelector.ByName("cache"), TopicSelector.ByTopicNamePrefix("topic-")
             ),
             ExpiresIn.Minutes(10)
         );
-        Assert.True(response is GenerateDisposableTokenResponse.Success);
+        Assert.True(response is GenerateDisposableTokenResponse.Success, $"Unexpected response: {response}");
 
         response = await authClient.GenerateDisposableTokenAsync(
             DisposableTokenScopes.TopicNamePrefixSubscribeOnly("cache", "topic-"),
             ExpiresIn.Minutes(10)
         );
-        Assert.True(response is GenerateDisposableTokenResponse.Success);
+        Assert.True(response is GenerateDisposableTokenResponse.Success, $"Unexpected response: {response}");
         response = await authClient.GenerateDisposableTokenAsync(
             DisposableTokenScopes.TopicNamePrefixSubscribeOnly(
                 CacheSelector.ByName("cache"), "topic-"
             ),
             ExpiresIn.Minutes(10)
         );
-        Assert.True(response is GenerateDisposableTokenResponse.Success);
+        Assert.True(response is GenerateDisposableTokenResponse.Success, $"Unexpected response: {response}");
         response = await authClient.GenerateDisposableTokenAsync(
             DisposableTokenScopes.TopicNamePrefixSubscribeOnly(
                 "cache", TopicSelector.ByTopicNamePrefix("topic-")
             ),
             ExpiresIn.Minutes(10)
         );
-        Assert.True(response is GenerateDisposableTokenResponse.Success);
+        Assert.True(response is GenerateDisposableTokenResponse.Success, $"Unexpected response: {response}");
         response = await authClient.GenerateDisposableTokenAsync(
             DisposableTokenScopes.TopicNamePrefixSubscribeOnly(
                 CacheSelector.ByName("cache"), TopicSelector.ByTopicNamePrefix("topic-")
             ),
             ExpiresIn.Minutes(10)
         );
-        Assert.True(response is GenerateDisposableTokenResponse.Success);
+        Assert.True(response is GenerateDisposableTokenResponse.Success, $"Unexpected response: {response}");
 
         response = await authClient.GenerateDisposableTokenAsync(
             DisposableTokenScopes.TopicNamePrefixPublishOnly("cache", "topic-"),
             ExpiresIn.Minutes(10)
         );
-        Assert.True(response is GenerateDisposableTokenResponse.Success);
+        Assert.True(response is GenerateDisposableTokenResponse.Success, $"Unexpected response: {response}");
         response = await authClient.GenerateDisposableTokenAsync(
             DisposableTokenScopes.TopicNamePrefixPublishOnly(
                 CacheSelector.ByName("cache"), "topic-"
             ),
             ExpiresIn.Minutes(10)
         );
-        Assert.True(response is GenerateDisposableTokenResponse.Success);
+        Assert.True(response is GenerateDisposableTokenResponse.Success, $"Unexpected response: {response}");
         response = await authClient.GenerateDisposableTokenAsync(
             DisposableTokenScopes.TopicNamePrefixPublishOnly(
                 "cache", TopicSelector.ByTopicNamePrefix("topic-")
             ),
             ExpiresIn.Minutes(10)
         );
-        Assert.True(response is GenerateDisposableTokenResponse.Success);
+        Assert.True(response is GenerateDisposableTokenResponse.Success, $"Unexpected response: {response}");
         response = await authClient.GenerateDisposableTokenAsync(
             DisposableTokenScopes.TopicNamePrefixPublishOnly(
                 CacheSelector.ByName("cache"), TopicSelector.ByTopicNamePrefix("topic-")
             ),
             ExpiresIn.Minutes(10)
         );
-        Assert.True(response is GenerateDisposableTokenResponse.Success);
+        Assert.True(response is GenerateDisposableTokenResponse.Success, $"Unexpected response: {response}");
     }
 
     [Theory]
@@ -246,19 +246,19 @@ public class AuthClientTopicTest : IClassFixture<CacheClientFixture>, IClassFixt
             DisposableTokenScopes.TopicPublishOnly(cacheName, topicName),
             ExpiresIn.Minutes(10)
         );
-        Assert.True(response is GenerateDisposableTokenResponse.Error);
+        Assert.True(response is GenerateDisposableTokenResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((GenerateDisposableTokenResponse.Error)response).ErrorCode);
         response = await authClient.GenerateDisposableTokenAsync(
             DisposableTokenScopes.TopicSubscribeOnly(cacheName, topicName),
             ExpiresIn.Minutes(10)
         );
-        Assert.True(response is GenerateDisposableTokenResponse.Error);
+        Assert.True(response is GenerateDisposableTokenResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((GenerateDisposableTokenResponse.Error)response).ErrorCode);
         response = await authClient.GenerateDisposableTokenAsync(
             DisposableTokenScopes.TopicPublishSubscribe(cacheName, topicName),
             ExpiresIn.Minutes(10)
         );
-        Assert.True(response is GenerateDisposableTokenResponse.Error);
+        Assert.True(response is GenerateDisposableTokenResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((GenerateDisposableTokenResponse.Error)response).ErrorCode);
     }
 
@@ -271,19 +271,19 @@ public class AuthClientTopicTest : IClassFixture<CacheClientFixture>, IClassFixt
             DisposableTokenScopes.TopicPublishOnly(cacheName, topicName),
             ExpiresIn.Minutes(10)
         );
-        Assert.True(response is GenerateDisposableTokenResponse.Error);
+        Assert.True(response is GenerateDisposableTokenResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((GenerateDisposableTokenResponse.Error)response).ErrorCode);
         response = await authClient.GenerateDisposableTokenAsync(
             DisposableTokenScopes.TopicSubscribeOnly(cacheName, topicName),
             ExpiresIn.Minutes(10)
         );
-        Assert.True(response is GenerateDisposableTokenResponse.Error);
+        Assert.True(response is GenerateDisposableTokenResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((GenerateDisposableTokenResponse.Error)response).ErrorCode);
         response = await authClient.GenerateDisposableTokenAsync(
             DisposableTokenScopes.TopicPublishSubscribe(cacheName, topicName),
             ExpiresIn.Minutes(10)
         );
-        Assert.True(response is GenerateDisposableTokenResponse.Error);
+        Assert.True(response is GenerateDisposableTokenResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((GenerateDisposableTokenResponse.Error)response).ErrorCode);
     }
 
@@ -293,7 +293,7 @@ public class AuthClientTopicTest : IClassFixture<CacheClientFixture>, IClassFixt
         var response = await authClient.GenerateDisposableTokenAsync(
             DisposableTokenScopes.TopicPublishSubscribe(cacheName, "foo"), ExpiresIn.Minutes(0)
         );
-        Assert.True(response is GenerateDisposableTokenResponse.Error);
+        Assert.True(response is GenerateDisposableTokenResponse.Error, $"Unexpected response: {response}");
         if (response is GenerateDisposableTokenResponse.Error err)
         {
             Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, err.ErrorCode);
@@ -301,7 +301,7 @@ public class AuthClientTopicTest : IClassFixture<CacheClientFixture>, IClassFixt
         response = await authClient.GenerateDisposableTokenAsync(
             DisposableTokenScopes.TopicPublishSubscribe(cacheName, "foo"), ExpiresIn.Minutes(-50)
         );
-        Assert.True(response is GenerateDisposableTokenResponse.Error);
+        Assert.True(response is GenerateDisposableTokenResponse.Error, $"Unexpected response: {response}");
         if (response is GenerateDisposableTokenResponse.Error err2)
         {
             Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, err2.ErrorCode);
@@ -309,7 +309,7 @@ public class AuthClientTopicTest : IClassFixture<CacheClientFixture>, IClassFixt
         response = await authClient.GenerateDisposableTokenAsync(
             DisposableTokenScopes.TopicPublishSubscribe(cacheName, "foo"), ExpiresIn.Days(365)
         );
-        Assert.True(response is GenerateDisposableTokenResponse.Error);
+        Assert.True(response is GenerateDisposableTokenResponse.Error, $"Unexpected response: {response}");
         if (response is GenerateDisposableTokenResponse.Error err3)
         {
             Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, err3.ErrorCode);
@@ -319,9 +319,9 @@ public class AuthClientTopicTest : IClassFixture<CacheClientFixture>, IClassFixt
     private async Task GenerateDisposableTopicAuthToken_ReadWrite_Common(ITopicClient readwriteTopicClient, string messageValue)
     {
         var subscribeResponse = await readwriteTopicClient.SubscribeAsync(cacheName, topicName);
-        Assert.True(subscribeResponse is TopicSubscribeResponse.Subscription);
+        Assert.True(subscribeResponse is TopicSubscribeResponse.Subscription, $"Unexpected response: {subscribeResponse}");
         var publishResponse = await readwriteTopicClient.PublishAsync(cacheName, topicName, messageValue);
-        Assert.True(publishResponse is TopicPublishResponse.Success);
+        Assert.True(publishResponse is TopicPublishResponse.Success, $"Unexpected response: {publishResponse}");
         if (subscribeResponse is TopicSubscribeResponse.Subscription subscription)
         {
             await PublishToTopic(cacheName, topicName, messageValue, readwriteTopicClient);
@@ -352,7 +352,7 @@ public class AuthClientTopicTest : IClassFixture<CacheClientFixture>, IClassFixt
     private async Task GenerateDisposableTopicAuthToken_ReadOnly_Common(ITopicClient readonlyTopicClient, string messageValue)
     {
         var subscribeResponse = await readonlyTopicClient.SubscribeAsync(cacheName, topicName);
-        Assert.True(subscribeResponse is TopicSubscribeResponse.Subscription);
+        Assert.True(subscribeResponse is TopicSubscribeResponse.Subscription, $"Unexpected response: {subscribeResponse}");
         var publishResponse = await readonlyTopicClient.PublishAsync(cacheName, topicName, messageValue);
         AssertPermissionError<TopicPublishResponse, TopicPublishResponse.Error>(publishResponse);
         await PublishToTopic(cacheName, topicName, messageValue);
@@ -403,7 +403,7 @@ public class AuthClientTopicTest : IClassFixture<CacheClientFixture>, IClassFixt
     )
     {
         var subscribeResponse = await topicClient.SubscribeAsync(cacheName, topicName);
-        Assert.True(subscribeResponse is TopicSubscribeResponse.Subscription);
+        Assert.True(subscribeResponse is TopicSubscribeResponse.Subscription, $"Unexpected response: {subscribeResponse}");
 
         // `PublishToTopic` asserts a successful publish response
         await PublishToTopic(cacheName, topicName, messageValue, writeOnlyTopicClient);
@@ -428,15 +428,15 @@ public class AuthClientTopicTest : IClassFixture<CacheClientFixture>, IClassFixt
 
     // TODO: this test is flaky and has been breaking build pipelines. Commenting it out until we have time to
     //  root cause it. Chris 2023-10-30
-    //[Fact]
-    //public async Task GenerateDisposableTopicAuthToken_WriteOnly_NamePrefix_CanPublish()
-    //{
+    // [Fact]
+    // public async Task GenerateDisposableTopicAuthToken_WriteOnly_NamePrefix_CanPublish()
+    // {
     //    const string messageValue = "hello";
     //    var writeOnlyTopicClient = await GetClientForTokenScope(
     //        DisposableTokenScopes.TopicPublishOnly(cacheName, TopicSelector.ByTopicNamePrefix(topicNamePrefix))
     //    );
     //    await GenerateDisposableTopicAuthToken_WriteOnly_CanPublish_Common(writeOnlyTopicClient, messageValue);
-    //}
+    // }
 
     [Fact]
     public async Task GenerateDisposableTopicAuthToken_NoCachePerms_CantPublish()
@@ -516,7 +516,7 @@ public class AuthClientTopicTest : IClassFixture<CacheClientFixture>, IClassFixt
 
         // we can publish but not subscribe to topics prefixed with topicNamePrefix
         var publishResponse = await multiPermsClient.PublishAsync(cacheName, topicName, "hi");
-        Assert.True(publishResponse is TopicPublishResponse.Success);
+        Assert.True(publishResponse is TopicPublishResponse.Success, $"Unexpected response: {publishResponse}");
         var subscribeResponse = await multiPermsClient.SubscribeAsync(cacheName, topicName);
         AssertPermissionError<TopicSubscribeResponse, TopicSubscribeResponse.Error>(subscribeResponse);
 
@@ -524,7 +524,7 @@ public class AuthClientTopicTest : IClassFixture<CacheClientFixture>, IClassFixt
         publishResponse = await multiPermsClient.PublishAsync(cacheName, "fun-topic", "hi");
         AssertPermissionError<TopicPublishResponse, TopicPublishResponse.Error>(publishResponse);
         subscribeResponse = await multiPermsClient.SubscribeAsync(cacheName, "fun-topic");
-        Assert.True(subscribeResponse is TopicSubscribeResponse.Subscription);
+        Assert.True(subscribeResponse is TopicSubscribeResponse.Subscription, $"Unexpected response: {subscribeResponse}");
 
         // we can neither publish nor subscribe to an unspecified topic
         publishResponse = await multiPermsClient.PublishAsync(cacheName, "unknown-topic", "hi");
@@ -536,7 +536,8 @@ public class AuthClientTopicTest : IClassFixture<CacheClientFixture>, IClassFixt
         var cache2Name = cacheName + "-2";
         try
         {
-            Assert.True(await cacheClient.CreateCacheAsync(cache2Name) is CreateCacheResponse.Success);
+            var response = await cacheClient.CreateCacheAsync(cache2Name);
+            Assert.True(response is CreateCacheResponse.Success, $"Unexpected response: {response}");
             publishResponse = await multiPermsClient.PublishAsync(cache2Name, topicName, "hi");
             AssertPermissionError<TopicPublishResponse, TopicPublishResponse.Error>(publishResponse);
             subscribeResponse = await multiPermsClient.SubscribeAsync(cache2Name, topicName);
@@ -544,7 +545,8 @@ public class AuthClientTopicTest : IClassFixture<CacheClientFixture>, IClassFixt
         }
         finally
         {
-            Assert.True(await cacheClient.DeleteCacheAsync(cache2Name) is DeleteCacheResponse.Success);
+            var response = await cacheClient.DeleteCacheAsync(cache2Name);
+            Assert.True(response is DeleteCacheResponse.Success, $"Unexpected response: {response}");
         }
     }
 }

--- a/tests/Integration/Momento.Sdk.Tests/AuthClientTopicTest.cs
+++ b/tests/Integration/Momento.Sdk.Tests/AuthClientTopicTest.cs
@@ -405,14 +405,11 @@ public class AuthClientTopicTest : IClassFixture<CacheClientFixture>, IClassFixt
         var subscribeResponse = await topicClient.SubscribeAsync(cacheName, topicName);
         Assert.True(subscribeResponse is TopicSubscribeResponse.Subscription, $"Unexpected response: {subscribeResponse}");
 
-        // `PublishToTopic` asserts a successful publish response
-        await PublishToTopic(cacheName, topicName, messageValue, writeOnlyTopicClient);
-
         if (subscribeResponse is TopicSubscribeResponse.Subscription subscription)
         {
-            var subTask = ExpectTextFromSubscription(subscription, messageValue);
+            // `PublishToTopic` asserts a successful publish response
             await PublishToTopic(cacheName, topicName, messageValue, writeOnlyTopicClient);
-            await subTask;
+            await ExpectTextFromSubscription(subscription, messageValue);
         }
     }
 

--- a/tests/Integration/Momento.Sdk.Tests/AuthClientTopicTest.cs
+++ b/tests/Integration/Momento.Sdk.Tests/AuthClientTopicTest.cs
@@ -428,15 +428,15 @@ public class AuthClientTopicTest : IClassFixture<CacheClientFixture>, IClassFixt
 
     // TODO: this test is flaky and has been breaking build pipelines. Commenting it out until we have time to
     //  root cause it. Chris 2023-10-30
-    // [Fact]
-    // public async Task GenerateDisposableTopicAuthToken_WriteOnly_NamePrefix_CanPublish()
-    // {
-    //    const string messageValue = "hello";
-    //    var writeOnlyTopicClient = await GetClientForTokenScope(
-    //        DisposableTokenScopes.TopicPublishOnly(cacheName, TopicSelector.ByTopicNamePrefix(topicNamePrefix))
-    //    );
-    //    await GenerateDisposableTopicAuthToken_WriteOnly_CanPublish_Common(writeOnlyTopicClient, messageValue);
-    // }
+    [Fact]
+    public async Task GenerateDisposableTopicAuthToken_WriteOnly_NamePrefix_CanPublish()
+    {
+       const string messageValue = "hello";
+       var writeOnlyTopicClient = await GetClientForTokenScope(
+           DisposableTokenScopes.TopicPublishOnly(cacheName, TopicSelector.ByTopicNamePrefix(topicNamePrefix))
+       );
+       await GenerateDisposableTopicAuthToken_WriteOnly_CanPublish_Common(writeOnlyTopicClient, messageValue);
+    }
 
     [Fact]
     public async Task GenerateDisposableTopicAuthToken_NoCachePerms_CantPublish()

--- a/tests/Integration/Momento.Sdk.Tests/CacheDataTest.cs
+++ b/tests/Integration/Momento.Sdk.Tests/CacheDataTest.cs
@@ -46,7 +46,7 @@ public class CacheDataTest : TestBase
         Assert.True(response is CacheKeyExistsResponse.Success, $"Unexpected response: {response}");
         var goodResponse = (CacheKeyExistsResponse.Success)response;
         bool exists = goodResponse.Exists;
-        Assert.True(exists);
+        Assert.True(exists, $"expected key to exist but it doesn't: {key}");
 
         key = Utils.NewGuidByteArray();
         response = await client.KeyExistsAsync(cacheName, key);
@@ -66,14 +66,14 @@ public class CacheDataTest : TestBase
         Assert.True(response is CacheKeyExistsResponse.Success, $"Unexpected response: {response}");
         var goodResponse = (CacheKeyExistsResponse.Success)response;
         bool exists = goodResponse.Exists;
-        Assert.True(exists);
+        Assert.True(exists, $"expected key to exist but it doesn't: {key}");
 
         key = Utils.NewGuidString();
         response = await client.KeyExistsAsync(cacheName, key);
         Assert.True(response is CacheKeyExistsResponse.Success, $"Unexpected response: {response}");
         goodResponse = (CacheKeyExistsResponse.Success)response;
         exists = goodResponse.Exists;
-        Assert.False(exists);
+        Assert.False(exists, $"expected key to not exist but it does: {key}");
     }
 
     [Fact]

--- a/tests/Integration/Momento.Sdk.Tests/DictionaryTest.cs
+++ b/tests/Integration/Momento.Sdk.Tests/DictionaryTest.cs
@@ -914,12 +914,12 @@ public class DictionaryTest : TestBase
 
         var hitResponse = (CacheDictionaryFetchResponse.Hit)fetchResponse;
         // Exercise byte array dictionary structural equality comparer
-        Assert.True(hitResponse.ValueDictionaryByteArrayByteArray!.ContainsKey(field1));
-        Assert.True(hitResponse.ValueDictionaryByteArrayByteArray!.ContainsKey(field2));
+        Assert.True(hitResponse.ValueDictionaryByteArrayByteArray!.ContainsKey(field1), $"Could not find key {field1} in dictionary byte array: {hitResponse.ValueDictionaryByteArrayByteArray!}");
+        Assert.True(hitResponse.ValueDictionaryByteArrayByteArray!.ContainsKey(field2), $"Could not find key {field2} in dictionary byte array: {hitResponse.ValueDictionaryByteArrayByteArray!}");
         Assert.Equal(2, hitResponse.ValueDictionaryByteArrayByteArray!.Count);
 
         // Exercise DictionaryEquals extension
-        Assert.True(hitResponse.ValueDictionaryByteArrayByteArray!.DictionaryEquals(contentDictionary));
+        Assert.True(hitResponse.ValueDictionaryByteArrayByteArray!.DictionaryEquals(contentDictionary), $"Expected DictionaryEquals to return true for these dictionaries: {hitResponse.ValueDictionaryByteArrayByteArray!} AND {contentDictionary}");
 
         // Test field caching behavior
         Assert.Same(hitResponse.ValueDictionaryByteArrayByteArray, hitResponse.ValueDictionaryByteArrayByteArray);
@@ -929,10 +929,12 @@ public class DictionaryTest : TestBase
     public async Task DictionaryDeleteAsync_DictionaryDoesNotExist_Noop()
     {
         var dictionaryName = Utils.NewGuidString();
-        Assert.True((await client.DictionaryFetchAsync(cacheName, dictionaryName)) is CacheDictionaryFetchResponse.Miss);
+        var response = await client.DictionaryFetchAsync(cacheName, dictionaryName);
+        Assert.True(response is CacheDictionaryFetchResponse.Miss, $"Unexpected response: {response}");
         var deleteResponse = await client.DeleteAsync(cacheName, dictionaryName);
         Assert.True(deleteResponse is CacheDeleteResponse.Success, $"Unexpected response: {deleteResponse}");
-        Assert.True((await client.DictionaryFetchAsync(cacheName, dictionaryName)) is CacheDictionaryFetchResponse.Miss);
+        var fetchResponse = await client.DictionaryFetchAsync(cacheName, dictionaryName);
+        Assert.True(fetchResponse is CacheDictionaryFetchResponse.Miss, $"Unexpected response: {fetchResponse}");
     }
 
     [Fact]
@@ -943,10 +945,12 @@ public class DictionaryTest : TestBase
         await client.DictionarySetFieldAsync(cacheName, dictionaryName, Utils.NewGuidString(), Utils.NewGuidString());
         await client.DictionarySetFieldAsync(cacheName, dictionaryName, Utils.NewGuidString(), Utils.NewGuidString());
 
-        Assert.True((await client.DictionaryFetchAsync(cacheName, dictionaryName)) is CacheDictionaryFetchResponse.Hit);
+        var fetchResponse = await client.DictionaryFetchAsync(cacheName, dictionaryName);
+        Assert.True(fetchResponse is CacheDictionaryFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
         var deleteResponse = await client.DeleteAsync(cacheName, dictionaryName);
         Assert.True(deleteResponse is CacheDeleteResponse.Success, $"Unexpected response: {deleteResponse}");
-        Assert.True((await client.DictionaryFetchAsync(cacheName, dictionaryName)) is CacheDictionaryFetchResponse.Miss);
+        var response = await client.DictionaryFetchAsync(cacheName, dictionaryName);
+        Assert.True(response is CacheDictionaryFetchResponse.Miss, $"Unexpected response: {fetchResponse}");
     }
 
     [Theory]
@@ -979,17 +983,22 @@ public class DictionaryTest : TestBase
         var field2 = Utils.NewGuidByteArray();
 
         // Add a field then delete it
-        Assert.True((await client.DictionaryGetFieldAsync(cacheName, dictionaryName, field1)) is CacheDictionaryGetFieldResponse.Miss);
+        var response = await client.DictionaryGetFieldAsync(cacheName, dictionaryName, field1);
+        Assert.True(response is CacheDictionaryGetFieldResponse.Miss, $"Unexpected response: {response}");
         await client.DictionarySetFieldAsync(cacheName, dictionaryName, field1, value1);
-        Assert.True((await client.DictionaryGetFieldAsync(cacheName, dictionaryName, field1)) is CacheDictionaryGetFieldResponse.Hit);
+        response = await client.DictionaryGetFieldAsync(cacheName, dictionaryName, field1);
+        Assert.True(response is CacheDictionaryGetFieldResponse.Hit, $"Unexpected response: {response}");
 
         await client.DictionaryRemoveFieldAsync(cacheName, dictionaryName, field1);
-        Assert.True((await client.DictionaryGetFieldAsync(cacheName, dictionaryName, field1)) is CacheDictionaryGetFieldResponse.Miss);
+        response = await client.DictionaryGetFieldAsync(cacheName, dictionaryName, field1);
+        Assert.True(response is CacheDictionaryGetFieldResponse.Miss, $"Unexpected response: {response}");
 
         // Test no-op
-        Assert.True((await client.DictionaryGetFieldAsync(cacheName, dictionaryName, field2)) is CacheDictionaryGetFieldResponse.Miss);
+        response = await client.DictionaryGetFieldAsync(cacheName, dictionaryName, field2);
+        Assert.True(response is CacheDictionaryGetFieldResponse.Miss, $"Unexpected response: {response}");
         await client.DictionaryRemoveFieldAsync(cacheName, dictionaryName, field2);
-        Assert.True((await client.DictionaryGetFieldAsync(cacheName, dictionaryName, field2)) is CacheDictionaryGetFieldResponse.Miss);
+        response = await client.DictionaryGetFieldAsync(cacheName, dictionaryName, field2);
+        Assert.True(response is CacheDictionaryGetFieldResponse.Miss, $"Unexpected response: {response}");
     }
 
     [Fact]
@@ -1001,17 +1010,22 @@ public class DictionaryTest : TestBase
         var field2 = Utils.NewGuidString();
 
         // Add a field then delete it
-        Assert.True((await client.DictionaryGetFieldAsync(cacheName, dictionaryName, field1)) is CacheDictionaryGetFieldResponse.Miss);
+        var response = await client.DictionaryGetFieldAsync(cacheName, dictionaryName, field1);
+        Assert.True(response is CacheDictionaryGetFieldResponse.Miss, $"Unexpected response: {response}");
         await client.DictionarySetFieldAsync(cacheName, dictionaryName, field1, value1);
-        Assert.True((await client.DictionaryGetFieldAsync(cacheName, dictionaryName, field1)) is CacheDictionaryGetFieldResponse.Hit);
+        response = await client.DictionaryGetFieldAsync(cacheName, dictionaryName, field1);
+        Assert.True(response is CacheDictionaryGetFieldResponse.Hit, $"Unexpected response: {response}");
 
         await client.DictionaryRemoveFieldAsync(cacheName, dictionaryName, field1);
-        Assert.True((await client.DictionaryGetFieldAsync(cacheName, dictionaryName, field1)) is CacheDictionaryGetFieldResponse.Miss);
+        response = await client.DictionaryGetFieldAsync(cacheName, dictionaryName, field1);
+        Assert.True(response is CacheDictionaryGetFieldResponse.Miss, $"Unexpected response: {response}");
 
         // Test no-op
-        Assert.True((await client.DictionaryGetFieldAsync(cacheName, dictionaryName, field2)) is CacheDictionaryGetFieldResponse.Miss);
+        response = await client.DictionaryGetFieldAsync(cacheName, dictionaryName, field2);
+        Assert.True(response is CacheDictionaryGetFieldResponse.Miss, $"Unexpected response: {response}");
         await client.DictionaryRemoveFieldAsync(cacheName, dictionaryName, field2);
-        Assert.True((await client.DictionaryGetFieldAsync(cacheName, dictionaryName, field2)) is CacheDictionaryGetFieldResponse.Miss);
+        response = await client.DictionaryGetFieldAsync(cacheName, dictionaryName, field2);
+        Assert.True(response is CacheDictionaryGetFieldResponse.Miss, $"Unexpected response: {response}");
     }
 
     [Fact]
@@ -1062,9 +1076,12 @@ public class DictionaryTest : TestBase
 
         var fieldsList = new List<byte[]>(fields);
         await client.DictionaryRemoveFieldsAsync(cacheName, dictionaryName, fieldsList);
-        Assert.True((await client.DictionaryGetFieldAsync(cacheName, dictionaryName, fields[0])) is CacheDictionaryGetFieldResponse.Miss);
-        Assert.True((await client.DictionaryGetFieldAsync(cacheName, dictionaryName, fields[1])) is CacheDictionaryGetFieldResponse.Miss);
-        Assert.True((await client.DictionaryGetFieldAsync(cacheName, dictionaryName, otherField)) is CacheDictionaryGetFieldResponse.Hit);
+        var response = await client.DictionaryGetFieldAsync(cacheName, dictionaryName, fields[0]);
+        Assert.True(response is CacheDictionaryGetFieldResponse.Miss, $"Unexpected response: {response}");
+        response = await client.DictionaryGetFieldAsync(cacheName, dictionaryName, fields[1]);
+        Assert.True(response is CacheDictionaryGetFieldResponse.Miss, $"Unexpected response: {response}");
+        response = await client.DictionaryGetFieldAsync(cacheName, dictionaryName, otherField);
+        Assert.True(response is CacheDictionaryGetFieldResponse.Hit, $"Unexpected response: {response}");
     }
 
     [Fact]
@@ -1114,9 +1131,12 @@ public class DictionaryTest : TestBase
 
         var fieldsList = new List<string>(fields);
         await client.DictionaryRemoveFieldsAsync(cacheName, dictionaryName, fieldsList);
-        Assert.True((await client.DictionaryGetFieldAsync(cacheName, dictionaryName, fields[0])) is CacheDictionaryGetFieldResponse.Miss);
-        Assert.True((await client.DictionaryGetFieldAsync(cacheName, dictionaryName, fields[1])) is CacheDictionaryGetFieldResponse.Miss);
-        Assert.True((await client.DictionaryGetFieldAsync(cacheName, dictionaryName, otherField)) is CacheDictionaryGetFieldResponse.Hit);
+        var response = await client.DictionaryGetFieldAsync(cacheName, dictionaryName, fields[0]);
+        Assert.True(response is CacheDictionaryGetFieldResponse.Miss, $"Unexpected response: {response}");
+        response = await client.DictionaryGetFieldAsync(cacheName, dictionaryName, fields[1]);
+        Assert.True(response is CacheDictionaryGetFieldResponse.Miss, $"Unexpected response: {response}");
+        response = await client.DictionaryGetFieldAsync(cacheName, dictionaryName, otherField);
+        Assert.True(response is CacheDictionaryGetFieldResponse.Hit, $"Unexpected response: {response}");
     }
 
     [Fact]

--- a/tests/Integration/Momento.Sdk.Tests/ListTest.cs
+++ b/tests/Integration/Momento.Sdk.Tests/ListTest.cs
@@ -179,7 +179,7 @@ public class ListTest : TestBase
         CacheListRetainResponse retainResponse = await client.ListRetainAsync(cacheName, listName, 1, 4);
         Assert.True(retainResponse is CacheListRetainResponse.Success, $"Unexpected response: {retainResponse}");
         var fetchResponse = await client.ListFetchAsync(cacheName, listName);
-        Assert.True(fetchResponse is CacheListFetchResponse.Hit);
+        Assert.True(fetchResponse is CacheListFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
         var hitResponse = (CacheListFetchResponse.Hit)fetchResponse;
         Assert.Equal(new string[] { value2, value3, value4 }, hitResponse.ValueListString);
         
@@ -187,7 +187,7 @@ public class ListTest : TestBase
         retainResponse = await client.ListRetainAsync(cacheName, listName, 2, -1);
         Assert.True(retainResponse is CacheListRetainResponse.Success, $"Unexpected response: {retainResponse}");
         fetchResponse = await client.ListFetchAsync(cacheName, listName);
-        Assert.True(fetchResponse is CacheListFetchResponse.Hit);
+        Assert.True(fetchResponse is CacheListFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
         hitResponse = (CacheListFetchResponse.Hit)fetchResponse;
         Assert.Equal(new string[] { value3, value4, value5 }, hitResponse.ValueListString);
         
@@ -195,7 +195,7 @@ public class ListTest : TestBase
         retainResponse = await client.ListRetainAsync(cacheName, listName, -4, -1);
         Assert.True(retainResponse is CacheListRetainResponse.Success, $"Unexpected response: {retainResponse}");
         fetchResponse = await client.ListFetchAsync(cacheName, listName);
-        Assert.True(fetchResponse is CacheListFetchResponse.Hit);
+        Assert.True(fetchResponse is CacheListFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
         hitResponse = (CacheListFetchResponse.Hit)fetchResponse;
         Assert.Equal(new string[] { value3, value4, value5 }, hitResponse.ValueListString);
         
@@ -204,7 +204,7 @@ public class ListTest : TestBase
         retainResponse = await client.ListRetainAsync(cacheName, listName, -3, null);
         Assert.True(retainResponse is CacheListRetainResponse.Success, $"Unexpected response: {retainResponse}");
         fetchResponse = await client.ListFetchAsync(cacheName, listName);
-        Assert.True(fetchResponse is CacheListFetchResponse.Hit);
+        Assert.True(fetchResponse is CacheListFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
         hitResponse = (CacheListFetchResponse.Hit)fetchResponse;
         Assert.Equal(new string[] { value4, value5, value6 }, hitResponse.ValueListString);
 
@@ -213,7 +213,7 @@ public class ListTest : TestBase
         retainResponse = await client.ListRetainAsync(cacheName, listName, 2);
         Assert.True(retainResponse is CacheListRetainResponse.Success, $"Unexpected response: {retainResponse}");
         fetchResponse = await client.ListFetchAsync(cacheName, listName);
-        Assert.True(fetchResponse is CacheListFetchResponse.Hit);
+        Assert.True(fetchResponse is CacheListFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
         hitResponse = (CacheListFetchResponse.Hit)fetchResponse;
         Assert.Equal(new string[] { value3, value4, value5, value6 }, hitResponse.ValueListString);
         
@@ -222,7 +222,7 @@ public class ListTest : TestBase
         retainResponse = await client.ListRetainAsync(cacheName, listName, null, 1);
         Assert.True(retainResponse is CacheListRetainResponse.Success, $"Unexpected response: {retainResponse}");
         fetchResponse = await client.ListFetchAsync(cacheName, listName);
-        Assert.True(fetchResponse is CacheListFetchResponse.Hit);
+        Assert.True(fetchResponse is CacheListFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
         hitResponse = (CacheListFetchResponse.Hit)fetchResponse;
         Assert.Equal(new string[] { value1 }, hitResponse.ValueListString);
 
@@ -231,7 +231,7 @@ public class ListTest : TestBase
         retainResponse = await client.ListRetainAsync(cacheName, listName, endIndex: -3);
         Assert.True(retainResponse is CacheListRetainResponse.Success, $"Unexpected response: {retainResponse}");
         fetchResponse = await client.ListFetchAsync(cacheName, listName);
-        Assert.True(fetchResponse is CacheListFetchResponse.Hit);
+        Assert.True(fetchResponse is CacheListFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
         hitResponse = (CacheListFetchResponse.Hit)fetchResponse;
         Assert.Equal(new string[] { value1, value2, value3 }, hitResponse.ValueListString);
     }
@@ -1255,7 +1255,7 @@ public class ListTest : TestBase
         var response = await client.ListFetchAsync(cacheName, listName);
         Assert.True(response is CacheListFetchResponse.Hit, $"Unexpected response: {response}");
         var cachedList = ((CacheListFetchResponse.Hit)response).ValueListByteArray!;
-        Assert.True(list.ListEquals(cachedList));
+        Assert.True(list.ListEquals(cachedList), $"lists did not match: {list} AND {cachedList}");
     }
 
     [Fact]
@@ -1277,16 +1277,18 @@ public class ListTest : TestBase
         var response = await client.ListFetchAsync(cacheName, listName);
         Assert.True(response is CacheListFetchResponse.Hit, $"Unexpected response: {response}");
         var cachedList = ((CacheListFetchResponse.Hit)response).ValueListByteArray!;
-        Assert.True(list.ListEquals(cachedList));
+        Assert.True(list.ListEquals(cachedList), $"lists did not match: {list} AND {cachedList}");
     }
 
     [Fact]
     public async Task ListRemoveValueAsync_ValueIsByteArray_ListNotThereNoop()
     {
         var listName = Utils.NewGuidString();
-        Assert.True(await client.ListFetchAsync(cacheName, listName) is CacheListFetchResponse.Miss);
+        var response = await client.ListFetchAsync(cacheName, listName);
+        Assert.True(response is CacheListFetchResponse.Miss, $"Unexpected response: {response}");
         await client.ListRemoveValueAsync(cacheName, listName, Utils.NewGuidByteArray());
-        Assert.True(await client.ListFetchAsync(cacheName, listName) is CacheListFetchResponse.Miss);
+        response = await client.ListFetchAsync(cacheName, listName);
+        Assert.True(response is CacheListFetchResponse.Miss, $"Unexpected response: {response}");
     }
 
     [Theory]
@@ -1326,7 +1328,7 @@ public class ListTest : TestBase
         var response = await client.ListFetchAsync(cacheName, listName);
         Assert.True(response is CacheListFetchResponse.Hit, $"Unexpected response: {response}");
         var cachedList = ((CacheListFetchResponse.Hit)response).ValueListString!;
-        Assert.True(list.SequenceEqual(cachedList));
+        Assert.True(list.SequenceEqual(cachedList), $"lists did not match: {list} AND {cachedList}");
     }
 
     [Fact]
@@ -1348,16 +1350,18 @@ public class ListTest : TestBase
         var response = await client.ListFetchAsync(cacheName, listName);
         Assert.True(response is CacheListFetchResponse.Hit, $"Unexpected response: {response}");
         var cachedList = ((CacheListFetchResponse.Hit)response).ValueListString!;
-        Assert.True(list.SequenceEqual(cachedList));
+        Assert.True(list.SequenceEqual(cachedList), $"lists did not match: {list} AND {cachedList}");
     }
 
     [Fact]
     public async Task ListRemoveValueAsync_ValueIsString_ListNotThereNoop()
     {
         var listName = Utils.NewGuidString();
-        Assert.True(await client.ListFetchAsync(cacheName, listName) is CacheListFetchResponse.Miss);
+        var response = await client.ListFetchAsync(cacheName, listName);
+        Assert.True(response is CacheListFetchResponse.Miss, $"Unexpected response: {response}");
         await client.ListRemoveValueAsync(cacheName, listName, Utils.NewGuidString());
-        Assert.True(await client.ListFetchAsync(cacheName, listName) is CacheListFetchResponse.Miss);
+        response = await client.ListFetchAsync(cacheName, listName);
+        Assert.True(response is CacheListFetchResponse.Miss, $"Unexpected response: {response}");
     }
 
     [Fact]
@@ -1416,10 +1420,12 @@ public class ListTest : TestBase
     public async Task ListDeleteAsync_ListDoesNotExist_Noop()
     {
         var listName = Utils.NewGuidString();
-        Assert.True((await client.ListFetchAsync(cacheName, listName)) is CacheListFetchResponse.Miss);
+        var response = await client.ListFetchAsync(cacheName, listName);
+        Assert.True(response is CacheListFetchResponse.Miss, $"Unexpected response: {response}");
         var deleteResponse = await client.DeleteAsync(cacheName, listName);
         Assert.True(deleteResponse is CacheDeleteResponse.Success, $"Unexpected response: {deleteResponse}");
-        Assert.True((await client.ListFetchAsync(cacheName, listName)) is CacheListFetchResponse.Miss);
+        response = await client.ListFetchAsync(cacheName, listName);
+        Assert.True(response is CacheListFetchResponse.Miss, $"Unexpected response: {response}");
     }
 
     [Fact]
@@ -1433,7 +1439,8 @@ public class ListTest : TestBase
         pushResponse = await client.ListPushFrontAsync(cacheName, listName, Utils.NewGuidString());
         Assert.True(pushResponse is CacheListPushFrontResponse.Success, $"Unexpected response: {pushResponse}");
 
-        Assert.True((await client.ListFetchAsync(cacheName, listName)) is CacheListFetchResponse.Hit);
+        var response = await client.ListFetchAsync(cacheName, listName);
+        Assert.True(response is CacheListFetchResponse.Hit, $"Unexpected response: {response}");
         var deleteResponse = await client.DeleteAsync(cacheName, listName);
         Assert.True(deleteResponse is CacheDeleteResponse.Success, $"Unexpected response: {deleteResponse}");
 

--- a/tests/Integration/Momento.Sdk.Tests/SetTest.cs
+++ b/tests/Integration/Momento.Sdk.Tests/SetTest.cs
@@ -342,14 +342,16 @@ public class SetTest : TestBase
         var element = Utils.NewGuidString();
 
         // Pre-condition: set is missing
-        Assert.True(await client.SetFetchAsync(cacheName, setName) is CacheSetFetchResponse.Miss);
+        var fetchResponse = await client.SetFetchAsync(cacheName, setName);
+        Assert.True(fetchResponse is CacheSetFetchResponse.Miss, $"Unexpected response: {fetchResponse}");
 
         // Remove element that is not there -- no-op
         CacheSetRemoveElementResponse removeResponse = await client.SetRemoveElementAsync(cacheName, setName, Utils.NewGuidByteArray());
         Assert.True(removeResponse is CacheSetRemoveElementResponse.Success, $"Unexpected response: {removeResponse}");
 
         // Post-condition: set is still missing
-        Assert.True(await client.SetFetchAsync(cacheName, setName) is CacheSetFetchResponse.Miss);
+        fetchResponse = await client.SetFetchAsync(cacheName, setName);
+        Assert.True(fetchResponse is CacheSetFetchResponse.Miss, $"Unexpected response: {fetchResponse}");
     }
 
     [Theory]
@@ -395,14 +397,16 @@ public class SetTest : TestBase
         var element = Utils.NewGuidString();
 
         // Pre-condition: set is missing
-        Assert.True(await client.SetFetchAsync(cacheName, setName) is CacheSetFetchResponse.Miss);
+        var fetchResponse = await client.SetFetchAsync(cacheName, setName);
+        Assert.True(fetchResponse is CacheSetFetchResponse.Miss, $"Unexpected response: {fetchResponse}");
 
         // Remove element that is not there -- no-op
         CacheSetRemoveElementResponse response = await client.SetRemoveElementAsync(cacheName, setName, Utils.NewGuidString());
         Assert.True(response is CacheSetRemoveElementResponse.Success, $"Unexpected response: {response}");
 
         // Post-condition: set is still missing
-        Assert.True(await client.SetFetchAsync(cacheName, setName) is CacheSetFetchResponse.Miss);
+        fetchResponse = await client.SetFetchAsync(cacheName, setName);
+        Assert.True(fetchResponse is CacheSetFetchResponse.Miss, $"Unexpected response: {fetchResponse}");
     }
 
     [Fact]
@@ -586,10 +590,12 @@ public class SetTest : TestBase
     public async Task SetDeleteAsync_SetDoesNotExist_Noop()
     {
         var setName = Utils.NewGuidString();
-        Assert.True(await client.SetFetchAsync(cacheName, setName) is CacheSetFetchResponse.Miss);
+        var fetchResponse = await client.SetFetchAsync(cacheName, setName);
+        Assert.True(fetchResponse is CacheSetFetchResponse.Miss, $"Unexpected response: {fetchResponse}");
         var response = await client.DeleteAsync(cacheName, setName);
         Assert.True(response is CacheDeleteResponse.Success, $"Unexpected response: {response}");
-        Assert.True(await client.SetFetchAsync(cacheName, setName) is CacheSetFetchResponse.Miss);
+        fetchResponse = await client.SetFetchAsync(cacheName, setName);
+        Assert.True(fetchResponse is CacheSetFetchResponse.Miss, $"Unexpected response: {fetchResponse}");
     }
 
     [Fact]
@@ -603,10 +609,12 @@ public class SetTest : TestBase
         response = await client.SetAddElementAsync(cacheName, setName, Utils.NewGuidString());
         Assert.True(response is CacheSetAddElementResponse.Success, $"Unexpected response: {response}");
 
-        Assert.True(await client.SetFetchAsync(cacheName, setName) is CacheSetFetchResponse.Hit);
+        var fetchResponse = await client.SetFetchAsync(cacheName, setName);
+        Assert.True(fetchResponse is CacheSetFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
         var deleteResponse = await client.DeleteAsync(cacheName, setName);
         Assert.True(deleteResponse is CacheDeleteResponse.Success, $"Unexpected response: {deleteResponse}");
-        Assert.True(await client.SetFetchAsync(cacheName, setName) is CacheSetFetchResponse.Miss);
+        fetchResponse = await client.SetFetchAsync(cacheName, setName);
+        Assert.True(fetchResponse is CacheSetFetchResponse.Miss, $"Unexpected response: {fetchResponse}");
     }
     
     [Fact]

--- a/tests/Integration/Momento.Sdk.Tests/TtlTest.cs
+++ b/tests/Integration/Momento.Sdk.Tests/TtlTest.cs
@@ -68,7 +68,7 @@ public class TtlTest : TestBase
 
         // Check it is there
         var existsResponse = await client.KeyExistsAsync(cacheName, key);
-        Assert.True(existsResponse is CacheKeyExistsResponse.Success, "exists response should be success");
+        Assert.True(existsResponse is CacheKeyExistsResponse.Success, $"Unexpected response: {response}");
         Assert.True(((CacheKeyExistsResponse.Success)existsResponse).Exists, "Key should exist");
 
         // Let's make the TTL really small.
@@ -80,8 +80,8 @@ public class TtlTest : TestBase
 
         // Check it is gone
         existsResponse = await client.KeyExistsAsync(cacheName, key);
-        Assert.True(existsResponse is CacheKeyExistsResponse.Success, "exists response should be success");
-        Assert.False(((CacheKeyExistsResponse.Success)existsResponse).Exists, "Key should not exist");
+        Assert.True(existsResponse is CacheKeyExistsResponse.Success, $"Unexpected response: {response}");
+        Assert.False(((CacheKeyExistsResponse.Success)existsResponse).Exists, $"Key {key} should not exist but it does");
     }
 
     [Fact]
@@ -95,8 +95,8 @@ public class TtlTest : TestBase
 
         // Check it is there
         var existsResponse = await client.KeyExistsAsync(cacheName, key);
-        Assert.True(existsResponse is CacheKeyExistsResponse.Success, "exists response should be success");
-        Assert.True(((CacheKeyExistsResponse.Success)existsResponse).Exists, "Key should exist");
+        Assert.True(existsResponse is CacheKeyExistsResponse.Success, $"Unexpected response: {response}");
+        Assert.True(((CacheKeyExistsResponse.Success)existsResponse).Exists, $"Key {key} should exist but does not");
 
         // Let's make the TTL really small.
         var updateTtlResponse = await client.UpdateTtlAsync(cacheName, key, TimeSpan.FromSeconds(1));
@@ -107,8 +107,8 @@ public class TtlTest : TestBase
 
         // Check it is gone
         existsResponse = await client.KeyExistsAsync(cacheName, key);
-        Assert.True(existsResponse is CacheKeyExistsResponse.Success, "exists response should be success");
-        Assert.False(((CacheKeyExistsResponse.Success)existsResponse).Exists, "Key should not exist");
+        Assert.True(existsResponse is CacheKeyExistsResponse.Success, $"Unexpected response: {response}");
+        Assert.False(((CacheKeyExistsResponse.Success)existsResponse).Exists, $"Key {key} should not exist but it does");
     }
 
     [Fact]


### PR DESCRIPTION
Addresses https://github.com/momentohq/oncall-tracker/issues/3051

Updated all `Assert.True` statements to include a message to print upon failure. Also uncomments the flaky test so it's back in now.