### PR TITLE
chore: lowercase agent and runtime-headers

### DIFF
--- a/src/Momento.Sdk/Internal/Middleware/HeaderMiddleware.cs
+++ b/src/Momento.Sdk/Internal/Middleware/HeaderMiddleware.cs
@@ -11,9 +11,9 @@ namespace Momento.Sdk.Internal.Middleware
 {
     internal class Header
     {
-        public const string AuthorizationKey = "Authorization";
-        public const string AgentKey = "Agent";
-        public const string RuntimeVersionKey = "Runtime_Version";
+        public const string AuthorizationKey = "authorization";
+        public const string AgentKey = "agent";
+        public const string RuntimeVersionKey = "runtime-version";
         public readonly List<string> onceOnlyHeaders = new List<string> { Header.AgentKey, Header.RuntimeVersionKey };
         public string Name;
         public string Value;

--- a/src/Momento.Sdk/Internal/ScsDataClient.cs
+++ b/src/Momento.Sdk/Internal/ScsDataClient.cs
@@ -35,7 +35,7 @@ public class ScsDataClientBase : IDisposable
         this._logger = config.LoggerFactory.CreateLogger<ScsDataClient>();
         this._exceptionMapper = new CacheExceptionMapper(config.LoggerFactory);
     }
-    
+
     internal Task EagerConnectAsync(TimeSpan eagerConnectionTimeout)
     {
         return this.grpcManager.EagerConnectAsync(eagerConnectionTimeout);
@@ -43,13 +43,14 @@ public class ScsDataClientBase : IDisposable
 
     protected Metadata MetadataWithCache(string cacheName)
     {
-        if (this.hasSentOnetimeHeaders) {
+        if (this.hasSentOnetimeHeaders)
+        {
             return new Metadata() { { "cache", cacheName } };
         }
         this.hasSentOnetimeHeaders = true;
         string sdkVersion = Assembly.GetExecutingAssembly().GetName().Version.ToString();
         string runtimeVer = System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription;
-        return new Metadata() { { "cache", cacheName }, { "Agent", $"dotnet:cache:{sdkVersion}" }, { "Runtime-Version", runtimeVer } };
+        return new Metadata() { { "cache", cacheName }, { "agent", $"dotnet:cache:{sdkVersion}" }, { "runtime-version", runtimeVer } };
     }
     protected DateTime CalculateDeadline()
     {
@@ -998,8 +999,8 @@ internal sealed class ScsDataClient : ScsDataClientBase
 
         return this._logger.LogTraceCollectionRequestSuccess(REQUEST_TYPE_SET_FETCH, cacheName, setName, new CacheSetFetchResponse.Miss());
     }
-    
-    
+
+
     const string REQUEST_TYPE_SET_SAMPLE = "SET_SAMPLE";
     private async Task<CacheSetSampleResponse> SendSetSampleAsync(string cacheName, string setName, ulong limit)
     {
@@ -1023,7 +1024,7 @@ internal sealed class ScsDataClient : ScsDataClientBase
 
         return this._logger.LogTraceCollectionRequestSuccess(REQUEST_TYPE_SET_SAMPLE, cacheName, setName, new CacheSetSampleResponse.Miss());
     }
-    
+
     const string REQUEST_TYPE_SET_LENGTH = "SET_LENGTH";
     private async Task<CacheSetLengthResponse> SendSetLengthAsync(string cacheName, string setName)
     {

--- a/src/Momento.Sdk/Internal/ScsTokenClient.cs
+++ b/src/Momento.Sdk/Internal/ScsTokenClient.cs
@@ -32,16 +32,17 @@ internal sealed class ScsTokenClient : IDisposable
         this._logger = config.LoggerFactory.CreateLogger<ScsTokenClient>();
         this._exceptionMapper = new CacheExceptionMapper(config.LoggerFactory);
     }
-    
+
     private Metadata Metadata()
     {
-        if (this.hasSentOnetimeHeaders) {
+        if (this.hasSentOnetimeHeaders)
+        {
             return new Metadata();
         }
         this.hasSentOnetimeHeaders = true;
         string sdkVersion = Assembly.GetExecutingAssembly().GetName().Version.ToString();
         string runtimeVer = System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription;
-        return new Metadata() { { "Agent", $"dotnet:auth:{sdkVersion}" }, { "Runtime-Version", runtimeVer } };
+        return new Metadata() { { "agent", $"dotnet:auth:{sdkVersion}" }, { "runtime-version", runtimeVer } };
     }
 
     private DateTime CalculateDeadline()

--- a/src/Momento.Sdk/Internal/ScsTopicClient.cs
+++ b/src/Momento.Sdk/Internal/ScsTopicClient.cs
@@ -33,13 +33,14 @@ public class ScsTopicClientBase : IDisposable
 
     private Metadata MetadataWithCache(string cacheName)
     {
-        if (this.hasSentOnetimeHeaders) {
+        if (this.hasSentOnetimeHeaders)
+        {
             return new Metadata() { { "cache", cacheName } };
         }
         this.hasSentOnetimeHeaders = true;
         string sdkVersion = Assembly.GetExecutingAssembly().GetName().Version.ToString();
         string runtimeVer = System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription;
-        return new Metadata() { { "cache", cacheName }, { "Agent", $"dotnet:topic:{sdkVersion}" }, { "Runtime-Version", runtimeVer } };
+        return new Metadata() { { "cache", cacheName }, { "agent", $"dotnet:topic:{sdkVersion}" }, { "runtime-v]ersion", runtimeVer } };
     }
 
     protected DateTime CalculateDeadline()


### PR DESCRIPTION
In order to standardize the agent and runtime-version headers, we
lowercase the header names.
