### PR TITLE
feat: adds customization options for SocketsHttpHandler

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,7 +14,7 @@ jobs:
           - os: windows-latest
             target-framework: net6.0
           - os: windows-latest
-            target-framework: net461
+            target-framework: net462
     runs-on: ${{ matrix.os }}
     env:
       TEST_AUTH_TOKEN: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}

--- a/.github/workflows/on-push-to-main-branch.yaml
+++ b/.github/workflows/on-push-to-main-branch.yaml
@@ -12,7 +12,7 @@ jobs:
           - os: ubuntu-latest
             target-framework: net6.0
           - os: windows-latest
-            target-framework: net461
+            target-framework: net462
     runs-on: ${{ matrix.os }}
     env:
       TEST_AUTH_TOKEN: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ test-net6:
 .PHONY: test-net-framework
 ## Run unit and integration tests on the .NET Framework runtime
 test-net-framework:
-	@dotnet test -f net461
+	@dotnet test -f net462
 
 
 .PHONY: run-examples

--- a/src/Momento.Sdk/CacheClient.cs
+++ b/src/Momento.Sdk/CacheClient.cs
@@ -35,7 +35,7 @@ public class CacheClient : ICacheClient
     protected readonly IConfiguration config;
     /// <inheritdoc cref="Microsoft.Extensions.Logging.ILogger" />
     protected readonly ILogger _logger;
-    
+
     /// <summary>
     /// Async factory function to construct a Momento CacheClient with an eager connection to the
     /// Momento server. Calling the CacheClient constructor directly will not establish a connection
@@ -66,10 +66,9 @@ public class CacheClient : ICacheClient
     public CacheClient(IConfiguration config, ICredentialProvider authProvider, TimeSpan defaultTtl)
     {
         this.config = config;
-        var _loggerFactory = config.LoggerFactory;
-        this._logger = _loggerFactory.CreateLogger<CacheClient>();
+        this._logger = config.LoggerFactory.CreateLogger<CacheClient>();
         Utils.ArgumentStrictlyPositive(defaultTtl, "defaultTtl");
-        this.controlClient = new(_loggerFactory, authProvider.AuthToken, authProvider.ControlEndpoint);
+        this.controlClient = new(config, authProvider.AuthToken, authProvider.ControlEndpoint);
         this.dataClients = new List<ScsDataClient>();
         int minNumGrpcChannels = this.config.TransportStrategy.GrpcConfig.MinNumGrpcChannels;
         int currentMaxConcurrentRequests = this.config.TransportStrategy.MaxConcurrentRequests;
@@ -995,7 +994,7 @@ public class CacheClient : ICacheClient
 
         return await this.DataClient.SetFetchAsync(cacheName, setName);
     }
-    
+
     /// <inheritdoc />
     public async Task<CacheSetSampleResponse> SetSampleAsync(string cacheName, string setName, int limit)
     {

--- a/src/Momento.Sdk/Config/Configuration.cs
+++ b/src/Momento.Sdk/Config/Configuration.cs
@@ -61,6 +61,12 @@ public class Configuration : IConfiguration
         return new Configuration(LoggerFactory, RetryStrategy, Middlewares, transportStrategy);
     }
 
+    /// <inheritdoc />
+    public IConfiguration WithSocketsHttpHandlerOptions(SocketsHttpHandlerOptions options)
+    {
+        return new Configuration(LoggerFactory, RetryStrategy, Middlewares, TransportStrategy.WithSocketsHttpHandlerOptions(options));
+    }
+
     /// <summary>
     /// Add the specified middlewares to an existing instance of Configuration object in addition to already specified middlewares.
     /// </summary>

--- a/src/Momento.Sdk/Config/Configurations.cs
+++ b/src/Momento.Sdk/Config/Configurations.cs
@@ -182,10 +182,20 @@ public class Configurations
             /// </summary>
             /// <param name="loggerFactory"></param>
             /// <returns></returns>
-            public static IConfiguration Latest(ILoggerFactory? loggerFactory = null)
+            public static IConfiguration V1(ILoggerFactory? loggerFactory = null)
             {
                 return Default.V1(loggerFactory).WithSocketsHttpHandlerOptions(
                     SocketsHttpHandlerOptions.Of(pooledConnectionIdleTimeout: TimeSpan.FromMinutes(6)));
+            }
+
+            /// <summary>
+            /// Provides the latest recommended configuration for a lambda environment.
+            /// </summary>
+            /// <param name="loggerFactory"></param>
+            /// <returns></returns>
+            public static IConfiguration Latest(ILoggerFactory? loggerFactory = null)
+            {
+                return V1(loggerFactory);
             }
         }
     }

--- a/src/Momento.Sdk/Config/Configurations.cs
+++ b/src/Momento.Sdk/Config/Configurations.cs
@@ -184,7 +184,8 @@ public class Configurations
             /// <returns></returns>
             public static IConfiguration Latest(ILoggerFactory? loggerFactory = null)
             {
-                return Default.V1(loggerFactory);
+                return Default.V1(loggerFactory).WithSocketsHttpHandlerOptions(
+                    SocketsHttpHandlerOptions.Of(pooledConnectionIdleTimeout: TimeSpan.FromMinutes(6)));
             }
         }
     }

--- a/src/Momento.Sdk/Config/IConfiguration.cs
+++ b/src/Momento.Sdk/Config/IConfiguration.cs
@@ -44,6 +44,13 @@ public interface IConfiguration
     public IConfiguration WithTransportStrategy(ITransportStrategy transportStrategy);
 
     /// <summary>
+    /// Creates a new instance of the Configuration object, updated to use the specified SocketHttpHandler options.
+    /// </summary>
+    /// <param name="options">Customizations to the SocketsHttpHandler</param>
+    /// <returns></returns>
+    public IConfiguration WithSocketsHttpHandlerOptions(SocketsHttpHandlerOptions options);
+
+    /// <summary>
     /// Creates a new instance of the Configuration object, updated to use the specified client timeout.
     /// </summary>
     /// <param name="clientTimeout">The amount of time to wait before cancelling the request.</param>

--- a/src/Momento.Sdk/Config/Transport/IGrpcConfiguration.cs
+++ b/src/Momento.Sdk/Config/Transport/IGrpcConfiguration.cs
@@ -34,6 +34,15 @@ public interface IGrpcConfiguration
     public GrpcChannelOptions GrpcChannelOptions { get; }
 
     /// <summary>
+    /// Override the SocketsHttpHandler's options.
+    /// This is irrelevant if the client is using the web client or the HttpClient (older .NET runtimes).
+    /// </summary>
+    /// <remarks>
+    /// This is not part of the gRPC config because it is not part of <see cref="GrpcChannelOptions"/>.
+    /// </remarks>
+    public SocketsHttpHandlerOptions SocketsHttpHandlerOptions { get; }
+
+    /// <summary>
     /// Copy constructor to override the Deadline
     /// </summary>
     /// <param name="deadline"></param>
@@ -54,4 +63,11 @@ public interface IGrpcConfiguration
     /// <param name="grpcChannelOptions"></param>
     /// <returns>A new IGrpcConfiguration with the specified channel options</returns>
     public IGrpcConfiguration WithGrpcChannelOptions(GrpcChannelOptions grpcChannelOptions);
+
+    /// <summary>
+    /// Copy constructor to override the SocketsHttpHandler's options.
+    /// </summary>
+    /// <param name="idleTimeout"></param>
+    /// <returns></returns>
+    public IGrpcConfiguration WithSocketsHttpHandlerOptions(SocketsHttpHandlerOptions idleTimeout);
 }

--- a/src/Momento.Sdk/Config/Transport/ITransportStrategy.cs
+++ b/src/Momento.Sdk/Config/Transport/ITransportStrategy.cs
@@ -37,6 +37,13 @@ public interface ITransportStrategy
     public ITransportStrategy WithGrpcConfig(IGrpcConfiguration grpcConfig);
 
     /// <summary>
+    /// Copy constructor to update the SocketsHttpHandler's options
+    /// </summary>
+    /// <param name="options"></param>
+    /// <returns></returns>
+    public ITransportStrategy WithSocketsHttpHandlerOptions(SocketsHttpHandlerOptions options);
+
+    /// <summary>
     /// Copy constructor to update the client timeout
     /// </summary>
     /// <param name="clientTimeout"></param>

--- a/src/Momento.Sdk/Config/Transport/SocketsHttpHandlerOptions.cs
+++ b/src/Momento.Sdk/Config/Transport/SocketsHttpHandlerOptions.cs
@@ -1,0 +1,66 @@
+#pragma warning disable 1591
+using System;
+using Momento.Sdk.Internal;
+namespace Momento.Sdk.Config.Transport;
+
+public class SocketsHttpHandlerOptions
+{
+    public static TimeSpan DefaultPooledConnectionIdleTimeout { get; } = TimeSpan.FromMinutes(1);
+    public TimeSpan PooledConnectionIdleTimeout { get; } = DefaultPooledConnectionIdleTimeout;
+    public bool EnableMultipleHttp2Connections { get; } = true;
+
+    public SocketsHttpHandlerOptions() { }
+    public SocketsHttpHandlerOptions(TimeSpan pooledConnectionIdleTimeout) : this(pooledConnectionIdleTimeout, true) { }
+    public SocketsHttpHandlerOptions(bool enableMultipleHttp2Connections) : this(DefaultPooledConnectionIdleTimeout, enableMultipleHttp2Connections) { }
+
+    public SocketsHttpHandlerOptions(TimeSpan pooledConnectionIdleTimeout, bool enableMultipleHttp2Connections)
+    {
+        Utils.ArgumentStrictlyPositive(pooledConnectionIdleTimeout, nameof(pooledConnectionIdleTimeout));
+        PooledConnectionIdleTimeout = pooledConnectionIdleTimeout;
+        EnableMultipleHttp2Connections = enableMultipleHttp2Connections;
+    }
+
+    public SocketsHttpHandlerOptions WithPooledConnectionIdleTimeout(TimeSpan pooledConnectionIdleTimeout)
+    {
+        return new SocketsHttpHandlerOptions(pooledConnectionIdleTimeout, EnableMultipleHttp2Connections);
+    }
+
+    public SocketsHttpHandlerOptions WithEnableMultipleHttp2Connections(bool enableMultipleHttp2Connections)
+    {
+        return new SocketsHttpHandlerOptions(PooledConnectionIdleTimeout, enableMultipleHttp2Connections);
+    }
+
+    public static SocketsHttpHandlerOptions Of(TimeSpan pooledConnectionIdleTimeout)
+    {
+        return new SocketsHttpHandlerOptions(pooledConnectionIdleTimeout);
+    }
+
+    public static SocketsHttpHandlerOptions Of(bool enableMultipleHttp2Connections)
+    {
+        return new SocketsHttpHandlerOptions(enableMultipleHttp2Connections);
+    }
+
+    public static SocketsHttpHandlerOptions Of(TimeSpan pooledConnectionIdleTimeout, bool enableMultipleHttp2Connections)
+    {
+        return new SocketsHttpHandlerOptions(pooledConnectionIdleTimeout, enableMultipleHttp2Connections);
+    }
+
+    public override bool Equals(object obj)
+    {
+        if (obj == null || GetType() != obj.GetType())
+        {
+            return false;
+        }
+
+        var other = (SocketsHttpHandlerOptions)obj;
+        return PooledConnectionIdleTimeout.Equals(other.PooledConnectionIdleTimeout) &&
+            EnableMultipleHttp2Connections.Equals(other.EnableMultipleHttp2Connections);
+    }
+
+    public override int GetHashCode()
+    {
+        return PooledConnectionIdleTimeout.GetHashCode() * 17 + EnableMultipleHttp2Connections.GetHashCode();
+    }
+
+
+}

--- a/src/Momento.Sdk/ITopicClient.cs
+++ b/src/Momento.Sdk/ITopicClient.cs
@@ -1,6 +1,4 @@
 using System;
-#if NETSTANDARD2_0_OR_GREATER
-
 
 using System.Threading.Tasks;
 using Momento.Sdk.Responses;
@@ -36,7 +34,7 @@ public interface ITopicClient : IDisposable
     /// </code>
     /// </returns>
     public Task<TopicPublishResponse> PublishAsync(string cacheName, string topicName, byte[] value);
-    
+
     /// <inheritdoc cref="PublishAsync(string, string, byte[])"/>
     public Task<TopicPublishResponse> PublishAsync(string cacheName, string topicName, string value);
 
@@ -66,4 +64,3 @@ public interface ITopicClient : IDisposable
     /// </returns>
     public Task<TopicSubscribeResponse> SubscribeAsync(string cacheName, string topicName, ulong? resumeAtSequenceNumber = null);
 }
-#endif

--- a/src/Momento.Sdk/Internal/LoggingUtils.cs
+++ b/src/Momento.Sdk/Internal/LoggingUtils.cs
@@ -379,8 +379,6 @@ namespace Momento.Sdk.Internal
             }
             return success;
         }
-        
-#if NETSTANDARD2_0_OR_GREATER
 
         /// <summary>
         /// Logs a message at TRACE level that indicates that a topic request is about to be executed.
@@ -396,7 +394,7 @@ namespace Momento.Sdk.Internal
                 logger.LogTrace("Executing '{}' request: cacheName: {}; topicName: {}", requestType, cacheName, topicName);
             }
         }
-        
+
         /// <summary>
         /// Logs a message at TRACE level that indicates that a topic request resulted in an error.
         /// </summary>
@@ -435,7 +433,7 @@ namespace Momento.Sdk.Internal
             }
             return success;
         }
-        
+
         /// <summary>
         /// Logs a message at TRACE level that indicates that a topic message was received.
         /// </summary>
@@ -450,7 +448,7 @@ namespace Momento.Sdk.Internal
                 logger.LogTrace("Received '{}' message on: cacheName: {}; topicName: {}", messageType, cacheName, topicName);
             }
         }
-        
+
         /// <summary>
         /// Logs a message at TRACE level that indicates that a discontinuity was received.
         /// </summary>
@@ -466,7 +464,7 @@ namespace Momento.Sdk.Internal
                 logger.LogTrace("Received discontinuity: cacheName: {}; topicName: {}, lastSequenceNumber: {}, newSequenceNumber: {}", cacheName, topicName, lastSequenceNumber, newSequenceNumber);
             }
         }
-        
+
         /// <summary>
         /// Logs a message at TRACE level that indicates that a topic subscription received an error.
         /// </summary>
@@ -484,7 +482,6 @@ namespace Momento.Sdk.Internal
             }
             return error;
         }
-#endif
 
         /// <summary>
         /// Logs a message at TRACE level that indicates that an request is about to be executed.
@@ -565,7 +562,7 @@ namespace Momento.Sdk.Internal
             }
             return error;
         }
-        
+
         /// <summary>
         /// Logs a message at TRACE level that indicates that a vector index request resulted in a success.
         /// </summary>

--- a/src/Momento.Sdk/Internal/ScsControlClient.cs
+++ b/src/Momento.Sdk/Internal/ScsControlClient.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Grpc.Core;
 using Microsoft.Extensions.Logging;
 using Momento.Protos.ControlClient;
+using Momento.Sdk.Config;
 using Momento.Sdk.Exceptions;
 using Momento.Sdk.Responses;
 
@@ -17,12 +18,12 @@ internal sealed class ScsControlClient : IDisposable
     private readonly ILogger _logger;
     private readonly CacheExceptionMapper _exceptionMapper;
 
-    public ScsControlClient(ILoggerFactory loggerFactory, string authToken, string endpoint)
+    public ScsControlClient(IConfiguration config, string authToken, string endpoint)
     {
-        this.grpcManager = new ControlGrpcManager(loggerFactory, authToken, endpoint);
+        this.grpcManager = new ControlGrpcManager(config, authToken, endpoint);
         this.authToken = authToken;
-        this._logger = loggerFactory.CreateLogger<ScsControlClient>();
-        this._exceptionMapper = new CacheExceptionMapper(loggerFactory);
+        this._logger = config.LoggerFactory.CreateLogger<ScsControlClient>();
+        this._exceptionMapper = new CacheExceptionMapper(config.LoggerFactory);
     }
 
     public async Task<CreateCacheResponse> CreateCacheAsync(string cacheName)

--- a/src/Momento.Sdk/Internal/ScsTopicClient.cs
+++ b/src/Momento.Sdk/Internal/ScsTopicClient.cs
@@ -1,7 +1,5 @@
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 
-#if NETSTANDARD2_0_OR_GREATER
-
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -287,4 +285,3 @@ internal sealed class ScsTopicClient : ScsTopicClientBase
         }
     }
 }
-#endif

--- a/src/Momento.Sdk/Internal/TopicGrpcManager.cs
+++ b/src/Momento.Sdk/Internal/TopicGrpcManager.cs
@@ -1,7 +1,5 @@
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 
-#if NETSTANDARD2_0_OR_GREATER
-
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -135,4 +133,3 @@ public class TopicGrpcManager : IDisposable
         GC.SuppressFinalize(this);
     }
 }
-#endif

--- a/src/Momento.Sdk/Momento.Sdk.csproj
+++ b/src/Momento.Sdk/Momento.Sdk.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<!-- Build Configuration -->
-		<TargetFrameworks>netstandard2.0;net6.0;net461</TargetFrameworks>
+		<TargetFrameworks>netstandard2.0;net6.0;net462</TargetFrameworks>
 		<LangVersion>latest</LangVersion>
 		<Nullable>enable</Nullable>
 		<!-- Microsoft.Bcl.AsyncInterfaces on net461 isn't supported; suppress warning -->

--- a/src/Momento.Sdk/Momento.Sdk.csproj
+++ b/src/Momento.Sdk/Momento.Sdk.csproj
@@ -5,8 +5,6 @@
 		<TargetFrameworks>netstandard2.0;net6.0;net462</TargetFrameworks>
 		<LangVersion>latest</LangVersion>
 		<Nullable>enable</Nullable>
-		<!-- Microsoft.Bcl.AsyncInterfaces on net461 isn't supported; suppress warning -->
-		<SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
 		<!-- Include documentation in build -->
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<!-- Include source and debug symbols-->
@@ -33,9 +31,9 @@
 	</PropertyGroup>
 
 	<!-- Because .NET Framework doesn't support HTTP/2, we use gRPC-Web over HTTP/1.1.
-		 Dependency resolution: .NET Framework binaries or libraries >= v4.61 that link
-		 to Momento.Sdk will link to the .NET Framework 4.61 build. -->
-	<PropertyGroup Condition="'$(TargetFramework)' == 'net461' ">
+		 Dependency resolution: .NET Framework binaries or libraries >= v4.62 that link
+		 to Momento.Sdk will link to the .NET Framework 4.62 build. -->
+	<PropertyGroup Condition="'$(TargetFramework)' == 'net462' ">
     	<DefineConstants>USE_GRPC_WEB</DefineConstants>
   	</PropertyGroup>
 

--- a/src/Momento.Sdk/Momento.Sdk.csproj
+++ b/src/Momento.Sdk/Momento.Sdk.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<!-- Build Configuration -->
-		<TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+		<TargetFrameworks>netstandard2.0;net6.0;net461</TargetFrameworks>
 		<LangVersion>latest</LangVersion>
 		<Nullable>enable</Nullable>
 		<!-- Microsoft.Bcl.AsyncInterfaces on net461 isn't supported; suppress warning -->

--- a/src/Momento.Sdk/Responses/TopicMessage.cs
+++ b/src/Momento.Sdk/Responses/TopicMessage.cs
@@ -1,5 +1,3 @@
-#if NETSTANDARD2_0_OR_GREATER
-
 using Momento.Protos.CacheClient.Pubsub;
 using Momento.Sdk.Exceptions;
 
@@ -53,14 +51,14 @@ public abstract class TopicMessage
         /// The text value of this message.
         /// </summary>
         public string Value { get; }
-        
+
         /// <summary>
         /// The TokenId that was used to publish the message, or null if the token did not have an id.
         /// This can be used to securely identify the sender of a message.
         /// </summary>
         public string? TokenId { get; }
     }
-    
+
     /// <summary>
     /// A topic message containing a binary value.
     /// </summary>
@@ -79,7 +77,7 @@ public abstract class TopicMessage
         /// The binary value of this message.
         /// </summary>
         public byte[] Value { get; }
-        
+
         /// <summary>
         /// The TokenId that was used to publish the message, or null if the token did not have an id.
         /// This can be used to securely identify the sender of a message.
@@ -115,4 +113,3 @@ public abstract class TopicMessage
 
     }
 }
-#endif

--- a/src/Momento.Sdk/Responses/TopicPublishResponse.cs
+++ b/src/Momento.Sdk/Responses/TopicPublishResponse.cs
@@ -1,5 +1,3 @@
-#if NETSTANDARD2_0_OR_GREATER
-
 using Momento.Sdk.Exceptions;
 
 namespace Momento.Sdk.Responses;
@@ -32,7 +30,7 @@ namespace Momento.Sdk.Responses;
 public abstract class TopicPublishResponse
 {
     /// <include file="../docs.xml" path='docs/class[@name="Success"]/description/*' />
-    public class Success : TopicPublishResponse {}
+    public class Success : TopicPublishResponse { }
 
     /// <include file="../docs.xml" path='docs/class[@name="Error"]/description/*' />
     public class Error : TopicPublishResponse, IError
@@ -62,4 +60,3 @@ public abstract class TopicPublishResponse
 
     }
 }
-#endif

--- a/src/Momento.Sdk/Responses/TopicSubscribeResponse.cs
+++ b/src/Momento.Sdk/Responses/TopicSubscribeResponse.cs
@@ -1,5 +1,3 @@
-#if NETSTANDARD2_0_OR_GREATER
-
 using System;
 using System.Collections.Generic;
 using System.Threading;
@@ -103,7 +101,7 @@ public abstract class TopicSubscribeResponse
                 Current = null;
                 return false;
             }
-            
+
             var nextMessage = await _moveNextFunction.Invoke(_enumeratorCancellationToken);
             switch (nextMessage)
             {
@@ -153,4 +151,3 @@ public abstract class TopicSubscribeResponse
         }
     }
 }
-#endif

--- a/src/Momento.Sdk/TopicClient.cs
+++ b/src/Momento.Sdk/TopicClient.cs
@@ -1,5 +1,3 @@
-#if NETSTANDARD2_0_OR_GREATER
-
 using System;
 using System.Threading.Tasks;
 using Momento.Sdk.Auth;
@@ -16,8 +14,8 @@ namespace Momento.Sdk;
 public class TopicClient : ITopicClient
 {
     private readonly ScsTopicClient scsTopicClient;
-    
-    
+
+
     /// <summary>
     /// Client to perform operations against Momento topics.
     /// </summary>
@@ -74,11 +72,10 @@ public class TopicClient : ITopicClient
         }
         return await scsTopicClient.Subscribe(cacheName, topicName, resumeAtSequenceNumber);
     }
-    
+
     /// <inheritdoc />
     public void Dispose()
     {
         scsTopicClient.Dispose();
     }
 }
-#endif

--- a/tests/Integration/Momento.Sdk.Tests/AuthClientTopicTest.cs
+++ b/tests/Integration/Momento.Sdk.Tests/AuthClientTopicTest.cs
@@ -1,5 +1,3 @@
-#if NET6_0_OR_GREATER
-
 using System.Threading.Tasks;
 using System.Threading;
 using Momento.Sdk.Auth;
@@ -585,4 +583,3 @@ public class AuthClientTopicTest : IClassFixture<CacheClientFixture>, IClassFixt
         }
     }
 }
-#endif

--- a/tests/Integration/Momento.Sdk.Tests/Fixtures.cs
+++ b/tests/Integration/Momento.Sdk.Tests/Fixtures.cs
@@ -52,13 +52,12 @@ public class CacheClientCollection : ICollectionFixture<CacheClientFixture>
 
 }
 
-#if NET6_0_OR_GREATER
 public class TopicClientFixture : IDisposable
 {
     public ITopicClient Client { get; private set; }
     public ICredentialProvider AuthProvider { get; private set; }
 
-    
+
     public TopicClientFixture()
     {
         AuthProvider = new EnvMomentoTokenProvider("TEST_AUTH_TOKEN");
@@ -89,7 +88,6 @@ public class TopicClientCollection : ICollectionFixture<TopicClientFixture>
 {
 
 }
-#endif
 
 public class AuthClientFixture : IDisposable
 {

--- a/tests/Integration/Momento.Sdk.Tests/Momento.Sdk.Tests.Integration.csproj
+++ b/tests/Integration/Momento.Sdk.Tests/Momento.Sdk.Tests.Integration.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net461</TargetFrameworks>
+    <TargetFrameworks>net6.0;net462</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>

--- a/tests/Integration/Momento.Sdk.Tests/Momento.Sdk.Tests.Integration.csproj
+++ b/tests/Integration/Momento.Sdk.Tests/Momento.Sdk.Tests.Integration.csproj
@@ -5,9 +5,6 @@
     <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
-    <!-- We get some warnings for the logger (used only in the tests) on net461.
-         These are safe to ignore -->
-    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
     <!-- Because this assembly targets multiple versions, and the test runner runs
          the target frameworks sequentially, we get spurious warnings about multiple
          versions of dependencies -->

--- a/tests/Unit/Momento.Sdk.Tests/Momento.Sdk.Tests.Unit.csproj
+++ b/tests/Unit/Momento.Sdk.Tests/Momento.Sdk.Tests.Unit.csproj
@@ -1,13 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net461</TargetFrameworks>
+    <TargetFrameworks>net6.0;net462</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
-    <!-- We get some warnings for the logger (used only in the tests) on net461.
-        These are safe to ignore -->
-    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
     <!-- Because this assembly targets multiple versions, and the test runner runs
          the target frameworks sequentially, we get spurious warnings about multiple
          versions of dependencies -->


### PR DESCRIPTION
# Overview
1. Add SocketHttpHandler config options and plumb through.
2. Set Lambda config to use `SocketHttpHandler.PooledConnectionIdleTimeout` 
    of 6 minutes. 
3. Add target frameworks for .NET 6.0 and bump target framework net461
    to net462 for async iterator support.

# SocketHttpHandler config
In `Grpc.Net.Client`, the default HttpHandler on .NET runtimes .NET
5.0 or greater is `SocketsHttpHandler`. In this PR we create a new
options class to encapsulate customizations to the handler, most
importantly the pooled connection timeout and whether to enable
multiple http connections.

# Lambda config
The default value for the idle connection timeout is 1 minute. We find
this too strict in lambda environments, where the container may freeze
and thaw in greater than 1 minute spans but less than the server
timeout (5 minutes as of writing). Therefore we set the lambda config
pooled connection idle timeout higher, to 6 minutes. That way a lambda
function will not needlessly reconnect when the connection is still
open.

# Target framework
Previously we relied on .NET Framework 4.61 as the .NET Framework
target. The next minor version introduced async iterator features
necessary for the topic client. Because of this, at the time, we added
preprocessor directives to exclude the topic client if the build target
wasn't .NET Standard 2.0 or greater.

Now that we add another target framework, .NET 6.0, maintaining the
different platform directives is difficult. Instead we bump the Framework
target from net461 to net462 to gain the async iterators and remove
the platform conditional compilation directives. There is no customer
impact by removing exactly .NET 4.61 as a target framework.

.NET 4.62 also includes `WinHttpHandler`, so we can revisit the use of
gRPC web in that Framework.