### PR TITLE
chore: add is supported guard for SocketsHttpHandler

### DIFF
--- a/src/Momento.Sdk/Internal/ControlGrpcManager.cs
+++ b/src/Momento.Sdk/Internal/ControlGrpcManager.cs
@@ -95,21 +95,26 @@ internal sealed class ControlGrpcManager : IDisposable
         endpoint = $"web.{endpoint}";
 #endif
         var uri = $"https://{endpoint}";
-        this.channel = GrpcChannel.ForAddress(uri, new GrpcChannelOptions()
+
+        var channelOptions = new GrpcChannelOptions()
         {
             Credentials = ChannelCredentials.SecureSsl,
             MaxReceiveMessageSize = Internal.Utils.DEFAULT_MAX_MESSAGE_SIZE,
             MaxSendMessageSize = Internal.Utils.DEFAULT_MAX_MESSAGE_SIZE,
+        };
 #if NET5_0_OR_GREATER
-            HttpHandler = new System.Net.Http.SocketsHttpHandler
+        if (SocketsHttpHandler.IsSupported)
+        {
+            channelOptions.HttpHandler = new SocketsHttpHandler
             {
                 EnableMultipleHttp2Connections = config.TransportStrategy.GrpcConfig.SocketsHttpHandlerOptions.EnableMultipleHttp2Connections,
                 PooledConnectionIdleTimeout = config.TransportStrategy.GrpcConfig.SocketsHttpHandlerOptions.PooledConnectionIdleTimeout
-            }
+            };
+        }
 #elif USE_GRPC_WEB
-            HttpHandler = new GrpcWebHandler(new HttpClientHandler())
+        channelOptions.HttpHandler = new GrpcWebHandler(new HttpClientHandler());
 #endif
-        });
+        this.channel = GrpcChannel.ForAddress(uri, channelOptions);
         List<Header> headers = new List<Header> { new Header(name: Header.AuthorizationKey, value: authToken), new Header(name: Header.AgentKey, value: version), new Header(name: Header.RuntimeVersionKey, value: runtimeVersion) };
         CallInvoker invoker = this.channel.CreateCallInvoker();
 

--- a/src/Momento.Sdk/Internal/ControlGrpcManager.cs
+++ b/src/Momento.Sdk/Internal/ControlGrpcManager.cs
@@ -103,7 +103,8 @@ internal sealed class ControlGrpcManager : IDisposable
             MaxSendMessageSize = Internal.Utils.DEFAULT_MAX_MESSAGE_SIZE,
         };
 #if NET5_0_OR_GREATER
-        if (SocketsHttpHandler.IsSupported)
+
+        if (SocketsHttpHandler.IsSupported) // see: https://github.com/grpc/grpc-dotnet/blob/098dca892a3949ade411c3f2f66003f7b330dfd2/src/Shared/HttpHandlerFactory.cs#L28-L30
         {
             channelOptions.HttpHandler = new SocketsHttpHandler
             {

--- a/src/Momento.Sdk/Internal/ControlGrpcManager.cs
+++ b/src/Momento.Sdk/Internal/ControlGrpcManager.cs
@@ -96,7 +96,7 @@ internal sealed class ControlGrpcManager : IDisposable
 #endif
         var uri = $"https://{endpoint}";
 
-        var channelOptions = new GrpcChannelOptions()
+        var channelOptions = new GrpcChannelOptions
         {
             Credentials = ChannelCredentials.SecureSsl,
             MaxReceiveMessageSize = Internal.Utils.DEFAULT_MAX_MESSAGE_SIZE,

--- a/src/Momento.Sdk/Internal/DataGrpcManager.cs
+++ b/src/Momento.Sdk/Internal/DataGrpcManager.cs
@@ -285,7 +285,7 @@ public class DataGrpcManager : IDisposable
         channelOptions.MaxSendMessageSize = Internal.Utils.DEFAULT_MAX_MESSAGE_SIZE;
 
 #if NET5_0_OR_GREATER
-        if (SocketsHttpHandler.IsSupported)
+        if (SocketsHttpHandler.IsSupported)  // see: https://github.com/grpc/grpc-dotnet/blob/098dca892a3949ade411c3f2f66003f7b330dfd2/src/Shared/HttpHandlerFactory.cs#L28-L30
         {
             channelOptions.HttpHandler = new SocketsHttpHandler
             {

--- a/src/Momento.Sdk/Internal/DataGrpcManager.cs
+++ b/src/Momento.Sdk/Internal/DataGrpcManager.cs
@@ -285,11 +285,14 @@ public class DataGrpcManager : IDisposable
         channelOptions.MaxSendMessageSize = Internal.Utils.DEFAULT_MAX_MESSAGE_SIZE;
 
 #if NET5_0_OR_GREATER
-        channelOptions.HttpHandler = new SocketsHttpHandler
+        if (SocketsHttpHandler.IsSupported)
         {
-            EnableMultipleHttp2Connections = config.TransportStrategy.GrpcConfig.SocketsHttpHandlerOptions.EnableMultipleHttp2Connections,
-            PooledConnectionIdleTimeout = config.TransportStrategy.GrpcConfig.SocketsHttpHandlerOptions.PooledConnectionIdleTimeout
-        };
+            channelOptions.HttpHandler = new SocketsHttpHandler
+            {
+                EnableMultipleHttp2Connections = config.TransportStrategy.GrpcConfig.SocketsHttpHandlerOptions.EnableMultipleHttp2Connections,
+                PooledConnectionIdleTimeout = config.TransportStrategy.GrpcConfig.SocketsHttpHandlerOptions.PooledConnectionIdleTimeout
+            };
+        }
 #elif USE_GRPC_WEB
         channelOptions.HttpHandler = new GrpcWebHandler(new HttpClientHandler());
 #endif


### PR DESCRIPTION
In some runtimes, even though `SocketsHttpHandler` is included in the
runtime it is not supported. Thus we add guards to test for this and
let the gRPC client fall back to a supported one.
