### PR TITLE
chore: remove socket option modifier from configuration

### DIFF
--- a/src/Momento.Sdk/Config/Configuration.cs
+++ b/src/Momento.Sdk/Config/Configuration.cs
@@ -61,12 +61,6 @@ public class Configuration : IConfiguration
         return new Configuration(LoggerFactory, RetryStrategy, Middlewares, transportStrategy);
     }
 
-    /// <inheritdoc />
-    public IConfiguration WithSocketsHttpHandlerOptions(SocketsHttpHandlerOptions options)
-    {
-        return new Configuration(LoggerFactory, RetryStrategy, Middlewares, TransportStrategy.WithSocketsHttpHandlerOptions(options));
-    }
-
     /// <summary>
     /// Add the specified middlewares to an existing instance of Configuration object in addition to already specified middlewares.
     /// </summary>

--- a/src/Momento.Sdk/Config/Configurations.cs
+++ b/src/Momento.Sdk/Config/Configurations.cs
@@ -184,8 +184,10 @@ public class Configurations
             /// <returns></returns>
             public static IConfiguration V1(ILoggerFactory? loggerFactory = null)
             {
-                return Default.V1(loggerFactory).WithSocketsHttpHandlerOptions(
+                var config = Default.V1(loggerFactory);
+                var transportStrategy = config.TransportStrategy.WithSocketsHttpHandlerOptions(
                     SocketsHttpHandlerOptions.Of(pooledConnectionIdleTimeout: TimeSpan.FromMinutes(6)));
+                return config.WithTransportStrategy(transportStrategy);
             }
 
             /// <summary>

--- a/src/Momento.Sdk/Config/IConfiguration.cs
+++ b/src/Momento.Sdk/Config/IConfiguration.cs
@@ -44,13 +44,6 @@ public interface IConfiguration
     public IConfiguration WithTransportStrategy(ITransportStrategy transportStrategy);
 
     /// <summary>
-    /// Creates a new instance of the Configuration object, updated to use the specified SocketHttpHandler options.
-    /// </summary>
-    /// <param name="options">Customizations to the SocketsHttpHandler</param>
-    /// <returns></returns>
-    public IConfiguration WithSocketsHttpHandlerOptions(SocketsHttpHandlerOptions options);
-
-    /// <summary>
     /// Creates a new instance of the Configuration object, updated to use the specified client timeout.
     /// </summary>
     /// <param name="clientTimeout">The amount of time to wait before cancelling the request.</param>


### PR DESCRIPTION
Previously we had added a copy factory to `Configuration` to change
`SocketHttpHandlerOptions`. While tihs was for the convenience of the
`Configurations` code, this exposed a low level detail to the top
level of `Configuration`, which is undesirable.

We remove that in this PR. Since the previous code using it was wholly
encapsulated in `Configurations`, this does not break other code.
