### PR TITLE
test: add unique, identifying suffix to each integration test index

### DIFF
--- a/tests/Integration/Momento.Sdk.Tests/Utils.cs
+++ b/tests/Integration/Momento.Sdk.Tests/Utils.cs
@@ -11,7 +11,18 @@ public static class Utils
 
     public static string TestCacheName() => "dotnet-integration-" + NewGuidString();
 
-    public static string TestVectorIndexName() => "dotnet-integration-" + NewGuidString();
+    /// <summary>
+    /// Returns a test vector index name that is unique to this test run.
+    /// </summary>
+    /// <remarks>
+    /// This is useful for debugging leaking test vector indexes.
+    /// </remarks>
+    /// <param name="meaningfulIdentifier">A string that uniquely identifies the test, e.g. "test1".</param>
+    /// <returns>A test vector index name that is unique to this test run.</returns>
+    public static string TestVectorIndexName(string meaningfulIdentifier)
+    {
+        return $"dotnet-integration-{NewGuidString()}-{meaningfulIdentifier}";
+    }
 
     public static string NewGuidString() => Guid.NewGuid().ToString();
 

--- a/tests/Integration/Momento.Sdk.Tests/VectorIndexControlTest.cs
+++ b/tests/Integration/Momento.Sdk.Tests/VectorIndexControlTest.cs
@@ -21,9 +21,9 @@ public class VectorIndexControlTest : IClassFixture<VectorIndexClientFixture>
         {
             return new List<object[]>
             {
-                new object[] { new IndexInfo(Utils.TestVectorIndexName(), 3, SimilarityMetric.CosineSimilarity) },
-                new object[] { new IndexInfo(Utils.TestVectorIndexName(), 3, SimilarityMetric.InnerProduct) },
-                new object[] { new IndexInfo(Utils.TestVectorIndexName(), 3, SimilarityMetric.EuclideanSimilarity) }
+                new object[] { new IndexInfo(Utils.TestVectorIndexName("control-create-and-list-1"), 3, SimilarityMetric.CosineSimilarity) },
+                new object[] { new IndexInfo(Utils.TestVectorIndexName("control-create-and-list-2"), 3, SimilarityMetric.InnerProduct) },
+                new object[] { new IndexInfo(Utils.TestVectorIndexName("control-create-and-list-3"), 3, SimilarityMetric.EuclideanSimilarity) }
             };
         }
     }
@@ -44,7 +44,7 @@ public class VectorIndexControlTest : IClassFixture<VectorIndexClientFixture>
     [Fact]
     public async Task CreateIndexAsync_AlreadyExistsError()
     {
-        var indexName = Utils.TestVectorIndexName();
+        var indexName = Utils.TestVectorIndexName("control-create-index-already-exists");
         const int numDimensions = 3;
         using (Utils.WithVectorIndex(vectorIndexClient, indexName, numDimensions))
         {
@@ -79,7 +79,7 @@ public class VectorIndexControlTest : IClassFixture<VectorIndexClientFixture>
     [Fact]
     public async Task DeleteIndexAsync_DoesntExistError()
     {
-        var indexName = Utils.TestVectorIndexName();
+        var indexName = Utils.TestVectorIndexName("control-delete-index-doesnt-exist");
         var deleteResponse = await vectorIndexClient.DeleteIndexAsync(indexName);
         Assert.True(deleteResponse is DeleteIndexResponse.Error, $"Unexpected response: {deleteResponse}");
         var deleteErr = (DeleteIndexResponse.Error)deleteResponse;

--- a/tests/Integration/Momento.Sdk.Tests/VectorIndexDataTest.cs
+++ b/tests/Integration/Momento.Sdk.Tests/VectorIndexDataTest.cs
@@ -109,7 +109,7 @@ public class VectorIndexDataTest : IClassFixture<VectorIndexClientFixture>
     public async Task UpsertAndSearch_InnerProduct<T>(SearchDelegate<T> searchDelegate,
         AssertOnSearchResponse<T> assertOnSearchResponse)
     {
-        var indexName = Utils.TestVectorIndexName();
+        var indexName = Utils.TestVectorIndexName("data-upsert-and-search-inner-product");
         using (Utils.WithVectorIndex(vectorIndexClient, indexName, 2, SimilarityMetric.InnerProduct))
         {
             var items = new List<Item>
@@ -137,7 +137,7 @@ public class VectorIndexDataTest : IClassFixture<VectorIndexClientFixture>
     public async Task UpsertAndSearch_CosineSimilarity<T>(SearchDelegate<T> searchDelegate,
         AssertOnSearchResponse<T> assertOnSearchResponse)
     {
-        var indexName = Utils.TestVectorIndexName();
+        var indexName = Utils.TestVectorIndexName("data-upsert-and-search-cosine-similarity");
         using (Utils.WithVectorIndex(vectorIndexClient, indexName, 2))
         {
             var items = new List<Item>
@@ -168,7 +168,7 @@ public class VectorIndexDataTest : IClassFixture<VectorIndexClientFixture>
     public async Task UpsertAndSearch_EuclideanSimilarity<T>(SearchDelegate<T> searchDelegate,
         AssertOnSearchResponse<T> assertOnSearchResponse)
     {
-        var indexName = Utils.TestVectorIndexName();
+        var indexName = Utils.TestVectorIndexName("data-upsert-and-search-euclidean-similarity");
         using (Utils.WithVectorIndex(vectorIndexClient, indexName, 2, SimilarityMetric.EuclideanSimilarity))
         {
             var items = new List<Item>
@@ -199,7 +199,7 @@ public class VectorIndexDataTest : IClassFixture<VectorIndexClientFixture>
     public async Task UpsertAndSearch_TopKLimit<T>(SearchDelegate<T> searchDelegate,
         AssertOnSearchResponse<T> assertOnSearchResponse)
     {
-        var indexName = Utils.TestVectorIndexName();
+        var indexName = Utils.TestVectorIndexName("data-upsert-and-search-top-k-limit");
         using (Utils.WithVectorIndex(vectorIndexClient, indexName, 2, SimilarityMetric.InnerProduct))
         {
             var items = new List<Item>
@@ -233,7 +233,7 @@ public class VectorIndexDataTest : IClassFixture<VectorIndexClientFixture>
     public async Task UpsertAndSearch_WithMetadata<T>(SearchDelegate<T> searchDelegate,
         AssertOnSearchResponse<T> assertOnSearchResponse)
     {
-        var indexName = Utils.TestVectorIndexName();
+        var indexName = Utils.TestVectorIndexName("data-upsert-and-search-with-metadata");
         using (Utils.WithVectorIndex(vectorIndexClient, indexName, 2, SimilarityMetric.InnerProduct))
         {
             var items = new List<Item>
@@ -305,7 +305,7 @@ public class VectorIndexDataTest : IClassFixture<VectorIndexClientFixture>
     public async Task UpsertAndSearch_WithDiverseMetadata<T>(SearchDelegate<T> searchDelegate,
         AssertOnSearchResponse<T> assertOnSearchResponse)
     {
-        var indexName = Utils.TestVectorIndexName();
+        var indexName = Utils.TestVectorIndexName("data-upsert-and-search-with-diverse-metadata");
         using (Utils.WithVectorIndex(vectorIndexClient, indexName, 2, SimilarityMetric.InnerProduct))
         {
             var metadata = new Dictionary<string, MetadataValue>
@@ -373,7 +373,7 @@ public class VectorIndexDataTest : IClassFixture<VectorIndexClientFixture>
     public async Task Search_PruneBasedOnThreshold<T>(SimilarityMetric similarityMetric, List<float> scores,
         List<float> thresholds, SearchDelegate<T> searchDelegate, AssertOnSearchResponse<T> assertOnSearchResponse)
     {
-        var indexName = Utils.TestVectorIndexName();
+        var indexName = Utils.TestVectorIndexName("data-search-prune-based-on-threshold");
         using (Utils.WithVectorIndex(vectorIndexClient, indexName, 2, similarityMetric))
         {
             var items = new List<Item>
@@ -500,7 +500,7 @@ public class VectorIndexDataTest : IClassFixture<VectorIndexClientFixture>
     [MemberData(nameof(GetItemAndGetItemMetadataTestData))]
     public async Task GetItemAndGetItemMetadata_HappyPath<T>(GetItemDelegate<T> getItemDelegate, AssertOnGetItemResponse<T> assertOnGetItemResponse, IEnumerable<string> ids, Object expected)
     {
-        var indexName = Utils.TestVectorIndexName();
+        var indexName = Utils.TestVectorIndexName("data-get-item-and-get-item-metadata-happy-path");
         using (Utils.WithVectorIndex(vectorIndexClient, indexName, 2, SimilarityMetric.InnerProduct))
         {
             var items = new List<Item>


### PR DESCRIPTION
In order to debug leaking indexes, we add a unique suffix for each
index name. That way we can inspect and identify patterns in leaked
resources.
