### PR TITLE
chore: update readme template to fix broken link instead of readme directly

### DIFF
--- a/README.template.md
+++ b/README.template.md
@@ -14,8 +14,8 @@ Here is a quickstart you can use in your own project:
 {% include "./examples/MomentoUsage/Program.cs" %}
 ```
 
-Note that the above code requires an environment variable named MOMENTO_AUTH_TOKEN which must
-be set to a valid [Momento authentication token](https://docs.momentohq.com/docs/getting-started#obtain-an-auth-token).
+Note that the above code requires an environment variable named MOMENTO_API_KEY which must
+be set to a valid [Momento authentication token](https://docs.momentohq.com/cache/develop/authentication/api-keys).
 
 ## Getting Started and Documentation
 


### PR DESCRIPTION
#544 seemed to break the readme generator on push to main.
This PR fixes the broken link in the readme using the template instead of editing the readme directly.