### PR TITLE
chore: change ListIndexesAsync return to a list of IndexInfo

### DIFF
--- a/src/Momento.Sdk/Internal/VectorIndexControlClient.cs
+++ b/src/Momento.Sdk/Internal/VectorIndexControlClient.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Grpc.Core;
 using Microsoft.Extensions.Logging;
@@ -69,7 +70,8 @@ internal sealed class VectorIndexControlClient : IDisposable
             var request = new _ListIndexesRequest();
             var response = await grpcManager.Client.ListIndexesAsync(request, new CallOptions(deadline: CalculateDeadline()));
             return _logger.LogTraceGenericRequestSuccess("listVectorIndexes",
-                new ListIndexesResponse.Success(new List<string>(response.IndexNames)));
+                new ListIndexesResponse.Success(
+                    new List<IndexInfo>(response.IndexNames.Select(n => new IndexInfo(n)))));
         }
         catch (Exception e)
         {

--- a/src/Momento.Sdk/Responses/Vector/IndexInfo.cs
+++ b/src/Momento.Sdk/Responses/Vector/IndexInfo.cs
@@ -1,0 +1,39 @@
+namespace Momento.Sdk.Responses.Vector;
+
+/// <summary>
+/// Information about a vector index.
+/// </summary>
+public class IndexInfo
+{
+    /// <summary>
+    /// The name of the index.
+    /// </summary>
+    public string Name { get; }
+
+    /// <summary>
+    /// Constructs an IndexInfo.
+    /// </summary>
+    /// <param name="name">The name of the index.</param>
+    public IndexInfo(string name)
+    {
+        Name = name;
+    }
+
+    /// <inheritdoc />
+    public override bool Equals(object obj)
+    {
+        return obj is IndexInfo other && Name == other.Name;
+    }
+
+    /// <inheritdoc />
+    public override int GetHashCode()
+    {
+        return Name.GetHashCode();
+    }
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return $"IndexInfo {{ Name = {Name} }}";
+    }
+}

--- a/src/Momento.Sdk/Responses/Vector/ListIndexesResponse.cs
+++ b/src/Momento.Sdk/Responses/Vector/ListIndexesResponse.cs
@@ -16,7 +16,7 @@ namespace Momento.Sdk.Responses.Vector;
 /// <code>
 /// if (response is ListIndexesResponse.Success successResponse)
 /// {
-///     return successResponse.IndexNames;
+///     return successResponse.Indexes;
 /// }
 /// else if (response is ListIndexesResponse.Error errorResponse)
 /// {
@@ -34,21 +34,21 @@ public abstract class ListIndexesResponse
     public class Success : ListIndexesResponse
     {
         /// <summary>
-        /// The list of vector available to the user.
+        /// The list of information about the vector indexes available to the user.
         /// </summary>
-        public List<string> IndexNames { get; }
+        public List<IndexInfo> Indexes { get; }
 
         /// <include file="../../docs.xml" path='docs/class[@name="Success"]/description/*' />
-        /// <param name="indexNames">the list of index names</param>
-        public Success(List<string> indexNames)
+        /// <param name="indexes">the list of index information</param>
+        public Success(List<IndexInfo> indexes)
         {
-            IndexNames = indexNames;
+            Indexes = indexes;
         }
 
         /// <inheritdoc />
         public override string ToString()
         {
-            return $"{base.ToString()}: {string.Join(", ", IndexNames)}";
+            return $"{base.ToString()}: {string.Join(", ", Indexes)}";
         }
 
     }

--- a/tests/Integration/Momento.Sdk.Tests/VectorIndexControlTest.cs
+++ b/tests/Integration/Momento.Sdk.Tests/VectorIndexControlTest.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Threading.Tasks;
     using Momento.Sdk.Responses.Vector;
 
@@ -26,7 +27,7 @@ public class VectorIndexControlTest : IClassFixture<VectorIndexClientFixture>
             var listResponse = await vectorIndexClient.ListIndexesAsync();
             Assert.True(listResponse is ListIndexesResponse.Success, $"Unexpected response: {listResponse}");
             var listOk = (ListIndexesResponse.Success)listResponse;
-            Assert.Contains(listOk.IndexNames, name => name == indexName);
+            Assert.Contains(listOk.Indexes.Select(i => i.Name), name => name == indexName);
         }
         finally
         {


### PR DESCRIPTION
Change the data that ListIndexesAsync returns from a list of index names to a list of IndexInfo object containing the names. We will add more fields in the future.