### PR TITLE
spike: demo the storage api in C#

### DIFF
--- a/examples/StoreApi/Program.cs
+++ b/examples/StoreApi/Program.cs
@@ -1,0 +1,85 @@
+﻿using Momento.Sdk.StoreClient;
+
+namespace Driver;
+
+public class Program
+{
+    public static async Task Main(string[] args)
+    {
+        var client = new StoreClient();
+        await client.CreateStoreAsync("my-store");
+
+        // Can use implicit cast to create StoreValue.
+        await client.PutAsync("my-store", "my-key", "my-value");
+        await client.PutAsync("my-store", "my-key", 42);
+        await client.PutAsync("my-store", "my-key", 3.14);
+        await client.PutAsync("my-store", "my-key", true);
+
+        // The compiler will detect invalid casts.
+        // await client.PutAsync("my-store", "my-key", new string[] { "a", "b" });
+
+        // This demos usage where the developer is sure of the type.
+        {
+            var response = await client.GetAsync("my-store", "string-value");
+            if (response is StoreGet.Success success)
+            {
+                // This uses an implicit cast from StoreValue to string.
+                string value = success.Value;
+                Console.WriteLine($"Success: {value}");
+            }
+            else if (response is StoreGet.Error error)
+            {
+                Console.WriteLine($"Error: {error.Message}");
+            }
+        }
+
+        // A more cautious developer would handle the unfortunate case where the cast fails.
+        {
+            var response = await client.GetAsync("my-store", "bool-value");
+            if (response is StoreGet.Success success)
+            {
+                try
+                {
+                    // This uses an implicit cast from StoreValue to long, but it's actually a bool.
+                    long value = success.Value;
+                    Console.WriteLine($"Success: {value}");
+                }
+                catch (InvalidCastException)
+                {
+                    Console.WriteLine($"Error: Invalid cast to long. Type was actually {success.Value.Type}");
+                }
+            }
+            else if (response is StoreGet.Error error)
+            {
+                Console.WriteLine($"Error: {error.Message}");
+            }
+        }
+
+        // This demos usage where the developer wants to do something specific based on the type.
+        {
+            foreach (var key in new string[] { "string-value", "int-value", "double-value", "bool-value", "unknown-value" })
+            {
+                var response = await client.GetAsync("my-store", key);
+                if (response is StoreGet.Success success)
+                {
+                    var message = success.Value.Type switch
+                    {
+                        StoreValueType.String => "string",
+                        StoreValueType.Integer64 => "integer",
+                        StoreValueType.Double => "double",
+                        StoreValueType.Bool => "boolean",
+                        _ => "unknown type :("
+                    };
+                    Console.WriteLine($"Success: {key} is a {message}.");
+                }
+                else if (response is StoreGet.Error error)
+                {
+                    Console.WriteLine($"Error when getting key {key}: {error.Message}");
+                }
+            }
+        }
+
+        await client.DeleteStoreAsync("my-store");
+    }
+}
+

--- a/examples/StoreApi/StoreApi.csproj
+++ b/examples/StoreApi/StoreApi.csproj
@@ -1,0 +1,10 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/examples/StoreApi/StoreApi.sln
+++ b/examples/StoreApi/StoreApi.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.002.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "StoreApi", "StoreApi.csproj", "{BAF8AA3E-54B8-483D-8A86-F4F9E8639ED5}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{BAF8AA3E-54B8-483D-8A86-F4F9E8639ED5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BAF8AA3E-54B8-483D-8A86-F4F9E8639ED5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BAF8AA3E-54B8-483D-8A86-F4F9E8639ED5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BAF8AA3E-54B8-483D-8A86-F4F9E8639ED5}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {D39D433C-744B-4390-AF23-E642AFC9E1A7}
+	EndGlobalSection
+EndGlobal

--- a/examples/StoreApi/StoreClient.cs
+++ b/examples/StoreApi/StoreClient.cs
@@ -1,0 +1,59 @@
+namespace Momento.Sdk.StoreClient;
+
+public class StoreClient
+{
+    public StoreClient()
+    {
+    }
+
+    public async Task CreateStoreAsync(string storeName)
+    {
+        // These are so the compiler doesn't complain no awaits.
+        await Task.Delay(0);
+    }
+
+    public async Task DeleteStoreAsync(string storeName)
+    {
+        await Task.Delay(0);
+    }
+
+    public async Task ListStoresAsync()
+    {
+        await Task.Delay(0);
+    }
+
+    public async Task<StoreGetResponse> GetAsync(string storeName, string key)
+    {
+        await Task.Delay(0);
+        if (key == "string-value")
+        {
+            return new StoreGet.Success("string-value");
+        }
+        else if (key == "int-value")
+        {
+            return new StoreGet.Success(42);
+        }
+        else if (key == "double-value")
+        {
+            return new StoreGet.Success(3.14);
+        }
+        else if (key == "bool-value")
+        {
+            return new StoreGet.Success(true);
+        }
+        else
+        {
+            return new StoreGet.Error("Key not found.");
+        }
+    }
+
+    public async Task PutAsync(string storeName, string key, StoreValue value)
+    {
+        await Task.Delay(0);
+    }
+
+    public async Task DeleteAsync(string storeName, string key)
+    {
+        await Task.Delay(0);
+    }
+}

--- a/examples/StoreApi/StoreGet.cs
+++ b/examples/StoreApi/StoreGet.cs
@@ -1,0 +1,28 @@
+namespace Momento.Sdk.StoreClient;
+
+public abstract class StoreGetResponse
+{
+}
+
+public abstract class StoreGet
+{
+    public class Success : StoreGetResponse
+    {
+        public StoreValue Value { get; }
+
+        public Success(StoreValue value)
+        {
+            Value = value;
+        }
+    }
+
+    public class Error : StoreGetResponse
+    {
+        public string Message { get; }
+
+        public Error(string message)
+        {
+            Message = message;
+        }
+    }
+}

--- a/examples/StoreApi/StoreValue.cs
+++ b/examples/StoreApi/StoreValue.cs
@@ -1,0 +1,49 @@
+namespace Momento.Sdk.StoreClient;
+
+public enum StoreValueType
+{
+    String,
+    Integer64,
+    Double,
+    Bool
+}
+
+public class StoreValue
+{
+    private object _value;
+    public StoreValueType Type { get; }
+
+    public StoreValue(object value, StoreValueType type)
+    {
+        _value = value;
+        Type = type;
+    }
+
+    public StoreValue(string value) : this(value, StoreValueType.String)
+    {
+    }
+
+    public StoreValue(long value) : this(value, StoreValueType.Integer64)
+    {
+    }
+
+    public StoreValue(double value) : this(value, StoreValueType.Double)
+    {
+    }
+
+    public StoreValue(bool value) : this(value, StoreValueType.Bool)
+    {
+    }
+
+    // implicit cast from the various types into StoreValue
+    public static implicit operator StoreValue(string value) => new StoreValue(value);
+    public static implicit operator StoreValue(long value) => new StoreValue(value);
+    public static implicit operator StoreValue(double value) => new StoreValue(value);
+    public static implicit operator StoreValue(bool value) => new StoreValue(value);
+
+    // implicit cast from StoreValue into the various types
+    public static implicit operator string(StoreValue value) => (string)value._value;
+    public static implicit operator long(StoreValue value) => (long)value._value;
+    public static implicit operator double(StoreValue value) => (double)value._value;
+    public static implicit operator bool(StoreValue value) => (bool)value._value;
+}


### PR DESCRIPTION
This demonstrates the Store API in C#. Because C# has significant support for implicit casts, we can greatly simplify the developer experience when interacting with the multitude of types that go in and out of the store.

By using implicit casts on the way in, we only need one `Put` method that takes a `StoreValue`. The `StoreValue` type defines casts from various types to `StoreValue`. That way a developer can write:

```dotnet
await client.PutAsync("my-store", "my-key", 3.14);
```

and the runtime will create a `StoreValue` from the double. The compiler detects any invalid casts.

Similarly on when we retrieve data with `GetAsync`, we can return a `Success` that has a `StoreValue`. The user can benefit from implicit casting in the reverse direction. They can write

```dotnet
var getResponse = await client.GetAsync("my-store", "string-value");
if (getResponse is StoreGet.Success success)
{
    string value = success.Value;
}
```

If the cast is incorrect, the .NET runtime will throw an `InvalidCastException`.

By storing the type in `StoreValue`, we the developer can do pattern matching exhaustively over that. The compiler notifies the developer when the pattern matching is not exhaustive.