### PR TITLE
refactor: rename mvi parameter ids to filter on get/delete item batch

### DIFF
--- a/src/Momento.Sdk/IPreviewVectorIndexClient.cs
+++ b/src/Momento.Sdk/IPreviewVectorIndexClient.cs
@@ -148,7 +148,7 @@ public interface IPreviewVectorIndexClient : IDisposable
     /// Gets a batch of items from a vector index by ID.
     /// </summary>
     /// <param name="indexName">The name of the vector index to get the items from.</param>
-    /// <param name="ids">The IDs of the items to get from the index.</param>
+    /// <param name="filter">The IDs of the items to get from the index.</param>
     /// <returns>
     /// Task representing the result of the get item batch operation. The
     /// response object is resolved to a type-safe object of one of
@@ -167,13 +167,13 @@ public interface IPreviewVectorIndexClient : IDisposable
     /// }
     /// </code>
     /// </returns>
-    public Task<GetItemBatchResponse> GetItemBatchAsync(string indexName, IEnumerable<string> ids);
+    public Task<GetItemBatchResponse> GetItemBatchAsync(string indexName, IEnumerable<string> filter);
 
     /// <summary>
     /// Gets metadata for a batch of items from a vector index by ID.
     /// </summary>
     /// <param name="indexName">The name of the vector index to get the item metadata from.</param>
-    /// <param name="ids">The IDs of the item metadata to get from the index.</param>
+    /// <param name="filter">The IDs of the item metadata to get from the index.</param>
     /// <returns>
     /// Task representing the result of the get item metadata batch operation. The
     /// response object is resolved to a type-safe object of one of
@@ -192,13 +192,13 @@ public interface IPreviewVectorIndexClient : IDisposable
     /// }
     /// </code>
     /// </returns>
-    public Task<GetItemMetadataBatchResponse> GetItemMetadataBatchAsync(string indexName, IEnumerable<string> ids);
+    public Task<GetItemMetadataBatchResponse> GetItemMetadataBatchAsync(string indexName, IEnumerable<string> filter);
 
     /// <summary>
     /// Deletes all items with the given IDs from the index. Returns success if for items that do not exist.
     /// </summary>
     /// <param name="indexName">The name of the vector index to delete the items from.</param>
-    /// <param name="ids">The IDs of the items to delete from the index.</param>
+    /// <param name="filter">The IDs of the items to delete from the index.</param>
     /// <returns>
     /// Task representing the result of the upsert operation. The
     /// response object is resolved to a type-safe object of one of
@@ -216,7 +216,7 @@ public interface IPreviewVectorIndexClient : IDisposable
     /// }
     /// </code>
     ///</returns>
-    public Task<DeleteItemBatchResponse> DeleteItemBatchAsync(string indexName, IEnumerable<string> ids);
+    public Task<DeleteItemBatchResponse> DeleteItemBatchAsync(string indexName, IEnumerable<string> filter);
 
     ///  <summary>
     ///  Searches for the most similar vectors to the query vector in the index.

--- a/src/Momento.Sdk/Internal/VectorIndexDataClient.cs
+++ b/src/Momento.Sdk/Internal/VectorIndexDataClient.cs
@@ -74,7 +74,7 @@ internal sealed class VectorIndexDataClient : IDisposable
     }
 
     const string REQUEST_GET_ITEM_BATCH = "GET_ITEM_BATCH";
-    public async Task<GetItemBatchResponse> GetItemBatchAsync(string indexName, IEnumerable<string> ids)
+    public async Task<GetItemBatchResponse> GetItemBatchAsync(string indexName, IEnumerable<string> filter)
     {
         try
         {
@@ -83,7 +83,7 @@ internal sealed class VectorIndexDataClient : IDisposable
             var request = new _GetItemBatchRequest()
             {
                 IndexName = indexName,
-                Filter = idsToFilterExpression(ids),
+                Filter = idsToFilterExpression(filter),
                 MetadataFields = new _MetadataRequest { All = new _MetadataRequest.Types.All() }
             };
 
@@ -102,7 +102,7 @@ internal sealed class VectorIndexDataClient : IDisposable
     }
 
     const string REQUEST_GET_ITEM_METADATA_BATCH = "GET_ITEM_METADATA_BATCH";
-    public async Task<GetItemMetadataBatchResponse> GetItemMetadataBatchAsync(string indexName, IEnumerable<string> ids)
+    public async Task<GetItemMetadataBatchResponse> GetItemMetadataBatchAsync(string indexName, IEnumerable<string> filter)
     {
         try
         {
@@ -111,7 +111,7 @@ internal sealed class VectorIndexDataClient : IDisposable
             var request = new _GetItemMetadataBatchRequest()
             {
                 IndexName = indexName,
-                Filter = idsToFilterExpression(ids),
+                Filter = idsToFilterExpression(filter),
                 MetadataFields = new _MetadataRequest { All = new _MetadataRequest.Types.All() }
             };
 
@@ -147,13 +147,13 @@ internal sealed class VectorIndexDataClient : IDisposable
     }
 
     const string REQUEST_DELETE_ITEM_BATCH = "DELETE_ITEM_BATCH";
-    public async Task<DeleteItemBatchResponse> DeleteItemBatchAsync(string indexName, IEnumerable<string> ids)
+    public async Task<DeleteItemBatchResponse> DeleteItemBatchAsync(string indexName, IEnumerable<string> filter)
     {
         try
         {
             _logger.LogTraceVectorIndexRequest(REQUEST_DELETE_ITEM_BATCH, indexName);
             CheckValidIndexName(indexName);
-            var request = new _DeleteItemBatchRequest() { IndexName = indexName, Filter = idsToFilterExpression(ids) };
+            var request = new _DeleteItemBatchRequest() { IndexName = indexName, Filter = idsToFilterExpression(filter) };
 
             await grpcManager.Client.DeleteItemBatchAsync(request, new CallOptions(deadline: CalculateDeadline()));
             return _logger.LogTraceVectorIndexRequestSuccess(REQUEST_DELETE_ITEM_BATCH, indexName,

--- a/src/Momento.Sdk/PreviewVectorIndexClient.cs
+++ b/src/Momento.Sdk/PreviewVectorIndexClient.cs
@@ -69,21 +69,21 @@ public class PreviewVectorIndexClient : IPreviewVectorIndexClient
     }
 
     /// <inheritdoc />
-    public async Task<GetItemBatchResponse> GetItemBatchAsync(string indexName, IEnumerable<string> ids)
+    public async Task<GetItemBatchResponse> GetItemBatchAsync(string indexName, IEnumerable<string> filter)
     {
-        return await dataClient.GetItemBatchAsync(indexName, ids);
+        return await dataClient.GetItemBatchAsync(indexName, filter);
     }
 
     /// <inheritdoc />
-    public async Task<GetItemMetadataBatchResponse> GetItemMetadataBatchAsync(string indexName, IEnumerable<string> ids)
+    public async Task<GetItemMetadataBatchResponse> GetItemMetadataBatchAsync(string indexName, IEnumerable<string> filter)
     {
-        return await dataClient.GetItemMetadataBatchAsync(indexName, ids);
+        return await dataClient.GetItemMetadataBatchAsync(indexName, filter);
     }
 
     /// <inheritdoc />
-    public async Task<DeleteItemBatchResponse> DeleteItemBatchAsync(string indexName, IEnumerable<string> ids)
+    public async Task<DeleteItemBatchResponse> DeleteItemBatchAsync(string indexName, IEnumerable<string> filter)
     {
-        return await dataClient.DeleteItemBatchAsync(indexName, ids);
+        return await dataClient.DeleteItemBatchAsync(indexName, filter);
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
To standardize how we select items in get item batch, get item
metadata batch, and delete item batch, we use the term filter in
methods, whether selecting by ids or filter expression.
