### PR TITLE
feat: drop grpc-web for .NET 4.62 build.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,6 +14,7 @@ jobs:
         include:
           - os: windows-latest
             target-framework: net462
+            grpc-web: [false, true]
     runs-on: ${{ matrix.os }}
     env:
       TEST_AUTH_TOKEN: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,12 +8,10 @@ jobs:
   build_csharp:
     strategy:
       matrix:
+        os: [ubuntu-latest, windows-latest]
+        target-framework: net6.0
         grpc-web: [false, true]
         include:
-          - os: ubuntu-latest
-            target-framework: net6.0
-          - os: windows-latest
-            target-framework: net6.0
           - os: windows-latest
             target-framework: net462
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        target-framework: net6.0
+        target-framework: [net6.0]
         grpc-web: [false, true]
         include:
           - os: windows-latest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -48,7 +48,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build
-        run: dotnet build ${{ matrix.grpc-web == 'true' && '-p:DefineConstants=USE_GRPC_WEB' || '' }}
+        run: dotnet build ${{ matrix.grpc-web && '-p:DefineConstants=USE_GRPC_WEB' || '' }}
 
       - name: Unit Test
         run: dotnet test --logger "console;verbosity=detailed" -f ${{ matrix.target-framework }} tests/Unit/Momento.Sdk.Tests

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,6 +8,7 @@ jobs:
   build_csharp:
     strategy:
       matrix:
+        grpc-web: [false, true]
         include:
           - os: ubuntu-latest
             target-framework: net6.0
@@ -47,7 +48,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build
-        run: dotnet build
+        run: dotnet build ${{ matrix.grpc-web == 'true' && '-p:DefineConstants=USE_GRPC_WEB' || '' }}
 
       - name: Unit Test
         run: dotnet test --logger "console;verbosity=detailed" -f ${{ matrix.target-framework }} tests/Unit/Momento.Sdk.Tests

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,7 +14,10 @@ jobs:
         include:
           - os: windows-latest
             target-framework: net462
-            grpc-web: [false, true]
+            grpc-web: false
+          - os: windows-latest
+            target-framework: net462
+            grpc-web: true
     runs-on: ${{ matrix.os }}
     env:
       TEST_AUTH_TOKEN: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}

--- a/.github/workflows/on-push-to-main-branch.yaml
+++ b/.github/workflows/on-push-to-main-branch.yaml
@@ -14,6 +14,7 @@ jobs:
         include:
           - os: windows-latest
             target-framework: net462
+            grpc-web: [false, true]
     runs-on: ${{ matrix.os }}
     env:
       TEST_AUTH_TOKEN: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}

--- a/.github/workflows/on-push-to-main-branch.yaml
+++ b/.github/workflows/on-push-to-main-branch.yaml
@@ -35,7 +35,7 @@ jobs:
           dotnet-version: "6.0.x"
 
       - name: Build
-        run: dotnet build ${{ matrix.grpc-web == 'true' && '-p:DefineConstants=USE_GRPC_WEB' || '' }}
+        run: dotnet build ${{ matrix.grpc-web && '-p:DefineConstants=USE_GRPC_WEB' || '' }}
 
       - name: Unit Test
         run: dotnet test -f ${{ matrix.target-framework }} tests/Unit/Momento.Sdk.Tests

--- a/.github/workflows/on-push-to-main-branch.yaml
+++ b/.github/workflows/on-push-to-main-branch.yaml
@@ -8,8 +8,11 @@ jobs:
   build_csharp:
     strategy:
       matrix:
+        grpc-web: [false, true]
         include:
           - os: ubuntu-latest
+            target-framework: net6.0
+          - os: windows-latest
             target-framework: net6.0
           - os: windows-latest
             target-framework: net462
@@ -32,7 +35,7 @@ jobs:
           dotnet-version: "6.0.x"
 
       - name: Build
-        run: dotnet build
+        run: dotnet build ${{ matrix.grpc-web == 'true' && '-p:DefineConstants=USE_GRPC_WEB' || '' }}
 
       - name: Unit Test
         run: dotnet test -f ${{ matrix.target-framework }} tests/Unit/Momento.Sdk.Tests

--- a/.github/workflows/on-push-to-main-branch.yaml
+++ b/.github/workflows/on-push-to-main-branch.yaml
@@ -8,12 +8,10 @@ jobs:
   build_csharp:
     strategy:
       matrix:
+        os: [ubuntu-latest, windows-latest]
+        target-framework: net6.0
         grpc-web: [false, true]
         include:
-          - os: ubuntu-latest
-            target-framework: net6.0
-          - os: windows-latest
-            target-framework: net6.0
           - os: windows-latest
             target-framework: net462
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/on-push-to-main-branch.yaml
+++ b/.github/workflows/on-push-to-main-branch.yaml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        target-framework: net6.0
+        target-framework: [net6.0]
         grpc-web: [false, true]
         include:
           - os: windows-latest

--- a/.github/workflows/on-push-to-main-branch.yaml
+++ b/.github/workflows/on-push-to-main-branch.yaml
@@ -14,7 +14,10 @@ jobs:
         include:
           - os: windows-latest
             target-framework: net462
-            grpc-web: [false, true]
+            grpc-web: false
+          - os: windows-latest
+            target-framework: net462
+            grpc-web: true
     runs-on: ${{ matrix.os }}
     env:
       TEST_AUTH_TOKEN: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}

--- a/src/Momento.Sdk/Momento.Sdk.csproj
+++ b/src/Momento.Sdk/Momento.Sdk.csproj
@@ -30,13 +30,6 @@
 		<RepositoryUrl>https://github.com/momentohq/client-sdk-dotnet</RepositoryUrl>
 	</PropertyGroup>
 
-	<!-- Because .NET Framework doesn't support HTTP/2, we use gRPC-Web over HTTP/1.1.
-		 Dependency resolution: .NET Framework binaries or libraries >= v4.62 that link
-		 to Momento.Sdk will link to the .NET Framework 4.62 build. -->
-	<PropertyGroup Condition="'$(TargetFramework)' == 'net462' ">
-    	<DefineConstants>USE_GRPC_WEB</DefineConstants>
-  	</PropertyGroup>
-
 	<ItemGroup>
 	  <None Remove="System.Threading.Channels" />
 	  <None Remove="Internal\Middleware\" />
@@ -66,7 +59,7 @@
 	  <PackageReference Include="System.Threading" Version="4.3.0" />
 	</ItemGroup>
 	<ItemGroup Condition=" $(DefineConstants.Contains('USE_GRPC_WEB')) ">
-	  <!-- Because .NET Framework does not support HTTP/2, we fall back to gRPC-Web over HTTP/1.1 -->
+	  <!-- Currently the Unity build needs gRPC-Web -->
 	  <PackageReference Include="Grpc.Net.Client.Web" Version="2.52.0" />
 	</ItemGroup>
 	<ProjectExtensions>


### PR DESCRIPTION
Since we bumped the minimum .NET Framework build version from 4.61 to
4.62, we gained access to an Http/2 handler for .NET
Framework. Because 4.61 did not have an Http/2 handler, we had to
resort to gRPC-Web. Now we only need gRPC-Web for the Unity build.

In order to exercise the gRPC-Web build, we add that to the testing
matrix.
