### PR TITLE
fix: include exception in log message when eager connection fails; update env vars to MOMENTO_API_KEY

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -60,7 +60,7 @@ jobs:
     env:
       # TODO: remove token stored as secret in favor of using a
       # momento-local instance that can be spun up for testing
-      MOMENTO_AUTH_TOKEN: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
+      MOMENTO_API_KEY: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
 
     steps:
       - name: Setup repo

--- a/examples/DictionaryExample/Program.cs
+++ b/examples/DictionaryExample/Program.cs
@@ -8,7 +8,7 @@ using Momento.Sdk.Responses;
 
 public class Driver
 {
-    private static readonly string AUTH_TOKEN_ENV_VAR = "MOMENTO_AUTH_TOKEN";
+    private static readonly string AUTH_TOKEN_ENV_VAR = "MOMENTO_API_KEY";
     private static readonly string CACHE_NAME_ENV_VAR = "MOMENTO_CACHE_NAME";
     private static readonly ILogger _logger;
     private static readonly ILoggerFactory _loggerFactory;

--- a/examples/DisposableTokens/Program.cs
+++ b/examples/DisposableTokens/Program.cs
@@ -14,7 +14,7 @@ static class Program
  
     static Program()
     {
-        authProvider = new EnvMomentoTokenProvider("MOMENTO_AUTH_TOKEN");
+        authProvider = new EnvMomentoTokenProvider("MOMENTO_API_KEY");
         client = new AuthClient(AuthConfigurations.Default.Latest(), authProvider);
     }
 

--- a/examples/DisposableTokens/README.md
+++ b/examples/DisposableTokens/README.md
@@ -6,10 +6,10 @@ This example program demonstrates how to generate disposable Momento auth tokens
 
 # Usage
 
-The program assumes that your Momento auth token is available in the `MOMENTO_AUTH_TOKEN` environment variable:
+The program assumes that your Momento auth token is available in the `MOMENTO_API_KEY` environment variable:
 
 ```bash
-MOMENTO_AUTH_TOKEN=<YOUR_AUTH_TOKEN> dotnet run
+MOMENTO_API_KEY=<YOUR_AUTH_TOKEN> dotnet run
 ```
 
 The example generates a disposable expiring auth token using the enumerated permissions and expiry defined in the program and prints its attributes to the console.

--- a/examples/DocExampleApis/Program.cs
+++ b/examples/DocExampleApis/Program.cs
@@ -11,15 +11,15 @@ public class Program
     {
         var config = Configurations.Laptop.V1();
         var client = new CacheClient(config,
-            new EnvMomentoTokenProvider("MOMENTO_AUTH_TOKEN"),
+            new EnvMomentoTokenProvider("MOMENTO_API_KEY"),
             TimeSpan.FromSeconds(10));
         IAuthClient authClient = new AuthClient(
             AuthConfigurations.Default.Latest(),
-            new EnvMomentoTokenProvider("MOMENTO_AUTH_TOKEN")
+            new EnvMomentoTokenProvider("MOMENTO_API_KEY")
         );
         ITopicClient topicClient = new TopicClient(
             TopicConfigurations.Laptop.latest(),
-            new EnvMomentoTokenProvider("MOMENTO_AUTH_TOKEN")
+            new EnvMomentoTokenProvider("MOMENTO_API_KEY")
         );
 
         await Example_API_CreateCache(client);
@@ -240,7 +240,7 @@ public class Program
     {
         new TopicClient(
             TopicConfigurations.Laptop.latest(),
-            new EnvMomentoTokenProvider("MOMENTO_AUTH_TOKEN")
+            new EnvMomentoTokenProvider("MOMENTO_API_KEY")
         );
     }
 #pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously

--- a/examples/MomentoApplication/Program.cs
+++ b/examples/MomentoApplication/Program.cs
@@ -7,7 +7,7 @@ using Momento.Sdk.Config;
 using Momento.Sdk.Exceptions;
 using Momento.Sdk.Responses;
 
-ICredentialProvider authProvider = new EnvMomentoTokenProvider("MOMENTO_AUTH_TOKEN");
+ICredentialProvider authProvider = new EnvMomentoTokenProvider("MOMENTO_API_KEY");
 
 TimeSpan DEFAULT_TTL = TimeSpan.FromSeconds(60);
 
@@ -128,7 +128,7 @@ public class AdvancedExamples {
     /// </summary>
     public static void EagerConnectionExample()
     {
-        ICredentialProvider authProvider = new EnvMomentoTokenProvider("MOMENTO_AUTH_TOKEN");
+        ICredentialProvider authProvider = new EnvMomentoTokenProvider("MOMENTO_API_KEY");
         TimeSpan defaultTtl = TimeSpan.FromSeconds(60);
         var config = Configurations.Laptop.V1();
         var eagerConnectionConfig = config.WithTransportStrategy(config.TransportStrategy.WithEagerConnectionTimeout(TimeSpan.FromSeconds(10)));

--- a/examples/MomentoApplication/README.md
+++ b/examples/MomentoApplication/README.md
@@ -20,13 +20,13 @@ functionality, including:
 Run the following from within the `examples` directory:
 
 ```bash
-MOMENTO_AUTH_TOKEN=<YOUR AUTH TOKEN> dotnet run --project MomentoApplication
+MOMENTO_API_KEY=<YOUR AUTH TOKEN> dotnet run --project MomentoApplication
 ```
 
 Within the `MomentoAppication` directory you can run:
 
 ```bash
-MOMENTO_AUTH_TOKEN=<YOUR AUTH TOKEN> dotnet run
+MOMENTO_API_KEY=<YOUR AUTH TOKEN> dotnet run
 ```
 
 ## Error Handling

--- a/examples/MomentoFSharpApplication/Program.fs
+++ b/examples/MomentoFSharpApplication/Program.fs
@@ -6,7 +6,7 @@ open System
 
 let CACHE_NAME = "cache"
 let DEFAULT_TTL = TimeSpan.FromSeconds(60.0)
-let authProvider = new EnvMomentoTokenProvider("MOMENTO_AUTH_TOKEN")
+let authProvider = new EnvMomentoTokenProvider("MOMENTO_API_KEY")
 
 let exerciseCache() = (
     printfn "Howdy"

--- a/examples/MomentoLoadGen/Program.cs
+++ b/examples/MomentoLoadGen/Program.cs
@@ -90,7 +90,7 @@ namespace MomentoLoadGen
 
         public async Task Run()
         {
-            var authProvider = new EnvMomentoTokenProvider("MOMENTO_AUTH_TOKEN");
+            var authProvider = new EnvMomentoTokenProvider("MOMENTO_API_KEY");
 
             using (ICacheClient momento = new CacheClient(
                 _momentoClientConfig,

--- a/examples/MomentoLoadGen/README.md
+++ b/examples/MomentoLoadGen/README.md
@@ -31,14 +31,14 @@ To run the load generator (from the `examples` directory):
 
 ```bash
 # Run example load generator
-MOMENTO_AUTH_TOKEN=<YOUR AUTH TOKEN> dotnet run --project MomentoLoadGen
+MOMENTO_API_KEY=<YOUR AUTH TOKEN> dotnet run --project MomentoLoadGen
 ```
 
 Within the `MomentoLoadGen` directory you can run:
 
 ```bash
 # Run example load generator
-MOMENTO_AUTH_TOKEN=<YOUR AUTH TOKEN> dotnet run
+MOMENTO_API_KEY=<YOUR AUTH TOKEN> dotnet run
 ```
 
 If you make modifications to the code, remember to do a clean otherwise
@@ -46,5 +46,5 @@ the program might not run.
 
 ```bash
 dotnet clean
-MOMENTO_AUTH_TOKEN=<YOUR AUTH TOKEN> dotnet run
+MOMENTO_API_KEY=<YOUR AUTH TOKEN> dotnet run
 ```

--- a/examples/MomentoUsage/Program.cs
+++ b/examples/MomentoUsage/Program.cs
@@ -4,7 +4,7 @@ using Momento.Sdk.Auth;
 using Momento.Sdk.Config;
 using Momento.Sdk.Responses;
 
-ICredentialProvider authProvider = new EnvMomentoTokenProvider("MOMENTO_AUTH_TOKEN");
+ICredentialProvider authProvider = new EnvMomentoTokenProvider("MOMENTO_API_KEY");
 const string CACHE_NAME = "cache";
 const string KEY = "MyKey";
 const string VALUE = "MyData";

--- a/examples/MomentoUsage/README.md
+++ b/examples/MomentoUsage/README.md
@@ -16,13 +16,13 @@ the client's full capabilities, take a look at the more advanced  [MomentoApplic
 Run the following from within the `examples` directory:
 
 ```bash
-MOMENTO_AUTH_TOKEN=<YOUR AUTH TOKEN> dotnet run --project MomentoUsage
+MOMENTO_API_KEY=<YOUR AUTH TOKEN> dotnet run --project MomentoUsage
 ```
 
 Within the `MomentoUsage` directory you can run:
 
 ```bash
-MOMENTO_AUTH_TOKEN=<YOUR AUTH TOKEN> dotnet run
+MOMENTO_API_KEY=<YOUR AUTH TOKEN> dotnet run
 ```
 
 ## Error Handling

--- a/examples/TopicExample/Program.cs
+++ b/examples/TopicExample/Program.cs
@@ -9,7 +9,7 @@ namespace TopicExample;
 
 public class Driver
 {
-    private const string AuthTokenEnvVar = "MOMENTO_AUTH_TOKEN";
+    private const string AuthTokenEnvVar = "MOMENTO_API_KEY";
     private const string CacheNameEnvVar = "MOMENTO_CACHE_NAME";
     private const string TopicName = "example-topic";
     private static readonly ILogger Logger;

--- a/src/Momento.Sdk/Internal/DataGrpcManager.cs
+++ b/src/Momento.Sdk/Internal/DataGrpcManager.cs
@@ -310,9 +310,9 @@ public class DataGrpcManager : IDisposable
                 pingClient.Ping(new _PingRequest(),
                     new CallOptions(deadline: DateTime.UtcNow.Add(eagerConnectionTimeout)));
             }
-            catch (RpcException)
+            catch (RpcException ex)
             {
-                _logger.LogWarning("Failed to eagerly connect to the server; continuing with execution in case failure is recoverable later.");
+                _logger.LogWarning($"Failed to eagerly connect to the server; continuing with execution in case failure is recoverable later: {ex}");
             }
         }
 


### PR DESCRIPTION
Prior to this commit, if we failed to eagerly connect, we were not logging any information about
the reason. This commit adds the exception to the log. Tested by disabling my network connection
and verified it includes all the relevant info.

Also updates places in example code where we were still using MOMENTO_AUTH_TOKEN for env var names,
now that we have standardized on MOMENTO_API_KEY.
