### PR TITLE
fix: add missing step to workflow file for readme generator

### DIFF
--- a/.github/workflows/on-push-to-main-branch.yaml
+++ b/.github/workflows/on-push-to-main-branch.yaml
@@ -48,6 +48,11 @@ jobs:
   generate_readme:
     runs-on: ubuntu-latest
     steps:
+      - name: Setup repo
+        uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.MOMENTO_MACHINE_USER_GITHUB_TOKEN }}
+
       - name: Generate README
         uses: momentohq/standards-and-practices/github-actions/generate-and-commit-oss-readme@gh-actions-v2
         with:


### PR DESCRIPTION
Saw a [failure](https://github.com/momentohq/client-sdk-dotnet/actions/runs/8179952682/job/22367041811) on the readme generator job. Realized there was a checkout step missing.