### PR TITLE
fix: add support for item sizes up to 5mb

### DIFF
--- a/src/Momento.Sdk/Internal/AuthGrpcManager.cs
+++ b/src/Momento.Sdk/Internal/AuthGrpcManager.cs
@@ -74,6 +74,9 @@ public class AuthGrpcManager : IDisposable
         }
 
         channelOptions.Credentials = ChannelCredentials.SecureSsl;
+        channelOptions.MaxReceiveMessageSize = Internal.Utils.DEFAULT_MAX_MESSAGE_SIZE;
+        channelOptions.MaxSendMessageSize = Internal.Utils.DEFAULT_MAX_MESSAGE_SIZE;
+
 #if USE_GRPC_WEB
         channelOptions.HttpHandler = new GrpcWebHandler(new HttpClientHandler());
 #endif

--- a/src/Momento.Sdk/Internal/ControlGrpcManager.cs
+++ b/src/Momento.Sdk/Internal/ControlGrpcManager.cs
@@ -96,8 +96,10 @@ internal sealed class ControlGrpcManager : IDisposable
         this.channel = GrpcChannel.ForAddress(uri, new GrpcChannelOptions()
         {
             Credentials = ChannelCredentials.SecureSsl,
+            MaxReceiveMessageSize = Internal.Utils.DEFAULT_MAX_MESSAGE_SIZE,
+            MaxSendMessageSize = Internal.Utils.DEFAULT_MAX_MESSAGE_SIZE,
 #if USE_GRPC_WEB
-            HttpHandler = new GrpcWebHandler(new HttpClientHandler())
+            HttpHandler = new GrpcWebHandler(new HttpClientHandler()),
 #endif
         });
         List<Header> headers = new List<Header> { new Header(name: Header.AuthorizationKey, value: authToken), new Header(name: Header.AgentKey, value: version), new Header(name: Header.RuntimeVersionKey, value: runtimeVersion) };

--- a/src/Momento.Sdk/Internal/DataGrpcManager.cs
+++ b/src/Momento.Sdk/Internal/DataGrpcManager.cs
@@ -280,6 +280,9 @@ public class DataGrpcManager : IDisposable
             channelOptions.LoggerFactory = config.LoggerFactory;
         }
         channelOptions.Credentials = ChannelCredentials.SecureSsl;
+        channelOptions.MaxReceiveMessageSize = Internal.Utils.DEFAULT_MAX_MESSAGE_SIZE;
+        channelOptions.MaxSendMessageSize = Internal.Utils.DEFAULT_MAX_MESSAGE_SIZE;
+        
 #if USE_GRPC_WEB
         channelOptions.HttpHandler = new GrpcWebHandler(new HttpClientHandler());
 #endif

--- a/src/Momento.Sdk/Internal/TopicGrpcManager.cs
+++ b/src/Momento.Sdk/Internal/TopicGrpcManager.cs
@@ -100,6 +100,9 @@ public class TopicGrpcManager : IDisposable
         }
 
         channelOptions.Credentials = ChannelCredentials.SecureSsl;
+        channelOptions.MaxReceiveMessageSize = Internal.Utils.DEFAULT_MAX_MESSAGE_SIZE;
+        channelOptions.MaxSendMessageSize = Internal.Utils.DEFAULT_MAX_MESSAGE_SIZE;
+
 #if USE_GRPC_WEB
         channelOptions.HttpHandler = new GrpcWebHandler(new HttpClientHandler());
 #endif

--- a/src/Momento.Sdk/Internal/Utils.cs
+++ b/src/Momento.Sdk/Internal/Utils.cs
@@ -14,6 +14,11 @@ namespace Momento.Sdk.Internal;
 public static class Utils
 {
     /// <summary>
+    /// The default value for max_send_message_length is 4mb.  We need to increase this to 5mb in order to support cases where users have requested a limit increase up to our maximum item size of 5mb.
+    /// </summary>
+    public const int DEFAULT_MAX_MESSAGE_SIZE = 5_243_000;
+
+    /// <summary>
     /// Convert a UTF-8 encoded string to a byte array.
     /// </summary>
     /// <param name="s">The string to convert.</param>

--- a/src/Momento.Sdk/Internal/VectorIndexControlGrpcManager.cs
+++ b/src/Momento.Sdk/Internal/VectorIndexControlGrpcManager.cs
@@ -91,7 +91,9 @@ public class VectorIndexControlGrpcManager : IDisposable
         var channelOptions = new GrpcChannelOptions
         {
             LoggerFactory = loggerFactory,
-            Credentials = ChannelCredentials.SecureSsl
+            Credentials = ChannelCredentials.SecureSsl,
+            MaxReceiveMessageSize = Internal.Utils.DEFAULT_MAX_MESSAGE_SIZE,
+            MaxSendMessageSize = Internal.Utils.DEFAULT_MAX_MESSAGE_SIZE,
         };
 #if USE_GRPC_WEB
         channelOptions.HttpHandler = new GrpcWebHandler(new HttpClientHandler());

--- a/src/Momento.Sdk/Internal/VectorIndexDataGrpcManager.cs
+++ b/src/Momento.Sdk/Internal/VectorIndexDataGrpcManager.cs
@@ -118,6 +118,9 @@ public class VectorIndexDataGrpcManager : IDisposable
         var channelOptions = config.TransportStrategy.GrpcConfig.GrpcChannelOptions;
         channelOptions.LoggerFactory ??= config.LoggerFactory;
         channelOptions.Credentials = ChannelCredentials.SecureSsl;
+        channelOptions.MaxReceiveMessageSize = Internal.Utils.DEFAULT_MAX_MESSAGE_SIZE;
+        channelOptions.MaxSendMessageSize = Internal.Utils.DEFAULT_MAX_MESSAGE_SIZE;
+
 #if USE_GRPC_WEB
         channelOptions.HttpHandler = new GrpcWebHandler(new HttpClientHandler());
 #endif


### PR DESCRIPTION
By default, grpc allows the server to receive messages up to 4mb in size. This sets the default to 5mb.

Will DRY up the code in a follow up PR that will also add keepalive settings, as per https://github.com/momentohq/dev-eco-issue-tracker/issues/658