### PR TITLE
fix: clean up vector indexes in integration tests

### DIFF
--- a/tests/Integration/Momento.Sdk.Tests/Utils.cs
+++ b/tests/Integration/Momento.Sdk.Tests/Utils.cs
@@ -55,7 +55,8 @@ public static class Utils
             VectorIndexClient = vectorIndexClient;
             IndexInfo = indexInfo;
 
-            // This isn't kosher in a constructor, but it's the only way to get the using() syntax to work.
+            // This usually isn't kosher in a constructor; because we want this class to encapsulate
+            // index creation and deletion in a using block, the class has to do RAII.
             var createResponse = vectorIndexClient.CreateIndexAsync(indexInfo.Name, indexInfo.NumDimensions, indexInfo.SimilarityMetric).Result;
             if (createResponse is not (CreateIndexResponse.Success or CreateIndexResponse.AlreadyExists))
             {

--- a/tests/Integration/Momento.Sdk.Tests/VectorIndexControlTest.cs
+++ b/tests/Integration/Momento.Sdk.Tests/VectorIndexControlTest.cs
@@ -32,20 +32,12 @@ public class VectorIndexControlTest : IClassFixture<VectorIndexClientFixture>
     [MemberData(nameof(CreateAndListIndexTestData))]
     public async Task CreateListDelete_HappyPath(IndexInfo indexInfo)
     {
-        try
+        using (Utils.WithVectorIndex(vectorIndexClient, indexInfo))
         {
-            var createResponse = await vectorIndexClient.CreateIndexAsync(indexInfo.Name, indexInfo.NumDimensions, indexInfo.SimilarityMetric);
-            Assert.True(createResponse is CreateIndexResponse.Success, $"Unexpected response: {createResponse}");
-
             var listResponse = await vectorIndexClient.ListIndexesAsync();
             Assert.True(listResponse is ListIndexesResponse.Success, $"Unexpected response: {listResponse}");
             var listOk = (ListIndexesResponse.Success)listResponse;
             Assert.Contains(indexInfo, listOk.Indexes);
-        }
-        finally
-        {
-            var deleteResponse = await vectorIndexClient.DeleteIndexAsync(indexInfo.Name);
-            Assert.True(deleteResponse is DeleteIndexResponse.Success, $"Unexpected response: {deleteResponse}");
         }
     }
 
@@ -54,18 +46,10 @@ public class VectorIndexControlTest : IClassFixture<VectorIndexClientFixture>
     {
         var indexName = Utils.TestVectorIndexName();
         const int numDimensions = 3;
-        try
+        using (Utils.WithVectorIndex(vectorIndexClient, indexName, numDimensions))
         {
-            var createResponse = await vectorIndexClient.CreateIndexAsync(indexName, numDimensions);
-            Assert.True(createResponse is CreateIndexResponse.Success, $"Unexpected response: {createResponse}");
-
             var createAgainResponse = await vectorIndexClient.CreateIndexAsync(indexName, numDimensions);
             Assert.True(createAgainResponse is CreateIndexResponse.AlreadyExists, $"Unexpected response: {createAgainResponse}");
-        }
-        finally
-        {
-            var deleteResponse = await vectorIndexClient.DeleteIndexAsync(indexName);
-            Assert.True(deleteResponse is DeleteIndexResponse.Success, $"Unexpected response: {deleteResponse}");
         }
     }
 

--- a/tests/Integration/Momento.Sdk.Tests/VectorIndexControlTest.cs
+++ b/tests/Integration/Momento.Sdk.Tests/VectorIndexControlTest.cs
@@ -54,12 +54,19 @@ public class VectorIndexControlTest : IClassFixture<VectorIndexClientFixture>
     {
         var indexName = Utils.TestVectorIndexName();
         const int numDimensions = 3;
+        try
+        {
+            var createResponse = await vectorIndexClient.CreateIndexAsync(indexName, numDimensions);
+            Assert.True(createResponse is CreateIndexResponse.Success, $"Unexpected response: {createResponse}");
 
-        var createResponse = await vectorIndexClient.CreateIndexAsync(indexName, numDimensions);
-        Assert.True(createResponse is CreateIndexResponse.Success, $"Unexpected response: {createResponse}");
-
-        var createAgainResponse = await vectorIndexClient.CreateIndexAsync(indexName, numDimensions);
-        Assert.True(createAgainResponse is CreateIndexResponse.AlreadyExists, $"Unexpected response: {createAgainResponse}");
+            var createAgainResponse = await vectorIndexClient.CreateIndexAsync(indexName, numDimensions);
+            Assert.True(createAgainResponse is CreateIndexResponse.AlreadyExists, $"Unexpected response: {createAgainResponse}");
+        }
+        finally
+        {
+            var deleteResponse = await vectorIndexClient.DeleteIndexAsync(indexName);
+            Assert.True(deleteResponse is DeleteIndexResponse.Success, $"Unexpected response: {deleteResponse}");
+        }
     }
 
     [Fact]

--- a/tests/Integration/Momento.Sdk.Tests/VectorIndexDataTest.cs
+++ b/tests/Integration/Momento.Sdk.Tests/VectorIndexDataTest.cs
@@ -136,7 +136,8 @@ public class VectorIndexDataTest : IClassFixture<VectorIndexClientFixture>
         }
         finally
         {
-            await vectorIndexClient.DeleteIndexAsync(indexName);
+            var deleteResponse = await vectorIndexClient.DeleteIndexAsync(indexName);
+            Assert.True(deleteResponse is DeleteIndexResponse.Success, $"Unexpected response: {deleteResponse}");
         }
     }
 
@@ -175,7 +176,8 @@ public class VectorIndexDataTest : IClassFixture<VectorIndexClientFixture>
         }
         finally
         {
-            await vectorIndexClient.DeleteIndexAsync(indexName);
+            var deleteResponse = await vectorIndexClient.DeleteIndexAsync(indexName);
+            Assert.True(deleteResponse is DeleteIndexResponse.Success, $"Unexpected response: {deleteResponse}");
         }
     }
 
@@ -215,7 +217,8 @@ public class VectorIndexDataTest : IClassFixture<VectorIndexClientFixture>
         }
         finally
         {
-            await vectorIndexClient.DeleteIndexAsync(indexName);
+            var deleteResponse = await vectorIndexClient.DeleteIndexAsync(indexName);
+            Assert.True(deleteResponse is DeleteIndexResponse.Success, $"Unexpected response: {deleteResponse}");
         }
     }
 
@@ -257,7 +260,8 @@ public class VectorIndexDataTest : IClassFixture<VectorIndexClientFixture>
         }
         finally
         {
-            await vectorIndexClient.DeleteIndexAsync(indexName);
+            var deleteResponse = await vectorIndexClient.DeleteIndexAsync(indexName);
+            Assert.True(deleteResponse is DeleteIndexResponse.Success, $"Unexpected response: {deleteResponse}");
         }
     }
 
@@ -337,7 +341,8 @@ public class VectorIndexDataTest : IClassFixture<VectorIndexClientFixture>
         }
         finally
         {
-            await vectorIndexClient.DeleteIndexAsync(indexName);
+            var deleteResponse = await vectorIndexClient.DeleteIndexAsync(indexName);
+            Assert.True(deleteResponse is DeleteIndexResponse.Success, $"Unexpected response: {deleteResponse}");
         }
     }
 
@@ -383,7 +388,8 @@ public class VectorIndexDataTest : IClassFixture<VectorIndexClientFixture>
         }
         finally
         {
-            await vectorIndexClient.DeleteIndexAsync(indexName);
+            var deleteResponse = await vectorIndexClient.DeleteIndexAsync(indexName);
+            Assert.True(deleteResponse is DeleteIndexResponse.Success, $"Unexpected response: {deleteResponse}");
         }
     }
 
@@ -469,7 +475,8 @@ public class VectorIndexDataTest : IClassFixture<VectorIndexClientFixture>
         }
         finally
         {
-            await vectorIndexClient.DeleteIndexAsync(indexName);
+            var deleteResponse = await vectorIndexClient.DeleteIndexAsync(indexName);
+            Assert.True(deleteResponse is DeleteIndexResponse.Success, $"Unexpected response: {deleteResponse}");
         }
     }
 }

--- a/tests/Integration/Momento.Sdk.Tests/VectorIndexDataTest.cs
+++ b/tests/Integration/Momento.Sdk.Tests/VectorIndexDataTest.cs
@@ -110,11 +110,7 @@ public class VectorIndexDataTest : IClassFixture<VectorIndexClientFixture>
         AssertOnSearchResponse<T> assertOnSearchResponse)
     {
         var indexName = Utils.TestVectorIndexName();
-
-        var createResponse = await vectorIndexClient.CreateIndexAsync(indexName, 2, SimilarityMetric.InnerProduct);
-        Assert.True(createResponse is CreateIndexResponse.Success, $"Unexpected response: {createResponse}");
-
-        try
+        using (Utils.WithVectorIndex(vectorIndexClient, indexName, 2, SimilarityMetric.InnerProduct))
         {
             var items = new List<Item>
             {
@@ -134,11 +130,6 @@ public class VectorIndexDataTest : IClassFixture<VectorIndexClientFixture>
                 new("test_item", 5.0f)
             }, items.Select(i => i.Vector).ToList());
         }
-        finally
-        {
-            var deleteResponse = await vectorIndexClient.DeleteIndexAsync(indexName);
-            Assert.True(deleteResponse is DeleteIndexResponse.Success, $"Unexpected response: {deleteResponse}");
-        }
     }
 
     [Theory]
@@ -147,11 +138,7 @@ public class VectorIndexDataTest : IClassFixture<VectorIndexClientFixture>
         AssertOnSearchResponse<T> assertOnSearchResponse)
     {
         var indexName = Utils.TestVectorIndexName();
-
-        var createResponse = await vectorIndexClient.CreateIndexAsync(indexName, 2);
-        Assert.True(createResponse is CreateIndexResponse.Success, $"Unexpected response: {createResponse}");
-
-        try
+        using (Utils.WithVectorIndex(vectorIndexClient, indexName, 2))
         {
             var items = new List<Item>
             {
@@ -174,11 +161,6 @@ public class VectorIndexDataTest : IClassFixture<VectorIndexClientFixture>
                 new("test_item_3", -1.0f)
             }, items.Select(i => i.Vector).ToList());
         }
-        finally
-        {
-            var deleteResponse = await vectorIndexClient.DeleteIndexAsync(indexName);
-            Assert.True(deleteResponse is DeleteIndexResponse.Success, $"Unexpected response: {deleteResponse}");
-        }
     }
 
     [Theory]
@@ -187,12 +169,7 @@ public class VectorIndexDataTest : IClassFixture<VectorIndexClientFixture>
         AssertOnSearchResponse<T> assertOnSearchResponse)
     {
         var indexName = Utils.TestVectorIndexName();
-
-        var createResponse =
-            await vectorIndexClient.CreateIndexAsync(indexName, 2, SimilarityMetric.EuclideanSimilarity);
-        Assert.True(createResponse is CreateIndexResponse.Success, $"Unexpected response: {createResponse}");
-
-        try
+        using (Utils.WithVectorIndex(vectorIndexClient, indexName, 2, SimilarityMetric.EuclideanSimilarity))
         {
             var items = new List<Item>
             {
@@ -215,11 +192,6 @@ public class VectorIndexDataTest : IClassFixture<VectorIndexClientFixture>
                 new("test_item_3", 8.0f)
             }, items.Select(i => i.Vector).ToList());
         }
-        finally
-        {
-            var deleteResponse = await vectorIndexClient.DeleteIndexAsync(indexName);
-            Assert.True(deleteResponse is DeleteIndexResponse.Success, $"Unexpected response: {deleteResponse}");
-        }
     }
 
     [Theory]
@@ -228,11 +200,7 @@ public class VectorIndexDataTest : IClassFixture<VectorIndexClientFixture>
         AssertOnSearchResponse<T> assertOnSearchResponse)
     {
         var indexName = Utils.TestVectorIndexName();
-
-        var createResponse = await vectorIndexClient.CreateIndexAsync(indexName, 2, SimilarityMetric.InnerProduct);
-        Assert.True(createResponse is CreateIndexResponse.Success, $"Unexpected response: {createResponse}");
-
-        try
+        using (Utils.WithVectorIndex(vectorIndexClient, indexName, 2, SimilarityMetric.InnerProduct))
         {
             var items = new List<Item>
             {
@@ -258,11 +226,6 @@ public class VectorIndexDataTest : IClassFixture<VectorIndexClientFixture>
                 new() { 3.0f, 4.0f }
             });
         }
-        finally
-        {
-            var deleteResponse = await vectorIndexClient.DeleteIndexAsync(indexName);
-            Assert.True(deleteResponse is DeleteIndexResponse.Success, $"Unexpected response: {deleteResponse}");
-        }
     }
 
     [Theory]
@@ -271,11 +234,7 @@ public class VectorIndexDataTest : IClassFixture<VectorIndexClientFixture>
         AssertOnSearchResponse<T> assertOnSearchResponse)
     {
         var indexName = Utils.TestVectorIndexName();
-
-        var createResponse = await vectorIndexClient.CreateIndexAsync(indexName, 2, SimilarityMetric.InnerProduct);
-        Assert.True(createResponse is CreateIndexResponse.Success, $"Unexpected response: {createResponse}");
-
-        try
+        using (Utils.WithVectorIndex(vectorIndexClient, indexName, 2, SimilarityMetric.InnerProduct))
         {
             var items = new List<Item>
             {
@@ -339,11 +298,6 @@ public class VectorIndexDataTest : IClassFixture<VectorIndexClientFixture>
                     new Dictionary<string, MetadataValue> { { "key1", "value1" } })
             }, expectedVectors);
         }
-        finally
-        {
-            var deleteResponse = await vectorIndexClient.DeleteIndexAsync(indexName);
-            Assert.True(deleteResponse is DeleteIndexResponse.Success, $"Unexpected response: {deleteResponse}");
-        }
     }
 
     [Theory]
@@ -352,11 +306,7 @@ public class VectorIndexDataTest : IClassFixture<VectorIndexClientFixture>
         AssertOnSearchResponse<T> assertOnSearchResponse)
     {
         var indexName = Utils.TestVectorIndexName();
-
-        var createResponse = await vectorIndexClient.CreateIndexAsync(indexName, 2, SimilarityMetric.InnerProduct);
-        Assert.True(createResponse is CreateIndexResponse.Success, $"Unexpected response: {createResponse}");
-
-        try
+        using (Utils.WithVectorIndex(vectorIndexClient, indexName, 2, SimilarityMetric.InnerProduct))
         {
             var metadata = new Dictionary<string, MetadataValue>
             {
@@ -385,11 +335,6 @@ public class VectorIndexDataTest : IClassFixture<VectorIndexClientFixture>
             {
                 new("test_item_1", 5.0f, metadata)
             }, items.Select(i => i.Vector).ToList());
-        }
-        finally
-        {
-            var deleteResponse = await vectorIndexClient.DeleteIndexAsync(indexName);
-            Assert.True(deleteResponse is DeleteIndexResponse.Success, $"Unexpected response: {deleteResponse}");
         }
     }
 
@@ -429,11 +374,7 @@ public class VectorIndexDataTest : IClassFixture<VectorIndexClientFixture>
         List<float> thresholds, SearchDelegate<T> searchDelegate, AssertOnSearchResponse<T> assertOnSearchResponse)
     {
         var indexName = Utils.TestVectorIndexName();
-
-        var createResponse = await vectorIndexClient.CreateIndexAsync(indexName, 2, similarityMetric);
-        Assert.True(createResponse is CreateIndexResponse.Success, $"Unexpected response: {createResponse}");
-
-        try
+        using (Utils.WithVectorIndex(vectorIndexClient, indexName, 2, similarityMetric))
         {
             var items = new List<Item>
             {
@@ -472,11 +413,6 @@ public class VectorIndexDataTest : IClassFixture<VectorIndexClientFixture>
             searchResponse =
                 await searchDelegate.Invoke(vectorIndexClient, indexName, queryVector, 3, scoreThreshold: thresholds[2]);
             assertOnSearchResponse.Invoke(searchResponse, new List<SearchHit>(), new List<List<float>>());
-        }
-        finally
-        {
-            var deleteResponse = await vectorIndexClient.DeleteIndexAsync(indexName);
-            Assert.True(deleteResponse is DeleteIndexResponse.Success, $"Unexpected response: {deleteResponse}");
         }
     }
 }


### PR DESCRIPTION
Refactor integration tests to use `Disposable` pattern throughout. A helper class creates an index on initialization and cleans up on disposal. Integration test authors then wrap code that needs an index in a `using` block. Upon exit of the `using` block, the index will be deleted.