### PR TITLE
feat: implement mvi count items command

### DIFF
--- a/src/Momento.Sdk/IPreviewVectorIndexClient.cs
+++ b/src/Momento.Sdk/IPreviewVectorIndexClient.cs
@@ -106,6 +106,17 @@ public interface IPreviewVectorIndexClient : IDisposable
     public Task<DeleteIndexResponse> DeleteIndexAsync(string indexName);
 
     /// <summary>
+    /// Gets the number of items in a vector index.
+    /// </summary>
+    /// <remarks>
+    /// In the event the index does not exist, the response will be an error.
+    /// A count of zero is reserved for an index that exists but has no items.
+    /// </remarks>
+    /// <param name="indexName">The name of the vector index to get the item count from.</param>
+    /// <returns>Task representing the result of the count items operation.</returns>
+    public Task<CountItemsResponse> CountItemsAsync(string indexName);
+
+    /// <summary>
     /// Upserts a batch of items into a vector index.
     /// If an item with the same ID already exists in the index, it will be replaced.
     /// Otherwise, it will be added to the index.

--- a/src/Momento.Sdk/Internal/VectorIndexDataClient.cs
+++ b/src/Momento.Sdk/Internal/VectorIndexDataClient.cs
@@ -35,7 +35,7 @@ internal sealed class VectorIndexDataClient : IDisposable
         {
             _logger.LogTraceVectorIndexRequest(REQUEST_COUNT_ITEMS, indexName);
             CheckValidIndexName(indexName);
-            var request = new _CountItemsRequest() { IndexName = indexName };
+            var request = new _CountItemsRequest() { IndexName = indexName, All = new _CountItemsRequest.Types.All() };
 
             var response =
                 await grpcManager.Client.CountItemsAsync(request, new CallOptions(deadline: CalculateDeadline()));

--- a/src/Momento.Sdk/Internal/VectorIndexDataClient.cs
+++ b/src/Momento.Sdk/Internal/VectorIndexDataClient.cs
@@ -28,6 +28,30 @@ internal sealed class VectorIndexDataClient : IDisposable
         _exceptionMapper = new CacheExceptionMapper(config.LoggerFactory);
     }
 
+    const string REQUEST_COUNT_ITEMS = "COUNT_ITEMS";
+    public async Task<CountItemsResponse> CountItemsAsync(string indexName)
+    {
+        try
+        {
+            _logger.LogTraceVectorIndexRequest(REQUEST_COUNT_ITEMS, indexName);
+            CheckValidIndexName(indexName);
+            var request = new _CountItemsRequest() { IndexName = indexName };
+
+            var response =
+                await grpcManager.Client.CountItemsAsync(request, new CallOptions(deadline: CalculateDeadline()));
+            // To maintain CLS compliance we use a long here instead of a ulong.
+            // The max value of a long is still over 9 quintillion so we should be good for a while.
+            var itemCount = checked((long)response.ItemCount);
+            return _logger.LogTraceVectorIndexRequestSuccess(REQUEST_COUNT_ITEMS, indexName,
+                new CountItemsResponse.Success(itemCount));
+        }
+        catch (Exception e)
+        {
+            return _logger.LogTraceVectorIndexRequestError(REQUEST_COUNT_ITEMS, indexName,
+                new CountItemsResponse.Error(_exceptionMapper.Convert(e)));
+        }
+    }
+
     const string REQUEST_UPSERT_ITEM_BATCH = "UPSERT_ITEM_BATCH";
     public async Task<UpsertItemBatchResponse> UpsertItemBatchAsync(string indexName,
         IEnumerable<Item> items)

--- a/src/Momento.Sdk/Internal/VectorIndexDataGrpcManager.cs
+++ b/src/Momento.Sdk/Internal/VectorIndexDataGrpcManager.cs
@@ -19,6 +19,7 @@ namespace Momento.Sdk.Internal;
 
 public interface IVectorIndexDataClient
 {
+    public Task<_CountItemsResponse> CountItemsAsync(_CountItemsRequest request, CallOptions callOptions);
     public Task<_UpsertItemBatchResponse> UpsertItemBatchAsync(_UpsertItemBatchRequest request, CallOptions callOptions);
     public Task<_SearchResponse> SearchAsync(_SearchRequest request, CallOptions callOptions);
     public Task<_SearchAndFetchVectorsResponse> SearchAndFetchVectorsAsync(_SearchAndFetchVectorsRequest request, CallOptions callOptions);
@@ -45,6 +46,12 @@ public class VectorIndexDataClientWithMiddleware : IVectorIndexDataClient
     {
         _generatedClient = generatedClient;
         _middlewares = middlewares;
+    }
+
+    public async Task<_CountItemsResponse> CountItemsAsync(_CountItemsRequest request, CallOptions callOptions)
+    {
+        var wrapped = await _middlewares.WrapRequest(request, callOptions, (r, o) => _generatedClient.CountItemsAsync(r, o));
+        return await wrapped.ResponseAsync;
     }
 
     public async Task<_UpsertItemBatchResponse> UpsertItemBatchAsync(_UpsertItemBatchRequest request, CallOptions callOptions)

--- a/src/Momento.Sdk/Momento.Sdk.csproj
+++ b/src/Momento.Sdk/Momento.Sdk.csproj
@@ -57,7 +57,7 @@
 	<ItemGroup>
 	  <PackageReference Include="Grpc.Net.Client" Version="2.49.0" />
 	  <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
-	  <PackageReference Include="Momento.Protos" Version="0.97.1" />
+	  <PackageReference Include="Momento.Protos" Version="0.102.1" />
 	  <PackageReference Include="JWT" Version="9.0.3" />
 	  <PackageReference Include="System.Threading.Channels" Version="6.0.0" />
 	  <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />

--- a/src/Momento.Sdk/PreviewVectorIndexClient.cs
+++ b/src/Momento.Sdk/PreviewVectorIndexClient.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Momento.Sdk.Auth;
@@ -52,6 +53,12 @@ public class PreviewVectorIndexClient : IPreviewVectorIndexClient
     public async Task<DeleteIndexResponse> DeleteIndexAsync(string indexName)
     {
         return await controlClient.DeleteIndexAsync(indexName);
+    }
+
+    /// <inheritdoc />
+    public async Task<CountItemsResponse> CountItemsAsync(string indexName)
+    {
+        return await dataClient.CountItemsAsync(indexName);
     }
 
     /// <inheritdoc />

--- a/src/Momento.Sdk/Responses/Vector/CountItemsResponse.cs
+++ b/src/Momento.Sdk/Responses/Vector/CountItemsResponse.cs
@@ -1,0 +1,80 @@
+﻿using Momento.Sdk.Exceptions;
+
+namespace Momento.Sdk.Responses.Vector;
+
+/// <summary>
+/// Parent response type for a count items request. The
+/// response object is resolved to a type-safe object of one of
+/// the following subtypes:
+/// <list type="bullet">
+/// <item><description>CountItemsResponse.Success</description></item>
+/// <item><description>CountItemsResponse.Error</description></item>
+/// </list>
+/// Pattern matching can be used to operate on the appropriate subtype.
+/// For example:
+/// <code>
+/// if (response is CountItemsResponse.Success successResponse)
+/// {
+///     return successResponse.ItemCount;
+/// }
+/// else if (response is CountItemsResponse.Error errorResponse)
+/// {
+///     // handle error as appropriate
+/// }
+/// else
+/// {
+///     // handle unexpected response
+/// }
+/// </code>
+/// </summary>
+public abstract class CountItemsResponse
+{
+    /// <include file="../../docs.xml" path='docs/class[@name="Success"]/description/*' />
+    public class Success : CountItemsResponse
+    {
+        /// <summary>
+        /// The number of items in the vector index.
+        /// </summary>
+        public long ItemCount { get; }
+
+        /// <include file="../../docs.xml" path='docs/class[@name="Success"]/description/*' />
+        /// <param name="itemCount">The number of items in the vector index.</param>
+        public Success(long itemCount)
+        {
+            ItemCount = itemCount;
+        }
+
+        /// <inheritdoc />
+        public override string ToString()
+        {
+            return $"{base.ToString()}: {ItemCount}";
+        }
+
+    }
+
+    /// <include file="../../docs.xml" path='docs/class[@name="Error"]/description/*' />
+    public class Error : CountItemsResponse, IError
+    {
+        /// <include file="../../docs.xml" path='docs/class[@name="Error"]/constructor/*' />
+        public Error(SdkException error)
+        {
+            InnerException = error;
+        }
+
+        /// <inheritdoc />
+        public SdkException InnerException { get; }
+
+        /// <inheritdoc />
+        public MomentoErrorCode ErrorCode => InnerException.ErrorCode;
+
+        /// <inheritdoc />
+        public string Message => $"{InnerException.MessageWrapper}: {InnerException.Message}";
+
+        /// <inheritdoc />
+        public override string ToString()
+        {
+            return $"{base.ToString()}: {Message}";
+        }
+
+    }
+}


### PR DESCRIPTION
Adds MVI count items, which returns the number of items in a vector
index. In the event an index does not exist, the response is a
`NOT_FOUND` error. That way we distinguish between an empty index that
does exist vs an index that does not exist.

This PR adds the response type, method, documentation, and integration
tests.
