### PR TITLE
feat: onetime headers for agent and runtime-version

### DIFF
--- a/src/Momento.Sdk/Internal/ScsDataClient.cs
+++ b/src/Momento.Sdk/Internal/ScsDataClient.cs
@@ -47,9 +47,9 @@ public class ScsDataClientBase : IDisposable
             return new Metadata() { { "cache", cacheName } };
         }
         this.hasSentOnetimeHeaders = true;
-        string version = Assembly.GetExecutingAssembly().GetName().Version.ToString();
+        string sdkVersion = Assembly.GetExecutingAssembly().GetName().Version.ToString();
         string runtimeVer = System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription;
-        return new Metadata() { { "cache", cacheName }, { "Agent", $"dotnet:{version}" }, { "Runtime-Version", runtimeVer } };
+        return new Metadata() { { "cache", cacheName }, { "Agent", $"dotnet:{sdkVersion}" }, { "Runtime-Version", runtimeVer } };
     }
     protected DateTime CalculateDeadline()
     {

--- a/src/Momento.Sdk/Internal/ScsTopicClient.cs
+++ b/src/Momento.Sdk/Internal/ScsTopicClient.cs
@@ -39,7 +39,6 @@ public class ScsTopicClientBase : IDisposable
         this.hasSentOnetimeHeaders = true;
         string sdkVersion = Assembly.GetExecutingAssembly().GetName().Version.ToString();
         string runtimeVer = System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription;
-        Console.WriteLine($"cache: {cacheName}, agent:{sdkVersion}, runtime-version:{runtimeVer}");
         return new Metadata() { { "cache", cacheName }, { "Agent", $"dotnet:{sdkVersion}" }, { "Runtime-Version", runtimeVer } };
     }
 


### PR DESCRIPTION
```
agent: dotnet:1.0.0.0, runtime-version: .NET 6.0.11
```

The agent is showing up as `1.0.0.0` because inside of our sdk `.csproj` we do not have a `Version` property. This property gets set when we actually cut the release. I manually set the `.csproj` `Version` property to `2.2.2` and the agent shows up as `dotnet:2.2.2.0`

closes https://github.com/momentohq/dev-eco-issue-tracker/issues/887