### PR TITLE
fix: properly re-throw caught exception in eager connection code

### DIFF
--- a/src/Momento.Sdk/CacheClient.cs
+++ b/src/Momento.Sdk/CacheClient.cs
@@ -55,7 +55,7 @@ public class CacheClient : ICacheClient
         {
             await cacheClient.DataClient.EagerConnectAsync(eagerConnectionTimeout);
         }
-        catch (Exception e)
+        catch (Exception)
         {
             cacheClient.Dispose();
             throw;

--- a/src/Momento.Sdk/CacheClient.cs
+++ b/src/Momento.Sdk/CacheClient.cs
@@ -58,7 +58,7 @@ public class CacheClient : ICacheClient
         catch (Exception e)
         {
             cacheClient.Dispose();
-            throw e;
+            throw;
         }
         return cacheClient;
     }


### PR DESCRIPTION
To preserve the original stack trace, one needs to use a `throw;`
statement, not re-throw the original exception. See https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/statements/exception-handling-statements
