### PR TITLE
feat: async factory function for eager connections

### DIFF
--- a/src/Momento.Sdk/Config/Configurations.cs
+++ b/src/Momento.Sdk/Config/Configurations.cs
@@ -184,11 +184,7 @@ public class Configurations
             /// <returns></returns>
             public static IConfiguration Latest(ILoggerFactory? loggerFactory = null)
             {
-                var config = Default.V1(loggerFactory);
-                var transportStrategy = config.TransportStrategy.WithEagerConnectionTimeout(
-                    TimeSpan.FromSeconds(30)
-                );
-                return config.WithTransportStrategy(transportStrategy);
+                return Default.V1(loggerFactory);
             }
         }
     }

--- a/src/Momento.Sdk/Config/Transport/ITransportStrategy.cs
+++ b/src/Momento.Sdk/Config/Transport/ITransportStrategy.cs
@@ -15,14 +15,6 @@ public interface ITransportStrategy
     public int MaxConcurrentRequests { get; }
 
     /// <summary>
-    /// If null, the client will only attempt to connect to the server lazily when the first request is executed.
-    /// If provided, the client will attempt to connect to the server immediately upon construction; if the connection
-    /// cannot be established within the specified TimeSpan, it will abort the connection attempt, log a warning,
-    /// and proceed with execution so that the application doesn't hang.
-    /// </summary>
-    public TimeSpan? EagerConnectionTimeout { get; }
-
-    /// <summary>
     /// Configures the low-level gRPC settings for the Momento client's communication
     /// with the Momento server.
     /// </summary>
@@ -50,15 +42,4 @@ public interface ITransportStrategy
     /// <param name="clientTimeout"></param>
     /// <returns>A new ITransportStrategy with the specified client timeout</returns>
     public ITransportStrategy WithClientTimeout(TimeSpan clientTimeout);
-
-    /// <summary>
-    /// Copy constructor to enable eager connection to the server
-    /// </summary>
-    /// <param name="connectionTimeout">A timeout for attempting an eager connection to the server.  When the client
-    /// is constructed, it will attempt to connect to the server immediately.  If the connection
-    /// cannot be established within the specified TimeSpan, it will abort the connection attempt, log a warning,
-    /// and proceed with execution so that the application doesn't hang.
-    /// </param>
-    /// <returns>A new ITransportStrategy configured to eagerly connect to the server upon construction</returns>
-    public ITransportStrategy WithEagerConnectionTimeout(TimeSpan connectionTimeout);
 }

--- a/src/Momento.Sdk/Exceptions/ConnectionException.cs
+++ b/src/Momento.Sdk/Exceptions/ConnectionException.cs
@@ -1,0 +1,15 @@
+namespace Momento.Sdk.Exceptions;
+
+using System;
+
+/// <summary>
+/// Unable to connect to the server.
+/// </summary>
+public class ConnectionException : SdkException
+{
+    /// <include file="../docs.xml" path='docs/class[@name="SdkException"]/constructor/*' />
+    public ConnectionException(string message, MomentoErrorTransportDetails transportDetails, Exception? e = null) : base(MomentoErrorCode.CONNECTION_ERROR, message, transportDetails, e)
+    {
+        this.MessageWrapper = "Unable to connect to the server; consider retrying.  If the error persists, please contact us at support@momentohq.com";
+    }
+}

--- a/src/Momento.Sdk/Exceptions/SdkException.cs
+++ b/src/Momento.Sdk/Exceptions/SdkException.cs
@@ -66,6 +66,10 @@ public enum MomentoErrorCode
     /// </summary>
     FAILED_PRECONDITION_ERROR,
     /// <summary>
+    /// Unable to connect to the server
+    /// </summary>
+    CONNECTION_ERROR,
+    /// <summary>
     /// Unknown error has occurred
     /// </summary>
     UNKNOWN_ERROR

--- a/src/Momento.Sdk/Internal/ScsDataClient.cs
+++ b/src/Momento.Sdk/Internal/ScsDataClient.cs
@@ -33,6 +33,11 @@ public class ScsDataClientBase : IDisposable
         this._logger = config.LoggerFactory.CreateLogger<ScsDataClient>();
         this._exceptionMapper = new CacheExceptionMapper(config.LoggerFactory);
     }
+    
+    internal Task EagerConnectAsync(TimeSpan eagerConnectionTimeout)
+    {
+        return this.grpcManager.EagerConnectAsync(eagerConnectionTimeout);
+    }
 
     protected Metadata MetadataWithCache(string cacheName)
     {

--- a/tests/Integration/Momento.Sdk.Tests/CacheEagerConnectionTest.cs
+++ b/tests/Integration/Momento.Sdk.Tests/CacheEagerConnectionTest.cs
@@ -30,15 +30,6 @@ public class CacheEagerConnectionTest
     }
 
     [Fact]
-    public void CacheClientConstructor_EagerConnection_Success()
-    {
-        var config = Configurations.Laptop.Latest(loggerFactory);
-        config = config.WithTransportStrategy(config.TransportStrategy.WithEagerConnectionTimeout(TimeSpan.FromSeconds(5)));
-        // just validating that we can construct the client when the eager connection is successful
-        var client = new CacheClient(config, authProvider, defaultTtl);
-    }
-
-    [Fact]
     public void CacheClientConstructor_WithChannelsAndMaxConn_Success()
     {
         var config = Configurations.Laptop.Latest(loggerFactory);
@@ -56,13 +47,12 @@ public class CacheEagerConnectionTest
     }
 
     [Fact]
-    public void CacheClientConstructor_EagerConnection_BadEndpoint()
+    public async void CacheClientCreate_EagerConnection_BadEndpoint()
     {
         var config = Configurations.Laptop.Latest(loggerFactory);
-        config = config.WithTransportStrategy(config.TransportStrategy.WithEagerConnectionTimeout(TimeSpan.FromSeconds(2)));
         var authProviderWithBadCacheEndpoint = authProvider.WithCacheEndpoint("cache.cell-external-beta-1.prod.a.momentohq.com:65000");
         Console.WriteLine($"Hello developer!  We are about to run a test that verifies that the cache client is still operational even if our eager connection (ping) fails.  So you will see the test log a warning message about that.  It's expected, don't worry!");
-        // validating that the constructor doesn't fail when the eager connection fails
-        var client = new CacheClient(config, authProviderWithBadCacheEndpoint, defaultTtl);
+        
+        await Assert.ThrowsAsync<ConnectionException>(async () => await CacheClient.CreateAsync(config, authProviderWithBadCacheEndpoint, defaultTtl, TimeSpan.FromSeconds(2)));
     }
 }

--- a/tests/Unit/Momento.Sdk.Tests/ConfigTest.cs
+++ b/tests/Unit/Momento.Sdk.Tests/ConfigTest.cs
@@ -19,11 +19,4 @@ public class ConfigTest
         Assert.Equal(Configurations.InRegion.Default.Latest(), Configurations.InRegion.Default.V1());
         Assert.Equal(Configurations.InRegion.LowLatency.Latest(), Configurations.InRegion.LowLatency.V1());
     }
-
-    [Fact]
-    public void LambdaLatest_HasEagerConnectionTimeout_HappyPath()
-    {
-        var config = Configurations.InRegion.Lambda.Latest();
-        Assert.Equal(TimeSpan.FromSeconds(30), config.TransportStrategy.EagerConnectionTimeout);
-    }
 }


### PR DESCRIPTION
This commit makes the following changes:

* Stop trying to do the eager connection stuff in the constructor
  of the CacheClient, because this can have surprising side effects,
  e.g. if we want to throw an error on failure.
* Remove the associated Configuration settings since we no longer
  support eager connections at construction time.
* Add a new factory function, CacheClient.CreateAsync, which is the
  new mechanism for create a client with an eager connection. This
  matches the pattern we established in the other SDKs that support
  eager connections.
* If the eager connection fails, we now throw a new ConnectionError
  rather than just logging a warning. This gives the consumer
  the ability to decide how to handle this type of error rather than
  us just swallowing it and removing their choice. In most cases,
  users would just end up hitting a timeout error on their next
  request after we gave up on the eager connection.

In the future we may add more configuration options for how to
handle eager connection failures, possibly including some
automatic retries. For now, this gives the user more control, which
seems extremely desirable given the number of times we have recently
seen users run into DNS throttling when they try to make a very
high volume of connections to Momento from lambdas.
