### PR TITLE
feat: implement mvi get item and get item metadata methods

### DIFF
--- a/src/Momento.Sdk/IPreviewVectorIndexClient.cs
+++ b/src/Momento.Sdk/IPreviewVectorIndexClient.cs
@@ -161,7 +161,7 @@ public interface IPreviewVectorIndexClient : IDisposable
     /// <summary>
     /// Gets metadata for a batch of items from a vector index by ID.
     /// </summary>
-    /// <param name="indexName">The name of the vector index to get the items from.</param>
+    /// <param name="indexName">The name of the vector index to get the item metadata from.</param>
     /// <param name="ids">The IDs of the item metadata to get from the index.</param>
     /// <returns>
     /// Task representing the result of the get item metadata batch operation. The

--- a/src/Momento.Sdk/IPreviewVectorIndexClient.cs
+++ b/src/Momento.Sdk/IPreviewVectorIndexClient.cs
@@ -59,7 +59,7 @@ public interface IPreviewVectorIndexClient : IDisposable
     /// </remarks>
     /// </returns>
     public Task<CreateIndexResponse> CreateIndexAsync(string indexName, long numDimensions, SimilarityMetric similarityMetric = SimilarityMetric.CosineSimilarity);
-    
+
     /// <summary>
     /// Lists all vector indexes.
     /// </summary>
@@ -132,6 +132,57 @@ public interface IPreviewVectorIndexClient : IDisposable
     public Task<UpsertItemBatchResponse> UpsertItemBatchAsync(string indexName,
         IEnumerable<Item> items);
 
+
+    /// <summary>
+    /// Gets a batch of items from a vector index by ID.
+    /// </summary>
+    /// <param name="indexName">The name of the vector index to get the items from.</param>
+    /// <param name="ids">The IDs of the items to get from the index.</param>
+    /// <returns>
+    /// Task representing the result of the get item batch operation. The
+    /// response object is resolved to a type-safe object of one of
+    /// the following subtypes:
+    /// <list type="bullet">
+    /// <item><description>GetItemBatchResponse.Success</description></item>
+    /// <item><description>GetItemBatchResponse.Error</description></item>
+    /// </list>
+    /// Pattern matching can be used to operate on the appropriate subtype.
+    /// For example:
+    /// <code>
+    /// if (response is GetItemBatchResponse.Error errorResponse)
+    /// {
+    ///    // handle error as appropriate
+    ///    return;
+    /// }
+    /// </code>
+    /// </returns>
+    public Task<GetItemBatchResponse> GetItemBatchAsync(string indexName, IEnumerable<string> ids);
+
+    /// <summary>
+    /// Gets metadata for a batch of items from a vector index by ID.
+    /// </summary>
+    /// <param name="indexName">The name of the vector index to get the items from.</param>
+    /// <param name="ids">The IDs of the item metadata to get from the index.</param>
+    /// <returns>
+    /// Task representing the result of the get item metadata batch operation. The
+    /// response object is resolved to a type-safe object of one of
+    /// the following subtypes:
+    /// <list type="bullet">
+    /// <item><description>GetItemMetadataBatchResponse.Success</description></item>
+    /// <item><description>GetItemMetadataBatchResponse.Error</description></item>
+    /// </list>
+    /// Pattern matching can be used to operate on the appropriate subtype.
+    /// For example:
+    /// <code>
+    /// if (response is GetItemMetadataBatchResponse.Error errorResponse)
+    /// {
+    ///   // handle error as appropriate
+    ///   return;
+    /// }
+    /// </code>
+    /// </returns>
+    public Task<GetItemMetadataBatchResponse> GetItemMetadataBatchAsync(string indexName, IEnumerable<string> ids);
+
     /// <summary>
     /// Deletes all items with the given IDs from the index. Returns success if for items that do not exist.
     /// </summary>
@@ -188,7 +239,7 @@ public interface IPreviewVectorIndexClient : IDisposable
     /// </returns>
     public Task<SearchResponse> SearchAsync(string indexName, IEnumerable<float> queryVector, int topK = 10,
         MetadataFields? metadataFields = null, float? scoreThreshold = null);
-    
+
     ///  <summary>
     ///  Searches for the most similar vectors to the query vector in the index.
     ///  Ranks the vectors according to the similarity metric specified when the

--- a/src/Momento.Sdk/Internal/ExtensionMethods/DictionaryExtensions.cs
+++ b/src/Momento.Sdk/Internal/ExtensionMethods/DictionaryExtensions.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using Momento.Sdk.Messages.Vector;
 
 namespace Momento.Sdk.Internal.ExtensionMethods;
 
@@ -80,6 +81,56 @@ public static class DictionaryExtensions
         foreach (var item in items)
         {
             dictionary.Add(item);
+        }
+    }
+}
+
+
+/// <summary>
+/// Defines extension methods to operate on dictionaries with
+/// string keys and <see cref="MetadataValue"/> values.
+/// </summary>
+public static class MetadataDictionaryExtensions
+{
+    /// <summary>
+    /// Test whether two metadata dictionaries contain the same content.
+    /// </summary>
+    /// <param name="dictionary">The LHS dictionary.</param>
+    /// <param name="other">The RHS dictionary.</param>
+    /// <returns></returns>
+    public static bool MetadataEquals(this IDictionary<string, MetadataValue> dictionary, IDictionary<string, MetadataValue> other)
+    {
+        if (dictionary == null && other == null)
+        {
+            return true;
+        }
+        else if (dictionary == null || other == null)
+        {
+            return false;
+        }
+        else if (dictionary.Count != other.Count)
+        {
+            return false;
+        }
+
+        var keySet = new HashSet<string>(dictionary.Keys);
+        return other.All(kv => keySet.Contains(kv.Key) && dictionary[kv.Key].Equals(kv.Value));
+    }
+
+    /// <inheritdoc />
+    public static int MetadataHashCode(this IDictionary<string, MetadataValue> dictionary)
+    {
+        unchecked // Overflow is fine, just wrap
+        {
+            var hash = 17;
+
+            foreach (var pair in dictionary)
+            {
+                hash = hash * 23 + pair.Key.GetHashCode();
+                hash = hash * 23 + (pair.Value?.GetHashCode() ?? 0);
+            }
+
+            return hash;
         }
     }
 }

--- a/src/Momento.Sdk/Internal/VectorIndexDataClient.cs
+++ b/src/Momento.Sdk/Internal/VectorIndexDataClient.cs
@@ -28,51 +28,125 @@ internal sealed class VectorIndexDataClient : IDisposable
         _exceptionMapper = new CacheExceptionMapper(config.LoggerFactory);
     }
 
+    const string REQUEST_UPSERT_ITEM_BATCH = "UPSERT_ITEM_BATCH";
     public async Task<UpsertItemBatchResponse> UpsertItemBatchAsync(string indexName,
         IEnumerable<Item> items)
     {
         try
         {
-            _logger.LogTraceVectorIndexRequest("upsertItemBatch", indexName);
+            _logger.LogTraceVectorIndexRequest(REQUEST_UPSERT_ITEM_BATCH, indexName);
             CheckValidIndexName(indexName);
             var request = new _UpsertItemBatchRequest() { IndexName = indexName, Items = { items.Select(Convert) } };
 
             await grpcManager.Client.UpsertItemBatchAsync(request, new CallOptions(deadline: CalculateDeadline()));
-            return _logger.LogTraceVectorIndexRequestSuccess("upsertItemBatch", indexName,
+            return _logger.LogTraceVectorIndexRequestSuccess(REQUEST_UPSERT_ITEM_BATCH, indexName,
                 new UpsertItemBatchResponse.Success());
         }
         catch (Exception e)
         {
-            return _logger.LogTraceVectorIndexRequestError("upsertItemBatch", indexName,
+            return _logger.LogTraceVectorIndexRequestError(REQUEST_UPSERT_ITEM_BATCH, indexName,
                 new UpsertItemBatchResponse.Error(_exceptionMapper.Convert(e)));
         }
     }
 
+    const string REQUEST_GET_ITEM_BATCH = "GET_ITEM_BATCH";
+    public async Task<GetItemBatchResponse> GetItemBatchAsync(string indexName, IEnumerable<string> ids)
+    {
+        try
+        {
+            _logger.LogTraceVectorIndexRequest(REQUEST_GET_ITEM_BATCH, indexName);
+            CheckValidIndexName(indexName);
+            var request = new _GetItemBatchRequest() { IndexName = indexName, Ids = { ids } };
+
+            var response =
+                await grpcManager.Client.GetItemBatchAsync(request, new CallOptions(deadline: CalculateDeadline()));
+            var items = new Dictionary<string, Item>();
+            foreach (var item in response.ItemResponse)
+            {
+                switch (item.ResponseCase)
+                {
+                    case _ItemResponse.ResponseOneofCase.Hit:
+                        items[item.Hit.Id] = new(item.Hit.Id, item.Hit.Vector.Elements.ToList(), Convert(item.Hit.Metadata));
+                        break;
+                    case _ItemResponse.ResponseOneofCase.Miss:
+                        break;
+                    default:
+                        throw new UnknownException($"Unknown item response type {item.ResponseCase}");
+                }
+            }
+            return _logger.LogTraceVectorIndexRequestSuccess(REQUEST_GET_ITEM_BATCH, indexName,
+                new GetItemBatchResponse.Success(items));
+        }
+        catch (Exception e)
+        {
+            return _logger.LogTraceVectorIndexRequestError(REQUEST_GET_ITEM_BATCH, indexName,
+                new GetItemBatchResponse.Error(_exceptionMapper.Convert(e)));
+        }
+    }
+
+    const string REQUEST_GET_ITEM_METADATA_BATCH = "GET_ITEM_METADATA_BATCH";
+    public async Task<GetItemMetadataBatchResponse> GetItemMetadataBatchAsync(string indexName, IEnumerable<string> ids)
+    {
+        try
+        {
+            _logger.LogTraceVectorIndexRequest(REQUEST_GET_ITEM_METADATA_BATCH, indexName);
+            CheckValidIndexName(indexName);
+            var request = new _GetItemMetadataBatchRequest() { IndexName = indexName, Ids = { ids } };
+
+            var response =
+                await grpcManager.Client.GetItemMetadataBatchAsync(request,
+                    new CallOptions(deadline: CalculateDeadline()));
+            var items = new Dictionary<string, Dictionary<string, MetadataValue>>();
+            foreach (var item in response.ItemMetadataResponse)
+            {
+                switch (item.ResponseCase)
+                {
+                    case _ItemMetadataResponse.ResponseOneofCase.Hit:
+                        items[item.Hit.Id] = Convert(item.Hit.Metadata);
+                        break;
+                    case _ItemMetadataResponse.ResponseOneofCase.Miss:
+                        break;
+                    default:
+                        throw new UnknownException($"Unknown item response type {item.ResponseCase}");
+                }
+            }
+            return _logger.LogTraceVectorIndexRequestSuccess(REQUEST_GET_ITEM_METADATA_BATCH, indexName,
+                new GetItemMetadataBatchResponse.Success(items));
+        }
+        catch (Exception e)
+        {
+            return _logger.LogTraceVectorIndexRequestError(REQUEST_GET_ITEM_METADATA_BATCH, indexName,
+                new GetItemMetadataBatchResponse.Error(_exceptionMapper.Convert(e)));
+        }
+    }
+
+    const string REQUEST_DELETE_ITEM_BATCH = "DELETE_ITEM_BATCH";
     public async Task<DeleteItemBatchResponse> DeleteItemBatchAsync(string indexName, IEnumerable<string> ids)
     {
         try
         {
-            _logger.LogTraceVectorIndexRequest("deleteItemBatch", indexName);
+            _logger.LogTraceVectorIndexRequest(REQUEST_DELETE_ITEM_BATCH, indexName);
             CheckValidIndexName(indexName);
             var request = new _DeleteItemBatchRequest() { IndexName = indexName, Ids = { ids } };
 
             await grpcManager.Client.DeleteItemBatchAsync(request, new CallOptions(deadline: CalculateDeadline()));
-            return _logger.LogTraceVectorIndexRequestSuccess("deleteItemBatch", indexName,
+            return _logger.LogTraceVectorIndexRequestSuccess(REQUEST_DELETE_ITEM_BATCH, indexName,
                 new DeleteItemBatchResponse.Success());
         }
         catch (Exception e)
         {
-            return _logger.LogTraceVectorIndexRequestError("deleteItemBatch", indexName,
+            return _logger.LogTraceVectorIndexRequestError(REQUEST_DELETE_ITEM_BATCH, indexName,
                 new DeleteItemBatchResponse.Error(_exceptionMapper.Convert(e)));
         }
     }
 
+    const string REQUEST_SEARCH = "SEARCH";
     public async Task<SearchResponse> SearchAsync(string indexName, IEnumerable<float> queryVector, int topK,
         MetadataFields? metadataFields, float? scoreThreshold)
     {
         try
         {
-            _logger.LogTraceVectorIndexRequest("search", indexName);
+            _logger.LogTraceVectorIndexRequest(REQUEST_SEARCH, indexName);
             CheckValidIndexName(indexName);
             var validatedTopK = ValidateTopK(topK);
             metadataFields ??= new List<string>();
@@ -106,22 +180,23 @@ internal sealed class VectorIndexDataClient : IDisposable
             var response =
                 await grpcManager.Client.SearchAsync(request, new CallOptions(deadline: CalculateDeadline()));
             var searchHits = response.Hits.Select(Convert).ToList();
-            return _logger.LogTraceVectorIndexRequestSuccess("search", indexName,
+            return _logger.LogTraceVectorIndexRequestSuccess(REQUEST_SEARCH, indexName,
                 new SearchResponse.Success(searchHits));
         }
         catch (Exception e)
         {
-            return _logger.LogTraceVectorIndexRequestError("search", indexName,
+            return _logger.LogTraceVectorIndexRequestError(REQUEST_SEARCH, indexName,
                 new SearchResponse.Error(_exceptionMapper.Convert(e)));
         }
     }
 
+    const string REQUEST_SEARCH_AND_FETCH_VECTORS = "SEARCH_AND_FETCH_VECTORS";
     public async Task<SearchAndFetchVectorsResponse> SearchAndFetchVectorsAsync(string indexName,
         IEnumerable<float> queryVector, int topK, MetadataFields? metadataFields, float? scoreThreshold)
     {
         try
         {
-            _logger.LogTraceVectorIndexRequest("searchAndFetchVectors", indexName);
+            _logger.LogTraceVectorIndexRequest(REQUEST_SEARCH_AND_FETCH_VECTORS, indexName);
             CheckValidIndexName(indexName);
             var validatedTopK = ValidateTopK(topK);
             metadataFields ??= new List<string>();
@@ -157,12 +232,12 @@ internal sealed class VectorIndexDataClient : IDisposable
                     new CallOptions(deadline: CalculateDeadline()));
             var searchHits = response.Hits.Select(h =>
                 new SearchAndFetchVectorsHit(h.Id, h.Score, h.Vector.Elements.ToList(), Convert(h.Metadata))).ToList();
-            return _logger.LogTraceVectorIndexRequestSuccess("searchAndFetchVectors", indexName,
+            return _logger.LogTraceVectorIndexRequestSuccess(REQUEST_SEARCH_AND_FETCH_VECTORS, indexName,
                 new SearchAndFetchVectorsResponse.Success(searchHits));
         }
         catch (Exception e)
         {
-            return _logger.LogTraceVectorIndexRequestError("searchAndFetchVectors", indexName,
+            return _logger.LogTraceVectorIndexRequestError(REQUEST_SEARCH_AND_FETCH_VECTORS, indexName,
                 new SearchAndFetchVectorsResponse.Error(_exceptionMapper.Convert(e)));
         }
     }
@@ -171,7 +246,9 @@ internal sealed class VectorIndexDataClient : IDisposable
     {
         return new _Item
         {
-            Id = item.Id, Vector = new _Vector { Elements = { item.Vector } }, Metadata = { Convert(item.Metadata) }
+            Id = item.Id,
+            Vector = new _Vector { Elements = { item.Vector } },
+            Metadata = { Convert(item.Metadata) }
         };
     }
 

--- a/src/Momento.Sdk/Internal/VectorIndexDataClient.cs
+++ b/src/Momento.Sdk/Internal/VectorIndexDataClient.cs
@@ -56,7 +56,12 @@ internal sealed class VectorIndexDataClient : IDisposable
         {
             _logger.LogTraceVectorIndexRequest(REQUEST_GET_ITEM_BATCH, indexName);
             CheckValidIndexName(indexName);
-            var request = new _GetItemBatchRequest() { IndexName = indexName, Ids = { ids } };
+            var request = new _GetItemBatchRequest()
+            {
+                IndexName = indexName,
+                Ids = { ids },
+                MetadataFields = new _MetadataRequest { All = new _MetadataRequest.Types.All() }
+            };
 
             var response =
                 await grpcManager.Client.GetItemBatchAsync(request, new CallOptions(deadline: CalculateDeadline()));
@@ -91,7 +96,12 @@ internal sealed class VectorIndexDataClient : IDisposable
         {
             _logger.LogTraceVectorIndexRequest(REQUEST_GET_ITEM_METADATA_BATCH, indexName);
             CheckValidIndexName(indexName);
-            var request = new _GetItemMetadataBatchRequest() { IndexName = indexName, Ids = { ids } };
+            var request = new _GetItemMetadataBatchRequest()
+            {
+                IndexName = indexName,
+                Ids = { ids },
+                MetadataFields = new _MetadataRequest { All = new _MetadataRequest.Types.All() }
+            };
 
             var response =
                 await grpcManager.Client.GetItemMetadataBatchAsync(request,

--- a/src/Momento.Sdk/Internal/VectorIndexDataGrpcManager.cs
+++ b/src/Momento.Sdk/Internal/VectorIndexDataGrpcManager.cs
@@ -22,6 +22,8 @@ public interface IVectorIndexDataClient
     public Task<_UpsertItemBatchResponse> UpsertItemBatchAsync(_UpsertItemBatchRequest request, CallOptions callOptions);
     public Task<_SearchResponse> SearchAsync(_SearchRequest request, CallOptions callOptions);
     public Task<_SearchAndFetchVectorsResponse> SearchAndFetchVectorsAsync(_SearchAndFetchVectorsRequest request, CallOptions callOptions);
+    public Task<_GetItemBatchResponse> GetItemBatchAsync(_GetItemBatchRequest request, CallOptions callOptions);
+    public Task<_GetItemMetadataBatchResponse> GetItemMetadataBatchAsync(_GetItemMetadataBatchRequest request, CallOptions callOptions);
     public Task<_DeleteItemBatchResponse> DeleteItemBatchAsync(_DeleteItemBatchRequest request, CallOptions callOptions);
 }
 
@@ -56,10 +58,22 @@ public class VectorIndexDataClientWithMiddleware : IVectorIndexDataClient
         var wrapped = await _middlewares.WrapRequest(request, callOptions, (r, o) => _generatedClient.SearchAsync(r, o));
         return await wrapped.ResponseAsync;
     }
-    
+
     public async Task<_SearchAndFetchVectorsResponse> SearchAndFetchVectorsAsync(_SearchAndFetchVectorsRequest request, CallOptions callOptions)
     {
         var wrapped = await _middlewares.WrapRequest(request, callOptions, (r, o) => _generatedClient.SearchAndFetchVectorsAsync(r, o));
+        return await wrapped.ResponseAsync;
+    }
+
+    public async Task<_GetItemBatchResponse> GetItemBatchAsync(_GetItemBatchRequest request, CallOptions callOptions)
+    {
+        var wrapped = await _middlewares.WrapRequest(request, callOptions, (r, o) => _generatedClient.GetItemBatchAsync(r, o));
+        return await wrapped.ResponseAsync;
+    }
+
+    public async Task<_GetItemMetadataBatchResponse> GetItemMetadataBatchAsync(_GetItemMetadataBatchRequest request, CallOptions callOptions)
+    {
+        var wrapped = await _middlewares.WrapRequest(request, callOptions, (r, o) => _generatedClient.GetItemMetadataBatchAsync(r, o));
         return await wrapped.ResponseAsync;
     }
 

--- a/src/Momento.Sdk/Momento.Sdk.csproj
+++ b/src/Momento.Sdk/Momento.Sdk.csproj
@@ -55,7 +55,7 @@
 	<ItemGroup>
 	  <PackageReference Include="Grpc.Net.Client" Version="2.49.0" />
 	  <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
-	  <PackageReference Include="Momento.Protos" Version="0.96.0" />
+	  <PackageReference Include="Momento.Protos" Version="0.97.1" />
 	  <PackageReference Include="JWT" Version="9.0.3" />
 	  <PackageReference Include="System.Threading.Channels" Version="6.0.0" />
 	  <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />

--- a/src/Momento.Sdk/PreviewVectorIndexClient.cs
+++ b/src/Momento.Sdk/PreviewVectorIndexClient.cs
@@ -62,6 +62,18 @@ public class PreviewVectorIndexClient : IPreviewVectorIndexClient
     }
 
     /// <inheritdoc />
+    public async Task<GetItemBatchResponse> GetItemBatchAsync(string indexName, IEnumerable<string> ids)
+    {
+        return await dataClient.GetItemBatchAsync(indexName, ids);
+    }
+
+    /// <inheritdoc />
+    public async Task<GetItemMetadataBatchResponse> GetItemMetadataBatchAsync(string indexName, IEnumerable<string> ids)
+    {
+        return await dataClient.GetItemMetadataBatchAsync(indexName, ids);
+    }
+
+    /// <inheritdoc />
     public async Task<DeleteItemBatchResponse> DeleteItemBatchAsync(string indexName, IEnumerable<string> ids)
     {
         return await dataClient.DeleteItemBatchAsync(indexName, ids);

--- a/src/Momento.Sdk/Requests/Vector/Item.cs
+++ b/src/Momento.Sdk/Requests/Vector/Item.cs
@@ -1,5 +1,7 @@
 using System.Collections.Generic;
+using System.Linq;
 using Momento.Sdk.Messages.Vector;
+using Momento.Sdk.Internal.ExtensionMethods;
 
 namespace Momento.Sdk.Requests.Vector;
 
@@ -19,7 +21,7 @@ public class Item
         Vector = vector;
         Metadata = new Dictionary<string, MetadataValue>();
     }
-    
+
     /// <summary>
     /// Constructs a Item.
     /// </summary>
@@ -37,14 +39,41 @@ public class Item
     /// The ID of the vector.
     /// </summary>
     public string Id { get; }
-    
+
     /// <summary>
     /// The vector.
     /// </summary>
     public List<float> Vector { get; }
-    
+
     /// <summary>
     /// Metadata associated with the vector.
     /// </summary>
     public Dictionary<string, MetadataValue> Metadata { get; }
+
+    /// <inheritdoc />
+    public override bool Equals(object obj)
+    {
+        if (ReferenceEquals(this, obj))
+        {
+            return true;
+        }
+
+        if (obj is null || GetType() != obj.GetType())
+        {
+            return false;
+        }
+
+        var other = (Item)obj;
+        return Id == other.Id && Vector.SequenceEqual(other.Vector) && Metadata.MetadataEquals(other.Metadata);
+    }
+
+    /// <inheritdoc />
+    public override int GetHashCode()
+    {
+        int hash = 17;
+        hash = hash * 23 + Id.GetHashCode();
+        hash = hash * 23 + Vector.GetHashCode();
+        hash = hash * 23 + Metadata.MetadataHashCode();
+        return hash;
+    }
 }

--- a/src/Momento.Sdk/Responses/Vector/GetItemBatchResponse.cs
+++ b/src/Momento.Sdk/Responses/Vector/GetItemBatchResponse.cs
@@ -1,0 +1,84 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Momento.Sdk.Exceptions;
+using Momento.Sdk.Requests.Vector;
+
+namespace Momento.Sdk.Responses.Vector;
+
+/// <summary>
+/// Parent response type for a get item batch request. The
+/// response object is resolved to a type-safe object of one of
+/// the following subtypes:
+/// <list type="bullet">
+/// <item><description>GetItemBatch.Success</description></item>
+/// <item><description>GetItemBatch.Error</description></item>
+/// </list>
+/// Pattern matching can be used to operate on the appropriate subtype.
+/// For example:
+/// <code>
+/// if (response is GetItemBatch.Success successResponse)
+/// {
+///     return successResponse.Values;
+/// }
+/// else if (response is GetItemBatch.Error errorResponse)
+/// {
+///     // handle error as appropriate
+/// }
+/// else
+/// {
+///     // handle unexpected response
+/// }
+/// </code>
+/// </summary>
+public abstract class GetItemBatchResponse
+{
+    /// <include file="../../docs.xml" path='docs/class[@name="Success"]/description/*' />
+    public class Success : GetItemBatchResponse
+    {
+        /// <summary>
+        /// The found items by ID.
+        /// </summary>
+        public Dictionary<string, Item> Values { get; }
+
+        /// <include file="../../docs.xml" path='docs/class[@name="Success"]/description/*' />
+        /// <param name="values">the found items</param>
+        public Success(Dictionary<string, Item> values)
+        {
+            Values = values;
+        }
+
+        /// <inheritdoc />
+        public override string ToString()
+        {
+            var displayedHits = Values.Take(5).Select(value => $"{value.Value.ToString()}");
+            return $"{base.ToString()}: {string.Join(", ", displayedHits)}...";
+        }
+
+    }
+
+    /// <include file="../../docs.xml" path='docs/class[@name="Error"]/description/*' />
+    public class Error : GetItemBatchResponse, IError
+    {
+        /// <include file="../../docs.xml" path='docs/class[@name="Error"]/constructor/*' />
+        public Error(SdkException error)
+        {
+            InnerException = error;
+        }
+
+        /// <inheritdoc />
+        public SdkException InnerException { get; }
+
+        /// <inheritdoc />
+        public MomentoErrorCode ErrorCode => InnerException.ErrorCode;
+
+        /// <inheritdoc />
+        public string Message => $"{InnerException.MessageWrapper}: {InnerException.Message}";
+
+        /// <inheritdoc />
+        public override string ToString()
+        {
+            return $"{base.ToString()}: {Message}";
+        }
+
+    }
+}

--- a/src/Momento.Sdk/Responses/Vector/GetItemBatchResponse.cs
+++ b/src/Momento.Sdk/Responses/Vector/GetItemBatchResponse.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using Momento.Sdk.Exceptions;
 using Momento.Sdk.Requests.Vector;
+using Momento.Sdk.Internal.ExtensionMethods;
 
 namespace Momento.Sdk.Responses.Vector;
 
@@ -52,6 +53,60 @@ public abstract class GetItemBatchResponse
         {
             var displayedHits = Values.Take(5).Select(value => $"{value.Value.ToString()}");
             return $"{base.ToString()}: {string.Join(", ", displayedHits)}...";
+        }
+
+        /// <inheritdoc />
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(this, obj))
+            {
+                return true;
+            }
+            if (obj is null || GetType() != obj.GetType())
+            {
+                return false;
+            }
+            var other = (Success)obj;
+
+            if (Values == null && other.Values == null)
+            {
+                return true;
+            }
+            else if (Values == null || other.Values == null)
+            {
+                return false;
+            }
+            else if (Values.Count != other.Values.Count)
+            {
+                return false;
+            }
+            else
+            {
+                foreach (var item in Values)
+                {
+                    if (!other.Values.ContainsKey(item.Key))
+                    {
+                        return false;
+                    }
+                    else if (!item.Value.Equals(other.Values[item.Key]))
+                    {
+                        return false;
+                    }
+                }
+                return true;
+            }
+        }
+
+        /// <inheritdoc />
+        public override int GetHashCode()
+        {
+            int hash = 17;
+            foreach (var kv in Values)
+            {
+                hash = hash * 23 + kv.Key.GetHashCode();
+                hash = hash * 23 + kv.Value.GetHashCode();
+            }
+            return hash;
         }
 
     }

--- a/src/Momento.Sdk/Responses/Vector/GetItemMetadataResponse.cs
+++ b/src/Momento.Sdk/Responses/Vector/GetItemMetadataResponse.cs
@@ -7,7 +7,7 @@ using Momento.Sdk.Internal.ExtensionMethods;
 namespace Momento.Sdk.Responses.Vector;
 
 /// <summary>
-/// Parent response type for a get item batch request. The
+/// Parent response type for a get item metadata batch request. The
 /// response object is resolved to a type-safe object of one of
 /// the following subtypes:
 /// <list type="bullet">

--- a/src/Momento.Sdk/Responses/Vector/GetItemMetadataResponse.cs
+++ b/src/Momento.Sdk/Responses/Vector/GetItemMetadataResponse.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using Momento.Sdk.Exceptions;
 using Momento.Sdk.Messages.Vector;
+using Momento.Sdk.Internal.ExtensionMethods;
 
 namespace Momento.Sdk.Responses.Vector;
 
@@ -54,6 +55,38 @@ public abstract class GetItemMetadataBatchResponse
             return $"{base.ToString()}: {string.Join(", ", displayedHits)}...";
         }
 
+        /// <inheritdoc />
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(this, obj))
+            {
+                return true;
+            }
+
+            if (!(obj is Success other))
+            {
+                return false;
+            }
+
+            if (Values.Count != other.Values.Count)
+            {
+                return false;
+            }
+
+            return Values.All(kv => other.Values.ContainsKey(kv.Key) && kv.Value.MetadataEquals(other.Values[kv.Key]));
+        }
+
+        /// <inheritdoc />
+        public override int GetHashCode()
+        {
+            int hash = 17;
+            foreach (var kv in Values)
+            {
+                hash = hash * 23 + kv.Key.GetHashCode();
+                hash = hash * 23 + kv.Value.MetadataHashCode();
+            }
+            return hash;
+        }
     }
 
     /// <include file="../../docs.xml" path='docs/class[@name="Error"]/description/*' />

--- a/src/Momento.Sdk/Responses/Vector/GetItemMetadataResponse.cs
+++ b/src/Momento.Sdk/Responses/Vector/GetItemMetadataResponse.cs
@@ -1,0 +1,84 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Momento.Sdk.Exceptions;
+using Momento.Sdk.Messages.Vector;
+
+namespace Momento.Sdk.Responses.Vector;
+
+/// <summary>
+/// Parent response type for a get item batch request. The
+/// response object is resolved to a type-safe object of one of
+/// the following subtypes:
+/// <list type="bullet">
+/// <item><description>GetItemMetadataBatch.Success</description></item>
+/// <item><description>GetItemMetadataBatch.Error</description></item>
+/// </list>
+/// Pattern matching can be used to operate on the appropriate subtype.
+/// For example:
+/// <code>
+/// if (response is GetItemMetadataBatch.Success successResponse)
+/// {
+///     return successResponse.Values;
+/// }
+/// else if (response is GetItemMetadataBatch.Error errorResponse)
+/// {
+///     // handle error as appropriate
+/// }
+/// else
+/// {
+///     // handle unexpected response
+/// }
+/// </code>
+/// </summary>
+public abstract class GetItemMetadataBatchResponse
+{
+    /// <include file="../../docs.xml" path='docs/class[@name="Success"]/description/*' />
+    public class Success : GetItemMetadataBatchResponse
+    {
+        /// <summary>
+        /// The metadata for found items by ID.
+        /// </summary>
+        public Dictionary<string, Dictionary<string, MetadataValue>> Values { get; }
+
+        /// <include file="../../docs.xml" path='docs/class[@name="Success"]/description/*' />
+        /// <param name="values">the found items</param>
+        public Success(Dictionary<string, Dictionary<string, MetadataValue>> values)
+        {
+            Values = values;
+        }
+
+        /// <inheritdoc />
+        public override string ToString()
+        {
+            var displayedHits = Values.Take(5).Select(value => $"{value.Key} {value.Value.ToString()}");
+            return $"{base.ToString()}: {string.Join(", ", displayedHits)}...";
+        }
+
+    }
+
+    /// <include file="../../docs.xml" path='docs/class[@name="Error"]/description/*' />
+    public class Error : GetItemMetadataBatchResponse, IError
+    {
+        /// <include file="../../docs.xml" path='docs/class[@name="Error"]/constructor/*' />
+        public Error(SdkException error)
+        {
+            InnerException = error;
+        }
+
+        /// <inheritdoc />
+        public SdkException InnerException { get; }
+
+        /// <inheritdoc />
+        public MomentoErrorCode ErrorCode => InnerException.ErrorCode;
+
+        /// <inheritdoc />
+        public string Message => $"{InnerException.MessageWrapper}: {InnerException.Message}";
+
+        /// <inheritdoc />
+        public override string ToString()
+        {
+            return $"{base.ToString()}: {Message}";
+        }
+
+    }
+}

--- a/src/Momento.Sdk/Responses/Vector/SearchHit.cs
+++ b/src/Momento.Sdk/Responses/Vector/SearchHit.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using Momento.Sdk.Messages.Vector;
+using Momento.Sdk.Internal.ExtensionMethods;
 
 namespace Momento.Sdk.Responses.Vector;
 
@@ -64,15 +65,7 @@ public class SearchHit
         if (Id != other.Id || Score != other.Score) return false;
 
         // Compare Metadata dictionaries
-        if (Metadata.Count != other.Metadata.Count) return false;
-
-        foreach (var pair in Metadata)
-        {
-            if (!other.Metadata.TryGetValue(pair.Key, out var value)) return false;
-            if (!value.Equals(pair.Value)) return false;
-        }
-
-        return true;
+        return Metadata.MetadataEquals(other.Metadata);
     }
 
     /// <inheritdoc />
@@ -84,12 +77,7 @@ public class SearchHit
 
             hash = hash * 23 + Id.GetHashCode();
             hash = hash * 23 + Score.GetHashCode();
-
-            foreach (var pair in Metadata)
-            {
-                hash = hash * 23 + pair.Key.GetHashCode();
-                hash = hash * 23 + (pair.Value?.GetHashCode() ?? 0);
-            }
+            hash = hash * 23 + Metadata.MetadataHashCode();
 
             return hash;
         }
@@ -141,7 +129,7 @@ public class SearchAndFetchVectorsHit : SearchHit
     {
         Vector = vector;
     }
-    
+
     /// <inheritdoc />
     public override bool Equals(object obj)
     {


### PR DESCRIPTION
Implements MVI `GetItemBatchAsync` and `GetItemMetadataBatchAsync` methods, response types, and adds integration tests. Also extracts metadata dictionary equality and hash code to a central extension method.