### PR TITLE
chore: refactor makefile and actions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -44,7 +44,7 @@ jobs:
       - name: Build
         run: make GRPC_WEB=${{ matrix.grpc-web }} build
 
-      - name: Unit and Integration Test
+      - name: Test
         run: make test
 
   build_examples:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,15 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        target-framework: [net6.0]
         grpc-web: [false, true]
-        include:
-          - os: windows-latest
-            target-framework: net462
-            grpc-web: false
-          - os: windows-latest
-            target-framework: net462
-            grpc-web: true
     runs-on: ${{ matrix.os }}
     env:
       MOMENTO_API_KEY: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
@@ -50,13 +42,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build
-        run: dotnet build ${{ matrix.grpc-web && '-p:DefineConstants=USE_GRPC_WEB' || '' }}
+        run: make GRPC_WEB=${{ matrix.grpc-web }} build
 
-      - name: Unit Test
-        run: dotnet test --logger "console;verbosity=detailed" -f ${{ matrix.target-framework }} tests/Unit/Momento.Sdk.Tests
-
-      - name: Integration Test
-        run: dotnet test --logger "console;verbosity=detailed" -f ${{ matrix.target-framework }} tests/Integration/Momento.Sdk.Tests
+      - name: Unit and Integration Test
+        run: make test
 
   build_examples:
     runs-on: ubuntu-latest

--- a/.github/workflows/on-push-to-main-branch.yaml
+++ b/.github/workflows/on-push-to-main-branch.yaml
@@ -9,15 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        target-framework: [net6.0]
         grpc-web: [false, true]
-        include:
-          - os: windows-latest
-            target-framework: net462
-            grpc-web: false
-          - os: windows-latest
-            target-framework: net462
-            grpc-web: true
     runs-on: ${{ matrix.os }}
     env:
       MOMENTO_API_KEY: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
@@ -37,13 +29,10 @@ jobs:
           dotnet-version: "6.0.x"
 
       - name: Build
-        run: dotnet build ${{ matrix.grpc-web && '-p:DefineConstants=USE_GRPC_WEB' || '' }}
+        run: make GRPC_WEB=${{ matrix.grpc-web }} build
 
-      - name: Unit Test
-        run: dotnet test -f ${{ matrix.target-framework }} tests/Unit/Momento.Sdk.Tests
-
-      - name: Integration Test
-        run: dotnet test -f ${{ matrix.target-framework }} tests/Integration/Momento.Sdk.Tests
+      - name: Unit and Integration Test
+        run: make test
 
   generate_readme:
     runs-on: ubuntu-latest

--- a/.github/workflows/on-push-to-main-branch.yaml
+++ b/.github/workflows/on-push-to-main-branch.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Build
         run: make GRPC_WEB=${{ matrix.grpc-web }} build
 
-      - name: Unit and Integration Test
+      - name: Test
         run: make test
 
   generate_readme:

--- a/.github/workflows/on-push-to-release-branch.yaml
+++ b/.github/workflows/on-push-to-release-branch.yaml
@@ -45,7 +45,7 @@ jobs:
           dotnet-version: "6.0.x"
 
       - name: Build
-        run: dotnet build
+        run: make build
 
       - name: Pack and Publish
         run: |
@@ -57,7 +57,7 @@ jobs:
             dotnet pack -c Release -p:Version=${VERSION}
             dotnet nuget push ./bin/Release/Momento.Sdk.${VERSION}.nupkg --source https://api.nuget.org/v3/index.json --api-key=${{secrets.NUGET_API_KEY}}
           popd
-          
+
       - name: Build for Unity
         run: |
           set -x

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,16 +1,23 @@
 # Running tests
 
-Unless you are testing older .NET runtimes on Windows, you should run the tests against the newer runtimes as follows:
-  - https://dotnet.microsoft.com/en-us/download/dotnet/6.0
+## Recommended
+
+The Makefile target `test` runs against .NET 6.0 and has additional OS-conditional logic to run .NET Framework tests on Windows. Use this target by default.
+
+## Specifics
+
+You can explicitly run the tests against the newer runtimes as follows:
+
+- https://dotnet.microsoft.com/en-us/download/dotnet/6.0
 
 ```
-MOMENTO_API_KEY=$your_momento_token make test-net6
+MOMENTO_API_KEY=$your_momento_token make test-dotnet6
 ```
 
 To test against older .NET runtimes run:
 
 ```
-MOMENTO_API_KEY=$your_momento_token make test-net-framework
+MOMENTO_API_KEY=$your_momento_token make test-dotnet-framework
 ```
 
 To run specific tests:

--- a/Makefile
+++ b/Makefile
@@ -1,21 +1,48 @@
-.PHONY: all build clean clean-build precommit restore test test-net6 test-net-framework run-examples help
+.PHONY: all build build-dotnet6 build-dotnet-framework clean clean-build precommit restore test test-dotnet6 test-dotnet-framework run-examples help
+
+# Determine the operating system
+OS := $(shell uname)
+
+# Set the default .NET version to .NET 6.0
+DOTNET_VERSION := net6.0
+
+# Windows-specific settings
+ifeq ($(OS), Windows_NT)
+    BUILD_TARGETS := build-dotnet6 build-dotnet-framework
+    TEST_TARGETS := test-dotnet6 test-dotnet-framework
+else
+    BUILD_TARGETS := build-dotnet6
+    TEST_TARGETS := test-dotnet6
+endif
+
 
 ## Generate sync unit tests, format, lint, and test
 all: precommit
 
 
-## Build project
-build:
-	@dotnet build
+## Build the project (conditioned by OS)
+build: ${BUILD_TARGETS}
 
+
+## Build the project for .NET 6.0
+build-dotnet6:
+	@echo "Building the project for .NET 6.0..."
+	@dotnet build -f ${DOTNET_VERSION}
+
+
+## Build the project on .NET Framework
+build-dotnet-framework:
+	@echo "Building the project for .NET Framework 4.62..."
+	@dotnet build -f net462
 
 ## Remove build files
 clean:
+	@echo "Cleaning build artifacts..."
 	@dotnet clean
 
 
 ## Build project
-clean-build: clean restore build
+clean-build: clean restore ${BUILD_TARGETS}
 
 
 ## Run clean-build and test as a step before committing.
@@ -24,22 +51,22 @@ precommit: clean-build test
 
 ## Sync dependencies
 restore:
+	@echo "Restoring dependencies..."
 	@dotnet restore
 
 
-## Run unit and integration tests
-test:
-	@dotnet test
+## Run unit and integration tests (conditioned by OS)
+test: ${TEST_TARGETS}
 
 
 ## Run unit and integration tests on the .NET 6.0 runtime
-test-net6:
+test-dotnet6:
 	@echo "Running tests on .NET 6.0..."
-	@dotnet test -f net6.0
+	@dotnet test -f ${DOTNET_VERSION}
 
 
 ## Run unit and integration tests on the .NET Framework runtime (Windows only)
-test-net-framework:
+test-dotnet-framework:
 	@echo "Running tests on .NET Framework 4.62 (Windows only)..."
 	@dotnet test -f net462
 

--- a/Makefile
+++ b/Makefile
@@ -40,12 +40,14 @@ test:
 .PHONY: test-net6
 ## Run unit and integration tests on the .NET 6.0 runtime
 test-net6:
+	@echo "Running tests on .NET 6.0..."
 	@dotnet test -f net6.0
 
 
 .PHONY: test-net-framework
-## Run unit and integration tests on the .NET Framework runtime
+## Run unit and integration tests on the .NET Framework runtime (Windows only)
 test-net-framework:
+	@echo "Running tests on .NET Framework 4.62 (Windows only)..."
 	@dotnet test -f net462
 
 

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ build: ${BUILD_TARGETS}
 
 ## Build the project for .NET 6.0
 build-dotnet6:
+	echo "Detected OS was: ${OS}"
 	@echo "Building the project for .NET 6.0..."
 	@dotnet build -f ${DOTNET_VERSION} ${GRPC_WEB_FLAG}
 

--- a/Makefile
+++ b/Makefile
@@ -1,63 +1,54 @@
-.PHONY: all
+.PHONY: all build clean clean-build precommit restore test test-net6 test-net-framework run-examples help
+
 ## Generate sync unit tests, format, lint, and test
 all: precommit
 
 
-.PHONY: build
 ## Build project
 build:
 	@dotnet build
 
 
-.PHONY: clean
 ## Remove build files
 clean:
 	@dotnet clean
 
 
-.PHONY: clean-build
 ## Build project
 clean-build: clean restore build
 
 
-.PHONY: precommit
 ## Run clean-build and test as a step before committing.
 precommit: clean-build test
 
 
-.PHONY: restore
 ## Sync dependencies
 restore:
 	@dotnet restore
 
 
-.PHONY: test
 ## Run unit and integration tests
 test:
 	@dotnet test
 
 
-.PHONY: test-net6
 ## Run unit and integration tests on the .NET 6.0 runtime
 test-net6:
 	@echo "Running tests on .NET 6.0..."
 	@dotnet test -f net6.0
 
 
-.PHONY: test-net-framework
 ## Run unit and integration tests on the .NET Framework runtime (Windows only)
 test-net-framework:
 	@echo "Running tests on .NET Framework 4.62 (Windows only)..."
 	@dotnet test -f net462
 
 
-.PHONY: run-examples
 ## Run example applications and snippets
 run-examples:
 	@dotnet run --project examples/MomentoApplication
 	@dotnet run --project examples/DocExampleApis
 
 # See <https://gist.github.com/klmr/575726c7e05d8780505a> for explanation.
-.PHONY: help
 help:
 	@echo "$$(tput bold)Available rules:$$(tput sgr0)";echo;sed -ne"/^## /{h;s/.*//;:d" -e"H;n;s/^## //;td" -e"s/:.*//;G;s/\\n## /---/;s/\\n/ /g;p;}" ${MAKEFILE_LIST}|LC_ALL='C' sort -f|awk -F --- -v n=$$(tput cols) -v i=19 -v a="$$(tput setaf 6)" -v z="$$(tput sgr0)" '{printf"%s%*s%s ",a,-i,$$1,z;m=split($$2,w," ");l=n-i;for(j=1;j<=m;j++){l-=length(w[j])+1;if(l<= 0){l=n-i-length(w[j])-1;printf"\n%*s ",-i," ";}printf"%s ",w[j];}printf"\n";}'|more $(shell test $(shell uname) == Darwin && echo '-Xr')

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,11 @@ else
     TEST_TARGETS := test-dotnet6
 endif
 
+# Enable gRPC-Web if requested
+GRPC_WEB_FLAG :=
+ifeq ($(GRPC_WEB), true)
+    GRPC_WEB_FLAG := -p:DefineConstants=USE_GRPC_WEB
+endif
 
 ## Generate sync unit tests, format, lint, and test
 all: precommit
@@ -28,13 +33,13 @@ build: ${BUILD_TARGETS}
 ## Build the project for .NET 6.0
 build-dotnet6:
 	@echo "Building the project for .NET 6.0..."
-	@dotnet build -f ${DOTNET_VERSION}
+	@dotnet build -f ${DOTNET_VERSION} ${GRPC_WEB_FLAG}
 
 
 ## Build the project on .NET Framework
 build-dotnet-framework:
 	@echo "Building the project for .NET Framework 4.62..."
-	@dotnet build -f net462
+	@dotnet build -f net462 ${GRPC_WEB_FLAG}
 
 ## Remove build files
 clean:

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ OS := $(shell uname)
 
 # Set the default .NET version to .NET 6.0
 DOTNET_VERSION := net6.0
+TEST_LOGGER_OPTIONS := --logger "console;verbosity=detailed"
 
 # Windows-specific settings
 ifeq ($(OS), Windows_NT)
@@ -62,13 +63,13 @@ test: ${TEST_TARGETS}
 ## Run unit and integration tests on the .NET 6.0 runtime
 test-dotnet6:
 	@echo "Running tests on .NET 6.0..."
-	@dotnet test -f ${DOTNET_VERSION}
+	@dotnet test ${TEST_LOGGER_OPTIONS} -f ${DOTNET_VERSION}
 
 
 ## Run unit and integration tests on the .NET Framework runtime (Windows only)
 test-dotnet-framework:
 	@echo "Running tests on .NET Framework 4.62 (Windows only)..."
-	@dotnet test -f net462
+	@dotnet test ${TEST_LOGGER_OPTIONS} -f net462
 
 
 ## Run example applications and snippets

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,8 @@ DOTNET_VERSION := net6.0
 TEST_LOGGER_OPTIONS := --logger "console;verbosity=detailed"
 
 # Windows-specific settings
-ifeq ($(OS), Windows_NT)
+# This tests if "NT" is in the OS string, which would indicate Windows.
+ifneq (,$(findstring NT,$(OS)))
     BUILD_TARGETS := build-dotnet6 build-dotnet-framework
     TEST_TARGETS := test-dotnet6 test-dotnet-framework
 else
@@ -32,7 +33,6 @@ build: ${BUILD_TARGETS}
 
 ## Build the project for .NET 6.0
 build-dotnet6:
-	echo "Detected OS was: ${OS}"
 	@echo "Building the project for .NET 6.0..."
 	@dotnet build -f ${DOTNET_VERSION} ${GRPC_WEB_FLAG}
 


### PR DESCRIPTION
Simplifies the `Makefile` in the following ways:
- Refactors the core commands `build` and `test` to be OS-conditional. When we detect Windows, we build and test against not just .NET 6.0 but also .NET Framework, the latter of which is Windows-only. This way a developer or consumer of the `Makefile` does not need to specify an OS-specific target (`test-dotnet-framework` vs `test-dotnet-6`)
- Adds a make variable for building with gRPC web. The GitHub Actions tested against each OS, Framework, and with/without gRPC web. We make this easier by adding a `GRPC_WEB` variable. To build with gRPC web, run `make GRPC_WEB=true build`.
- Includes logging options previously only in GitHub actions.
- Refactors GitHub Actions to invoke the Makefile targets to build and test. When on Windows, `build` builds both .NET 6.0 and .NET Framework 4.62 targets; the same goes for when testing.
- Moves `PHONY` declarations to the top for readability.