### PR TITLE
chore: update mvi control plane for create and list indexes protos

### DIFF
--- a/src/Momento.Sdk/Internal/VectorIndexControlClient.cs
+++ b/src/Momento.Sdk/Internal/VectorIndexControlClient.cs
@@ -33,22 +33,22 @@ internal sealed class VectorIndexControlClient : IDisposable
             _logger.LogTraceVectorIndexRequest("createVectorIndex", indexName);
             CheckValidIndexName(indexName);
             var validatedNumDimensions = ValidateNumDimensions(numDimensions);
-            var request = new _CreateIndexRequest { IndexName = indexName, NumDimensions = validatedNumDimensions };
+            var request = new _CreateIndexRequest { IndexName = indexName, NumDimensions = validatedNumDimensions, SimilarityMetric = new _SimilarityMetric() };
             switch (similarityMetric)
             {
                 case SimilarityMetric.CosineSimilarity:
-                    request.CosineSimilarity = new _CreateIndexRequest.Types._CosineSimilarity();
+                    request.SimilarityMetric.CosineSimilarity = new _SimilarityMetric.Types._CosineSimilarity();
                     break;
                 case SimilarityMetric.InnerProduct:
-                    request.InnerProduct = new _CreateIndexRequest.Types._InnerProduct();
+                    request.SimilarityMetric.InnerProduct = new _SimilarityMetric.Types._InnerProduct();
                     break;
                 case SimilarityMetric.EuclideanSimilarity:
-                    request.EuclideanSimilarity = new _CreateIndexRequest.Types._EuclideanSimilarity();
+                    request.SimilarityMetric.EuclideanSimilarity = new _SimilarityMetric.Types._EuclideanSimilarity();
                     break;
                 default:
                     throw new InvalidArgumentException($"Unknown similarity metric {similarityMetric}");
             }
-            
+
             await grpcManager.Client.CreateIndexAsync(request, new CallOptions(deadline: CalculateDeadline()));
             return _logger.LogTraceVectorIndexRequestSuccess("createVectorIndex", indexName, new CreateIndexResponse.Success());
         }
@@ -71,7 +71,7 @@ internal sealed class VectorIndexControlClient : IDisposable
             var response = await grpcManager.Client.ListIndexesAsync(request, new CallOptions(deadline: CalculateDeadline()));
             return _logger.LogTraceGenericRequestSuccess("listVectorIndexes",
                 new ListIndexesResponse.Success(
-                    new List<IndexInfo>(response.IndexNames.Select(n => new IndexInfo(n)))));
+                    new List<IndexInfo>(response.Indexes.Select(n => new IndexInfo(n.IndexName)))));
         }
         catch (Exception e)
         {

--- a/src/Momento.Sdk/Momento.Sdk.csproj
+++ b/src/Momento.Sdk/Momento.Sdk.csproj
@@ -55,7 +55,7 @@
 	<ItemGroup>
 	  <PackageReference Include="Grpc.Net.Client" Version="2.49.0" />
 	  <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
-	  <PackageReference Include="Momento.Protos" Version="0.94.1" />
+	  <PackageReference Include="Momento.Protos" Version="0.96.0" />
 	  <PackageReference Include="JWT" Version="9.0.3" />
 	  <PackageReference Include="System.Threading.Channels" Version="6.0.0" />
 	  <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />


### PR DESCRIPTION
Updates MVI list and create indexes backend for latest changes. Updates protos but developer-facing API remains otherwise the same.