### PR TITLE
feat: add score threshold to MVI search

### DIFF
--- a/src/Momento.Sdk/IPreviewVectorIndexClient.cs
+++ b/src/Momento.Sdk/IPreviewVectorIndexClient.cs
@@ -156,32 +156,36 @@ public interface IPreviewVectorIndexClient : IDisposable
     ///</returns>
     public Task<DeleteItemBatchResponse> DeleteItemBatchAsync(string indexName, IEnumerable<string> ids);
 
-    /// <summary>
-    /// Searches for the most similar vectors to the query vector in the index.
-    /// Ranks the vectors according to the similarity metric specified when the
-    /// index was created.
-    /// </summary>
-    /// <param name="indexName">The name of the vector index to search in.</param>
-    /// <param name="queryVector">The vector to search for.</param>
-    /// <param name="topK">The number of results to return. Defaults to 10.</param>
-    /// <param name="metadataFields">A list of metadata fields to return with each result.</param>
-    /// <returns>
-    /// Task representing the result of the upsert operation. The
-    /// response object is resolved to a type-safe object of one of
-    /// the following subtypes:
-    /// <list type="bullet">
-    /// <item><description>SearchResponse.Success</description></item>
-    /// <item><description>SearchResponse.Error</description></item>
-    /// </list>
-    /// Pattern matching can be used to operate on the appropriate subtype.
-    /// For example:
-    /// <code>
-    /// if (response is SearchResponse.Error errorResponse)
-    /// {
-    ///     // handle error as appropriate
-    /// }
-    /// </code>
-    ///</returns>
+    ///  <summary>
+    ///  Searches for the most similar vectors to the query vector in the index.
+    ///  Ranks the vectors according to the similarity metric specified when the
+    ///  index was created.
+    ///  </summary>
+    ///  <param name="indexName">The name of the vector index to search in.</param>
+    ///  <param name="queryVector">The vector to search for.</param>
+    ///  <param name="topK">The number of results to return. Defaults to 10.</param>
+    ///  <param name="metadataFields">A list of metadata fields to return with each result.</param>
+    ///  <param name="scoreThreshold">A score threshold to filter results by. For cosine
+    /// similarity and inner product, scores lower than the threshold are excluded. For
+    /// euclidean similarity, scores higher than the threshold are excluded. The threshold
+    /// is exclusive. Defaults to None, ie no threshold.</param>
+    ///  <returns>
+    ///  Task representing the result of the upsert operation. The
+    ///  response object is resolved to a type-safe object of one of
+    ///  the following subtypes:
+    ///  <list type="bullet">
+    ///  <item><description>SearchResponse.Success</description></item>
+    ///  <item><description>SearchResponse.Error</description></item>
+    ///  </list>
+    ///  Pattern matching can be used to operate on the appropriate subtype.
+    ///  For example:
+    ///  <code>
+    ///  if (response is SearchResponse.Error errorResponse)
+    ///  {
+    ///      // handle error as appropriate
+    ///  }
+    ///  </code>
+    /// </returns>
     public Task<SearchResponse> SearchAsync(string indexName, IEnumerable<float> queryVector, int topK = 10,
-        MetadataFields? metadataFields = null);
+        MetadataFields? metadataFields = null, float? scoreThreshold = null);
 }

--- a/src/Momento.Sdk/Momento.Sdk.csproj
+++ b/src/Momento.Sdk/Momento.Sdk.csproj
@@ -55,7 +55,7 @@
 	<ItemGroup>
 	  <PackageReference Include="Grpc.Net.Client" Version="2.49.0" />
 	  <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
-	  <PackageReference Include="Momento.Protos" Version="0.91.1" />
+	  <PackageReference Include="Momento.Protos" Version="0.94.1" />
 	  <PackageReference Include="JWT" Version="9.0.3" />
 	  <PackageReference Include="System.Threading.Channels" Version="6.0.0" />
 	  <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />

--- a/src/Momento.Sdk/PreviewVectorIndexClient.cs
+++ b/src/Momento.Sdk/PreviewVectorIndexClient.cs
@@ -69,9 +69,9 @@ public class PreviewVectorIndexClient: IPreviewVectorIndexClient
 
     /// <inheritdoc />
     public async Task<SearchResponse> SearchAsync(string indexName, IEnumerable<float> queryVector,
-        int topK = 10, MetadataFields? metadataFields = null)
+        int topK = 10, MetadataFields? metadataFields = null, float? searchThreshold = null)
     {
-        return await dataClient.SearchAsync(indexName, queryVector, topK, metadataFields);
+        return await dataClient.SearchAsync(indexName, queryVector, topK, metadataFields, searchThreshold);
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
Add score threshold to the MVI search method.

Update the protos and change 'distance' to 'score' in internal search response.