### PR TITLE
chore: rename DeleteIndexesAsync to DeleteIndexAsync

### DIFF
--- a/src/Momento.Sdk/IPreviewVectorIndexClient.cs
+++ b/src/Momento.Sdk/IPreviewVectorIndexClient.cs
@@ -103,7 +103,7 @@ public interface IPreviewVectorIndexClient : IDisposable
     /// }
     /// </code>
     ///</returns>
-    public Task<DeleteIndexResponse> DeleteIndexesAsync(string indexName);
+    public Task<DeleteIndexResponse> DeleteIndexAsync(string indexName);
 
     /// <summary>
     /// Upserts a batch of items into a vector index.

--- a/src/Momento.Sdk/PreviewVectorIndexClient.cs
+++ b/src/Momento.Sdk/PreviewVectorIndexClient.cs
@@ -49,7 +49,7 @@ public class PreviewVectorIndexClient: IPreviewVectorIndexClient
     }
 
     /// <inheritdoc />
-    public async Task<DeleteIndexResponse> DeleteIndexesAsync(string indexName)
+    public async Task<DeleteIndexResponse> DeleteIndexAsync(string indexName)
     {
         return await controlClient.DeleteIndexAsync(indexName);
     }

--- a/tests/Integration/Momento.Sdk.Tests/VectorIndexControlTest.cs
+++ b/tests/Integration/Momento.Sdk.Tests/VectorIndexControlTest.cs
@@ -30,7 +30,7 @@ public class VectorIndexControlTest : IClassFixture<VectorIndexClientFixture>
         }
         finally
         {
-            var deleteResponse = await vectorIndexClient.DeleteIndexesAsync(indexName);
+            var deleteResponse = await vectorIndexClient.DeleteIndexAsync(indexName);
             Assert.True(deleteResponse is DeleteIndexResponse.Success, $"Unexpected response: {deleteResponse}");
         }
     }
@@ -75,7 +75,7 @@ public class VectorIndexControlTest : IClassFixture<VectorIndexClientFixture>
     public async Task DeleteIndexAsync_DoesntExistError()
     {
         var indexName = $"index-{Utils.NewGuidString()}";
-        var deleteResponse = await vectorIndexClient.DeleteIndexesAsync(indexName);
+        var deleteResponse = await vectorIndexClient.DeleteIndexAsync(indexName);
         Assert.True(deleteResponse is DeleteIndexResponse.Error, $"Unexpected response: {deleteResponse}");
         var deleteErr = (DeleteIndexResponse.Error)deleteResponse;
         Assert.Equal(MomentoErrorCode.NOT_FOUND_ERROR, deleteErr.InnerException.ErrorCode);

--- a/tests/Integration/Momento.Sdk.Tests/VectorIndexDataTest.cs
+++ b/tests/Integration/Momento.Sdk.Tests/VectorIndexDataTest.cs
@@ -86,7 +86,7 @@ public class VectorIndexDataTest : IClassFixture<VectorIndexClientFixture>
         }
         finally
         {
-            await vectorIndexClient.DeleteIndexesAsync(indexName);
+            await vectorIndexClient.DeleteIndexAsync(indexName);
         }
     }
 
@@ -123,7 +123,7 @@ public class VectorIndexDataTest : IClassFixture<VectorIndexClientFixture>
         }
         finally
         {
-            await vectorIndexClient.DeleteIndexesAsync(indexName);
+            await vectorIndexClient.DeleteIndexAsync(indexName);
         }
     }
 
@@ -161,7 +161,7 @@ public class VectorIndexDataTest : IClassFixture<VectorIndexClientFixture>
         }
         finally
         {
-            await vectorIndexClient.DeleteIndexesAsync(indexName);
+            await vectorIndexClient.DeleteIndexAsync(indexName);
         }
     }
 
@@ -197,7 +197,7 @@ public class VectorIndexDataTest : IClassFixture<VectorIndexClientFixture>
         }
         finally
         {
-            await vectorIndexClient.DeleteIndexesAsync(indexName);
+            await vectorIndexClient.DeleteIndexAsync(indexName);
         }
     }
 
@@ -271,7 +271,7 @@ public class VectorIndexDataTest : IClassFixture<VectorIndexClientFixture>
         }
         finally
         {
-            await vectorIndexClient.DeleteIndexesAsync(indexName);
+            await vectorIndexClient.DeleteIndexAsync(indexName);
         }
     }
 
@@ -314,20 +314,7 @@ public class VectorIndexDataTest : IClassFixture<VectorIndexClientFixture>
         }
         finally
         {
-            await vectorIndexClient.DeleteIndexesAsync(indexName);
-        }
-    }
-
-    [Fact]
-    public async Task TempDeleteAllIndexes()
-    {
-        var listResponse = await vectorIndexClient.ListIndexesAsync();
-        Assert.True(listResponse is ListIndexesResponse.Success, $"Unexpected response: {listResponse}");
-        var listOk = (ListIndexesResponse.Success)listResponse;
-        foreach (var indexName in listOk.IndexNames)
-        {
-            var deleteResponse = await vectorIndexClient.DeleteIndexesAsync(indexName);
-            Assert.True(deleteResponse is DeleteIndexResponse.Success, $"Unexpected response: {deleteResponse}");
+            await vectorIndexClient.DeleteIndexAsync(indexName);
         }
     }
 }


### PR DESCRIPTION
Remove incorrect plural from DeleteIndexesAsync. The preview vector index client has an unstable api warning, so this name change is possible.

Remove temp test that was used to clear out indexes on the test account.