### PR TITLE
fix: dispose cache client when eager connection fails

### DIFF
--- a/src/Momento.Sdk/CacheClient.cs
+++ b/src/Momento.Sdk/CacheClient.cs
@@ -51,7 +51,15 @@ public class CacheClient : ICacheClient
     public static async Task<ICacheClient> CreateAsync(IConfiguration config, ICredentialProvider authProvider, TimeSpan defaultTtl, TimeSpan eagerConnectionTimeout)
     {
         CacheClient cacheClient = new CacheClient(config, authProvider, defaultTtl);
-        await cacheClient.DataClient.EagerConnectAsync(eagerConnectionTimeout);
+        try
+        {
+            await cacheClient.DataClient.EagerConnectAsync(eagerConnectionTimeout);
+        }
+        catch (Exception e)
+        {
+            cacheClient.Dispose();
+            throw e;
+        }
         return cacheClient;
     }
 


### PR DESCRIPTION
In order to clean up resources on a failed eager connection (`Ping`)
RPC, we dispose the cache client on exception in
`CacheClient::CreateAsync`.
