### PR TITLE
refactor: use mvi filter fields for get/delete items

### DIFF
--- a/src/Momento.Sdk/Internal/VectorIndexDataClient.cs
+++ b/src/Momento.Sdk/Internal/VectorIndexDataClient.cs
@@ -83,7 +83,7 @@ internal sealed class VectorIndexDataClient : IDisposable
             var request = new _GetItemBatchRequest()
             {
                 IndexName = indexName,
-                Ids = { ids },
+                Filter = idsToFilterExpression(ids),
                 MetadataFields = new _MetadataRequest { All = new _MetadataRequest.Types.All() }
             };
 

--- a/src/Momento.Sdk/Internal/VectorIndexDataClient.cs
+++ b/src/Momento.Sdk/Internal/VectorIndexDataClient.cs
@@ -89,20 +89,8 @@ internal sealed class VectorIndexDataClient : IDisposable
 
             var response =
                 await grpcManager.Client.GetItemBatchAsync(request, new CallOptions(deadline: CalculateDeadline()));
-            var items = new Dictionary<string, Item>();
-            foreach (var item in response.ItemResponse)
-            {
-                switch (item.ResponseCase)
-                {
-                    case _ItemResponse.ResponseOneofCase.Hit:
-                        items[item.Hit.Id] = new(item.Hit.Id, item.Hit.Vector.Elements.ToList(), Convert(item.Hit.Metadata));
-                        break;
-                    case _ItemResponse.ResponseOneofCase.Miss:
-                        break;
-                    default:
-                        throw new UnknownException($"Unknown item response type {item.ResponseCase}");
-                }
-            }
+            var items = response.ItemResponse.ToDictionary(
+                item => item.Id, item => new Item(item.Id, item.Vector.Elements.ToList(), Convert(item.Metadata)));
             return _logger.LogTraceVectorIndexRequestSuccess(REQUEST_GET_ITEM_BATCH, indexName,
                 new GetItemBatchResponse.Success(items));
         }

--- a/src/Momento.Sdk/Internal/VectorIndexDataClient.cs
+++ b/src/Momento.Sdk/Internal/VectorIndexDataClient.cs
@@ -131,7 +131,7 @@ internal sealed class VectorIndexDataClient : IDisposable
     }
 
     /// <summary>
-    /// Convert a list of ids to a filter expression requiring the item id to be in the set.
+    /// Convert a list of ids to an id-in-set filter expression.
     /// </summary>
     /// <param name="ids"></param>
     /// <returns></returns>

--- a/src/Momento.Sdk/Internal/VectorIndexDataClient.cs
+++ b/src/Momento.Sdk/Internal/VectorIndexDataClient.cs
@@ -118,20 +118,8 @@ internal sealed class VectorIndexDataClient : IDisposable
             var response =
                 await grpcManager.Client.GetItemMetadataBatchAsync(request,
                     new CallOptions(deadline: CalculateDeadline()));
-            var items = new Dictionary<string, Dictionary<string, MetadataValue>>();
-            foreach (var item in response.ItemMetadataResponse)
-            {
-                switch (item.ResponseCase)
-                {
-                    case _ItemMetadataResponse.ResponseOneofCase.Hit:
-                        items[item.Hit.Id] = Convert(item.Hit.Metadata);
-                        break;
-                    case _ItemMetadataResponse.ResponseOneofCase.Miss:
-                        break;
-                    default:
-                        throw new UnknownException($"Unknown item response type {item.ResponseCase}");
-                }
-            }
+            var items = response.ItemMetadataResponse.ToDictionary(
+                item => item.Id, item => Convert(item.Metadata));
             return _logger.LogTraceVectorIndexRequestSuccess(REQUEST_GET_ITEM_METADATA_BATCH, indexName,
                 new GetItemMetadataBatchResponse.Success(items));
         }

--- a/src/Momento.Sdk/Internal/VectorIndexDataClient.cs
+++ b/src/Momento.Sdk/Internal/VectorIndexDataClient.cs
@@ -154,6 +154,22 @@ internal sealed class VectorIndexDataClient : IDisposable
         }
     }
 
+    /// <summary>
+    /// Convert a list of ids to a filter expression requiring the item id to be in the set.
+    /// </summary>
+    /// <param name="ids"></param>
+    /// <returns></returns>
+    private static _FilterExpression idsToFilterExpression(IEnumerable<string> ids)
+    {
+        return new _FilterExpression
+        {
+            IdInSetExpression = new _IdInSetExpression()
+            {
+                Ids = { ids }
+            }
+        };
+    }
+
     const string REQUEST_DELETE_ITEM_BATCH = "DELETE_ITEM_BATCH";
     public async Task<DeleteItemBatchResponse> DeleteItemBatchAsync(string indexName, IEnumerable<string> ids)
     {
@@ -161,7 +177,7 @@ internal sealed class VectorIndexDataClient : IDisposable
         {
             _logger.LogTraceVectorIndexRequest(REQUEST_DELETE_ITEM_BATCH, indexName);
             CheckValidIndexName(indexName);
-            var request = new _DeleteItemBatchRequest() { IndexName = indexName, Ids = { ids } };
+            var request = new _DeleteItemBatchRequest() { IndexName = indexName, Filter = idsToFilterExpression(ids) };
 
             await grpcManager.Client.DeleteItemBatchAsync(request, new CallOptions(deadline: CalculateDeadline()));
             return _logger.LogTraceVectorIndexRequestSuccess(REQUEST_DELETE_ITEM_BATCH, indexName,

--- a/src/Momento.Sdk/Internal/VectorIndexDataClient.cs
+++ b/src/Momento.Sdk/Internal/VectorIndexDataClient.cs
@@ -123,7 +123,7 @@ internal sealed class VectorIndexDataClient : IDisposable
             var request = new _GetItemMetadataBatchRequest()
             {
                 IndexName = indexName,
-                Ids = { ids },
+                Filter = idsToFilterExpression(ids),
                 MetadataFields = new _MetadataRequest { All = new _MetadataRequest.Types.All() }
             };
 

--- a/src/Momento.Sdk/Momento.Sdk.csproj
+++ b/src/Momento.Sdk/Momento.Sdk.csproj
@@ -57,7 +57,7 @@
 	<ItemGroup>
 	  <PackageReference Include="Grpc.Net.Client" Version="2.49.0" />
 	  <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
-	  <PackageReference Include="Momento.Protos" Version="0.105.2" />
+	  <PackageReference Include="Momento.Protos" Version="0.106.0" />
 	  <PackageReference Include="JWT" Version="9.0.3" />
 	  <PackageReference Include="System.Threading.Channels" Version="6.0.0" />
 	  <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />


### PR DESCRIPTION
We are in the process of migrating MVI delete item batch, get item batch, and get item metadata batch to use a filter expression to select items to delete (get) as opposed to a list of id's. For convenience, we will still allow users to select items with a list of id's from the top level methods. This PR migrates the backend.

As part of the migration we are also moving away from the hit/miss pattern for get item batch and get item metadata batch response messages. While the hit/miss pattern made sense for when we only selected items by id, it no longer makes sense for when a user supplies a general filter expression. What's more, previously when we read the hit/miss responses, we built a dictionary containing only the hits, so the distinction wasn't as important.

In future PRs we will add overloads to also use a filter expression from delete and get item methods.
