### PR TITLE
chore: update readmes to use api key from console instead of auth token from cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 Momento Cache is a fast, simple, pay-as-you-go caching solution without any of the operational overhead
 required by traditional caching solutions.  This repo contains the source code for the Momento .NET client library.
 
-To get started with Momento you will need a Momento Auth Token. You can get one from the [Momento Console](https://console.gomomento.com).
+To get started with Momento you will need a Momento API key. You can get one from the [Momento Console](https://console.gomomento.com/api-keys).
 
 * Website: [https://www.gomomento.com/](https://www.gomomento.com/)
 * Momento Documentation: [https://docs.momentohq.com/](https://docs.momentohq.com/)
@@ -73,8 +73,8 @@ using (ICacheClient client = new CacheClient(Configurations.Laptop.V1(), authPro
 
 ```
 
-Note that the above code requires an environment variable named MOMENTO_AUTH_TOKEN which must
-be set to a valid [Momento authentication token](https://docs.momentohq.com/docs/getting-started#obtain-an-auth-token).
+Note that the above code requires an environment variable named MOMENTO_API_KEY which must
+be set to a valid [Momento authentication token](https://docs.momentohq.com/cache/develop/authentication/api-keys).
 
 ## Getting Started and Documentation
 

--- a/examples/DictionaryExample/README.md
+++ b/examples/DictionaryExample/README.md
@@ -4,12 +4,12 @@ This example program demonstrates usage of the dictionary data type.
 
 # Usage
 
-The program assumes the auth token and cache names are available in environment variables. The auth token is assumed to be in the variable `TEST_AUTH_TOKEN` and the cache name in `TEST_CACHE_NAME`. If either of these is missing, you will be prompted to enter the values on the terminal.
+The program assumes the auth token and cache names are available in environment variables. The auth token is assumed to be in the variable `MOMENTO_API_KEY` and the cache name in `MOMENTO_CACHE_NAME`. If either of these is missing, you will be prompted to enter the values on the terminal.
 
 To run the program, run either:
 
 ```bash
-TEST_AUTH_TOKEN=<YOUR_TOKEN_HERE> TEST_CACHE_NAME=<YOUR_CACHE_NAME_HERE> dotnet run
+MOMENTO_API_KEY=<YOUR_API_KEY_HERE> MOMENTO_CACHE_NAME=<YOUR_CACHE_NAME_HERE> dotnet run
 ```
 
 or

--- a/examples/DisposableTokens/README.md
+++ b/examples/DisposableTokens/README.md
@@ -9,7 +9,7 @@ This example program demonstrates how to generate disposable Momento auth tokens
 The program assumes that your Momento auth token is available in the `MOMENTO_API_KEY` environment variable:
 
 ```bash
-MOMENTO_API_KEY=<YOUR_AUTH_TOKEN> dotnet run
+MOMENTO_API_KEY=<YOUR_API_KEY> dotnet run
 ```
 
 The example generates a disposable expiring auth token using the enumerated permissions and expiry defined in the program and prints its attributes to the console.

--- a/examples/MomentoApplication/README.md
+++ b/examples/MomentoApplication/README.md
@@ -13,20 +13,20 @@ functionality, including:
 ## Prerequisites
 
 * [`dotnet`](https://dotnet.microsoft.com/en-us/download) 6.0 or higher is required
-* A Momento auth token is required.  You can generate one using the [Momento CLI](https://github.com/momentohq/momento-cli).
+* A Momento API key is required.  You can generate one using the [Momento Console](https://console.gomomento.com/api-keys).
 
 ## Running the application example
 
 Run the following from within the `examples` directory:
 
 ```bash
-MOMENTO_API_KEY=<YOUR AUTH TOKEN> dotnet run --project MomentoApplication
+MOMENTO_API_KEY=<YOUR API KEY> dotnet run --project MomentoApplication
 ```
 
 Within the `MomentoAppication` directory you can run:
 
 ```bash
-MOMENTO_API_KEY=<YOUR AUTH TOKEN> dotnet run
+MOMENTO_API_KEY=<YOUR API KEY> dotnet run
 ```
 
 ## Error Handling

--- a/examples/MomentoLoadGen/README.md
+++ b/examples/MomentoLoadGen/README.md
@@ -23,7 +23,7 @@ If you have questions or need help experimenting further, please reach out to us
 ## Prerequisites
 
 * [`dotnet`](https://dotnet.microsoft.com/en-us/download) 6.0 or higher is required
-* A Momento auth token is required.  You can generate one using the [Momento CLI](https://github.com/momentohq/momento-cli).
+* A Momento API key is required.  You can generate one using the [Momento Console](https://console.gomomento.com/api-keys).
 
 ## Running the load generator
 
@@ -31,14 +31,14 @@ To run the load generator (from the `examples` directory):
 
 ```bash
 # Run example load generator
-MOMENTO_API_KEY=<YOUR AUTH TOKEN> dotnet run --project MomentoLoadGen
+MOMENTO_API_KEY=<YOUR API KEY> dotnet run --project MomentoLoadGen
 ```
 
 Within the `MomentoLoadGen` directory you can run:
 
 ```bash
 # Run example load generator
-MOMENTO_API_KEY=<YOUR AUTH TOKEN> dotnet run
+MOMENTO_API_KEY=<YOUR API KEY> dotnet run
 ```
 
 If you make modifications to the code, remember to do a clean otherwise
@@ -46,5 +46,5 @@ the program might not run.
 
 ```bash
 dotnet clean
-MOMENTO_API_KEY=<YOUR AUTH TOKEN> dotnet run
+MOMENTO_API_KEY=<YOUR API KEY> dotnet run
 ```

--- a/examples/MomentoUsage/README.md
+++ b/examples/MomentoUsage/README.md
@@ -9,20 +9,20 @@ the client's full capabilities, take a look at the more advanced  [MomentoApplic
 ## Prerequisites
 
 * [`dotnet`](https://dotnet.microsoft.com/en-us/download) 6.0 or higher is required
-* A Momento auth token is required.  You can generate one using the [Momento CLI](https://github.com/momentohq/momento-cli).
+* A Momento API key is required.  You can generate one using the [Momento Console](https://console.gomomento.com/api-keys).
 
 ## Running the application example
 
 Run the following from within the `examples` directory:
 
 ```bash
-MOMENTO_API_KEY=<YOUR AUTH TOKEN> dotnet run --project MomentoUsage
+MOMENTO_API_KEY=<YOUR API KEY> dotnet run --project MomentoUsage
 ```
 
 Within the `MomentoUsage` directory you can run:
 
 ```bash
-MOMENTO_API_KEY=<YOUR AUTH TOKEN> dotnet run
+MOMENTO_API_KEY=<YOUR API KEY> dotnet run
 ```
 
 ## Error Handling

--- a/examples/README.md
+++ b/examples/README.md
@@ -5,7 +5,7 @@
 ## Prerequisites
 
 * [`dotnet`](https://dotnet.microsoft.com/en-us/download) 6.0 or higher is required
-* A Momento auth token is required.  You can generate one using the [Momento CLI](https://github.com/momentohq/momento-cli).
+* A Momento API key is required.  You can generate one using the [Momento Console](https://console.gomomento.com/api-keys).
 
 ## Running the advanced example
 
@@ -13,7 +13,7 @@ To run the advanced example code defined in [`MomentoApplication/Program.cs`](./
 run the following from within the `examples` directory:
 
 ```bash
-MOMENTO_AUTH_TOKEN=<YOUR AUTH TOKEN> dotnet run --project MomentoApplication
+MOMENTO_API_KEY=<YOUR API KEY> dotnet run --project MomentoApplication
 ```
 
 ## Error Handling
@@ -82,5 +82,5 @@ To run the load generator (from the `examples` directory):
 
 ```bash
 # Run example load generator
-MOMENTO_AUTH_TOKEN=<YOUR AUTH TOKEN> dotnet run --project MomentoLoadGen
+MOMENTO_API_KEY=<YOUR AUTH TOKEN> dotnet run --project MomentoLoadGen
 ```

--- a/examples/TopicExample/README.md
+++ b/examples/TopicExample/README.md
@@ -4,12 +4,12 @@ This example program demonstrates usage of Momento Topics.
 
 # Usage
 
-The program assumes the auth token and cache names are available in environment variables. The auth token is assumed to be in the variable `TEST_AUTH_TOKEN` and the cache name in `TEST_CACHE_NAME`. If either of these is missing, you will be prompted to enter the values on the terminal.
+The program assumes the auth token and cache names are available in environment variables. The auth token is assumed to be in the variable `MOMENTO_API_KEY` and the cache name in `MOMENTO_CACHE_NAME`. If either of these is missing, you will be prompted to enter the values on the terminal.
 
 To run the program, run either:
 
 ```bash
-TEST_AUTH_TOKEN=<YOUR_TOKEN_HERE> TEST_CACHE_NAME=<YOUR_CACHE_NAME_HERE> dotnet run
+MOMENTO_API_KEY=<YOUR_API_KEY_HERE> MOMENTO_CACHE_NAME=<YOUR_CACHE_NAME_HERE> dotnet run
 ```
 
 or


### PR DESCRIPTION
Clean up readme instructions from "auth token from CLI" to "api key from console"