### PR TITLE
refactor: organize tests by endpoint and provide endpoint-specific make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,13 +10,13 @@
 #   - The caller can run `make GRPC_WEB=true build` to enable gRPC-Web support.
 # - We additionally group the integration tests by endpoint (cache, control, token).
 #   - This is to allow for more granular testing by endpoint.
-#   - Similar to `build` and `test` targets, we have `test-cache`, `test-control`, `test-token`, and `test-storage` targets
+#   - Similar to `build` and `test` targets, we have `test-cache-endpoint`, `test-control-endpoint`, `test-token-endpoint`, and `test-storage-endpoint` targets
 #	  that are conditionally run based on the operating system.
 
 .PHONY: all build build-dotnet6 build-dotnet-framework clean clean-build precommit restore test \
-	test-dotnet6 test-dotnet6-integration test-dotnet6-cache test-dotnet6-control test-dotnet6-token test-dotnet6-unit \
-	test-dotnet-framework test-dotnet-framework-integration test-dotnet-framework-cache test-dotnet-framework-control test-dotnet-framework-token test-dotnet-framework-unit \
-	test-control test-cache test-token test-storage \
+	test-dotnet6 test-dotnet6-integration test-dotnet6-cache-endpoint test-dotnet6-control-endpoint test-dotnet6-token-endpoint \
+	test-dotnet-framework test-dotnet-framework-integration test-dotnet-framework-cache-endpoint test-dotnet-framework-control-endpoint test-dotnet-framework-token-endpoint \
+	test-control-endpoint test-cache-endpoint test-token-endpoint test-storage-endpoint \
 	run-examples help
 
 # Determine the operating system
@@ -32,15 +32,15 @@ TEST_LOGGER_OPTIONS := --logger "console;verbosity=detailed"
 ifneq (,$(findstring NT,$(OS)))
 	BUILD_TARGETS := build-dotnet6 build-dotnet-framework
 	TEST_TARGETS := test-dotnet6 test-dotnet-framework
-	TEST_TARGETS_CACHE := test-dotnet6-cache test-dotnet-framework-cache
-	TEST_TARGETS_CONTROL := test-dotnet6-control test-dotnet-framework-control
-	TEST_TARGETS_TOKEN := test-dotnet6-token test-dotnet-framework-token
+	TEST_TARGETS_CACHE_ENDPOINT := test-dotnet6-cache-endpoint test-dotnet-framework-cache-endpoint
+	TEST_TARGETS_CONTROL_ENDPOINT := test-dotnet6-control-endpoint test-dotnet-framework-control-endpoint
+	TEST_TARGETS_TOKEN_ENDPOINT := test-dotnet6-token-endpoint test-dotnet-framework-token-endpoint
 else
 	BUILD_TARGETS := build-dotnet6
 	TEST_TARGETS := test-dotnet6
-	TEST_TARGETS_CACHE := test-dotnet6-cache
-	TEST_TARGETS_CONTROL := test-dotnet6-control
-	TEST_TARGETS_TOKEN := test-dotnet6-token
+	TEST_TARGETS_CACHE_ENDPOINT := test-dotnet6-cache-endpoint
+	TEST_TARGETS_CONTROL_ENDPOINT := test-dotnet6-control-endpoint
+	TEST_TARGETS_TOKEN_ENDPOINT := test-dotnet6-token-endpoint
 endif
 
 # Enable gRPC-Web if requested
@@ -105,19 +105,19 @@ test-dotnet6:
 
 
 ## Run integration tests on the .NET 6.0 runtime against the cache endpoint
-test-dotnet6-cache:
+test-dotnet6-cache-endpoint:
 	@echo "Running integration tests on the .NET 6.0 runtime against the cache endpoint..."
 	@dotnet test ${TEST_LOGGER_OPTIONS} -f ${DOTNET_VERSION} --filter ${CACHE_ENDPOINT_TESTS_FILTER}
 
 
 ## Run integration tests on the .NET 6.0 runtime against the control endpoint
-test-dotnet6-control:
+test-dotnet6-control-endpoint:
 	@echo "Running integration tests on the .NET 6.0 runtime against the control endpoint..."
 	@dotnet test ${TEST_LOGGER_OPTIONS} -f ${DOTNET_VERSION} --filter ${CONTROL_ENDPOINT_TESTS_FILTER}
 
 
 ## Run integration tests on the .NET 6.0 runtime against the token endpoint
-test-dotnet6-token:
+test-dotnet6-token-endpoint:
 	@echo "Running integration tests on the .NET 6.0 runtime against the token endpoint..."
 	@dotnet test ${TEST_LOGGER_OPTIONS} -f ${DOTNET_VERSION} --filter ${TOKEN_ENDPOINT_TESTS_FILTER}
 
@@ -129,37 +129,37 @@ test-dotnet-framework:
 
 
 ## Run integration tests on the .NET Framework runtime against the cache endpoint (Windows only)
-test-dotnet-framework-cache:
+test-dotnet-framework-cache-endpoint:
 	@echo "Running integration tests on the .NET Framework runtime against the cache endpoint..."
 	@dotnet test ${TEST_LOGGER_OPTIONS} -f ${DOTNET_FRAMEWORK_VERSION} --filter ${CACHE_ENDPOINT_TESTS_FILTER}
 
 
 ## Run integration tests on the .NET Framework runtime against the control endpoint (Windows only)
-test-dotnet-framework-control:
+test-dotnet-framework-control-endpoint:
 	@echo "Running integration tests on the .NET Framework runtime against the control endpoint..."
 	@dotnet test ${TEST_LOGGER_OPTIONS} -f ${DOTNET_FRAMEWORK_VERSION} --filter ${CONTROL_ENDPOINT_TESTS_FILTER}
 
 
 ## Run integration tests on the .NET Framework runtime against the token endpoint (Windows only)
-test-dotnet-framework-token:
+test-dotnet-framework-token-endpoint:
 	@echo "Running integration tests on the .NET Framework runtime against the token endpoint..."
 	@dotnet test ${TEST_LOGGER_OPTIONS} -f ${DOTNET_FRAMEWORK_VERSION} --filter ${TOKEN_ENDPOINT_TESTS_FILTER}
 
 
 ## Run cache endpoint tests
-test-cache: ${TEST_TARGETS_CACHE}
+test-cache-endpoint: ${TEST_TARGETS_CACHE_ENDPOINT}
 
 
 ## Run control endpoint tests
-test-control: ${TEST_TARGETS_CONTROL}
+test-control-endpoint: ${TEST_TARGETS_CONTROL_ENDPOINT}
 
 
 ## Run token endpoint tests
-test-token: ${TEST_TARGETS_TOKEN}
+test-token-endpoint: ${TEST_TARGETS_TOKEN_ENDPOINT}
 
 
 ## Run storage endpoint tests
-test-storage:
+test-storage-endpoint:
 	@echo "Storage tests are not yet implemented."
 
 

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@
 #   - On Windows `make build` (test) runs both .NET 6.0 and .NET Framework build (test) targets.
 #   - On other operating systems `make build` (test) we only runs the .NET 6.0 build (test) targets.
 # - We also have a GRPC_WEB flag that can be set to true to enable gRPC-Web support.
-#   - The caller can run `make GRPC_WEB=true <target>` (eg build or test) to enable gRPC-Web support.
+#   - The caller can run `make GRPC_WEB=true build` to enable gRPC-Web support.
 # - We additionally group the integration tests by endpoint (cache, control, token).
 #   - This is to allow for more granular testing by endpoint.
 #   - Similar to `build` and `test` targets, we have `test-cache`, `test-control`, `test-token`, and `test-storage` targets
@@ -53,7 +53,6 @@ endif
 CACHE_ENDPOINT_TESTS_FILTER := "FullyQualifiedName~Momento.Sdk.Tests.Integration.Cache.Data|FullyQualifiedName~Momento.Sdk.Tests.Integration.Topics.Data"
 CONTROL_ENDPOINT_TESTS_FILTER := "FullyQualifiedName~Momento.Sdk.Tests.Integration.Cache.Control"
 TOKEN_ENDPOINT_TESTS_FILTER := "FullyQualifiedName~Momento.Sdk.Tests.Integration.Auth"
-UNIT_TESTS_FILTER := "FullyQualifiedName~Momento.Sdk.Tests.Unit"
 
 
 ## Generate sync unit tests, format, lint, and test
@@ -100,11 +99,9 @@ test: ${TEST_TARGETS}
 
 
 ## Run unit and integration tests on the .NET 6.0 runtime
-test-dotnet6: test-dotnet6-integration test-dotnet6-unit
-
-
-## Run integration tests on the .NET 6.0 runtime
-test-dotnet6-integration: test-dotnet6-cache test-dotnet6-control test-dotnet6-token
+test-dotnet6:
+	@echo "Running unit and integration tests on the .NET 6.0 runtime..."
+	@dotnet test ${TEST_LOGGER_OPTIONS} -f ${DOTNET_VERSION}
 
 
 ## Run integration tests on the .NET 6.0 runtime against the cache endpoint
@@ -125,18 +122,10 @@ test-dotnet6-token:
 	@dotnet test ${TEST_LOGGER_OPTIONS} -f ${DOTNET_VERSION} --filter ${TOKEN_ENDPOINT_TESTS_FILTER}
 
 
-## Run unit tests on the .NET 6.0 runtime
-test-dotnet6-unit:
-	@echo "Running unit tests on the .NET 6.0 runtime..."
-	@dotnet test ${TEST_LOGGER_OPTIONS} -f ${DOTNET_VERSION} --filter ${UNIT_TESTS_FILTER}
-
-
 ## Run unit and integration tests on the .NET Framework runtime (Windows only)
-test-dotnet-framework: test-dotnet-framework-integration test-dotnet-framework-unit
-
-
-## Run integration tests on the .NET Framework runtime (Windows only)
-test-dotnet-framework-integration: test-dotnet-framework-cache test-dotnet-framework-control test-dotnet-framework-token
+test-dotnet-framework:
+	@echo "Running unit and integration tests on the .NET Framework runtime..."
+	@dotnet test ${TEST_LOGGER_OPTIONS} -f ${DOTNET_FRAMEWORK_VERSION}
 
 
 ## Run integration tests on the .NET Framework runtime against the cache endpoint (Windows only)
@@ -155,12 +144,6 @@ test-dotnet-framework-control:
 test-dotnet-framework-token:
 	@echo "Running integration tests on the .NET Framework runtime against the token endpoint..."
 	@dotnet test ${TEST_LOGGER_OPTIONS} -f ${DOTNET_FRAMEWORK_VERSION} --filter ${TOKEN_ENDPOINT_TESTS_FILTER}
-
-
-## Run unit tests on the .NET Framework runtime (Windows only)
-test-dotnet-framework-unit:
-	@echo "Running unit tests on the .NET Framework runtime..."
-	@dotnet test ${TEST_LOGGER_OPTIONS} -f ${DOTNET_FRAMEWORK_VERSION} --filter ${UNIT_TESTS_FILTER}
 
 
 ## Run cache endpoint tests

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,30 @@
-.PHONY: all build build-dotnet6 build-dotnet-framework clean clean-build precommit restore test test-dotnet6 test-dotnet-framework run-examples help
+# Note on the structure of this Makefile:
+# - We build the project on both .NET 6.0 and .NET Framework 4.62. The latter of which is only available on Windows.
+#   - We still test on Linux. That means we can't run the .NET Framework tests on Linux, but we need to run both .NET 6.0 and .NET Framework tests on Windows.
+# - Because of this, we must conditionally run certain build and test targets based on the operating system.
+#   - We split the build and test targets are split into two categories: .NET 6.0 and .NET Framework.
+#   - At the top we detect the operating system and set the appropriate build and test targets.
+#   - On Windows `make build` (test) runs both .NET 6.0 and .NET Framework build (test) targets.
+#   - On other operating systems `make build` (test) we only runs the .NET 6.0 build (test) targets.
+# - We also have a GRPC_WEB flag that can be set to true to enable gRPC-Web support.
+#   - The caller can run `make GRPC_WEB=true <target>` (eg build or test) to enable gRPC-Web support.
+# - We additionally group the integration tests by endpoint (cache, control, token).
+#   - This is to allow for more granular testing by endpoint.
+#   - Similar to `build` and `test` targets, we have `test-cache`, `test-control`, `test-token`, and `test-storage` targets
+#	  that are conditionally run based on the operating system.
+
+.PHONY: all build build-dotnet6 build-dotnet-framework clean clean-build precommit restore test \
+	test-dotnet6 test-dotnet6-integration test-dotnet6-cache test-dotnet6-control test-dotnet6-token test-dotnet6-unit \
+	test-dotnet-framework test-dotnet-framework-integration test-dotnet-framework-cache test-dotnet-framework-control test-dotnet-framework-token test-dotnet-framework-unit \
+	test-control test-cache test-token test-storage \
+	run-examples help
 
 # Determine the operating system
 OS := $(shell uname)
 
 # Set the default .NET version to .NET 6.0
 DOTNET_VERSION := net6.0
+DOTNET_FRAMEWORK_VERSION := net462
 TEST_LOGGER_OPTIONS := --logger "console;verbosity=detailed"
 
 # Windows-specific settings
@@ -12,9 +32,15 @@ TEST_LOGGER_OPTIONS := --logger "console;verbosity=detailed"
 ifneq (,$(findstring NT,$(OS)))
     BUILD_TARGETS := build-dotnet6 build-dotnet-framework
     TEST_TARGETS := test-dotnet6 test-dotnet-framework
+	TEST_TARGETS_CACHE := test-dotnet6-cache test-dotnet-framework-cache
+	TEST_TARGETS_CONTROL := test-dotnet6-control test-dotnet-framework-control
+	TEST_TARGETS_TOKEN := test-dotnet6-token test-dotnet-framework-token
 else
     BUILD_TARGETS := build-dotnet6
     TEST_TARGETS := test-dotnet6
+	TEST_TARGETS_CACHE := test-dotnet6-cache
+	TEST_TARGETS_CONTROL := test-dotnet6-control
+	TEST_TARGETS_TOKEN := test-dotnet6-token
 endif
 
 # Enable gRPC-Web if requested
@@ -22,6 +48,13 @@ GRPC_WEB_FLAG :=
 ifeq ($(GRPC_WEB), true)
     GRPC_WEB_FLAG := -p:DefineConstants=USE_GRPC_WEB
 endif
+
+# Various test filters
+CACHE_ENDPOINT_TESTS_FILTER := "FullyQualifiedName~Momento.Sdk.Tests.Integration.Cache.Data|FullyQualifiedName~Momento.Sdk.Tests.Integration.Topics.Data"
+CONTROL_ENDPOINT_TESTS_FILTER := "FullyQualifiedName~Momento.Sdk.Tests.Integration.Cache.Control"
+TOKEN_ENDPOINT_TESTS_FILTER := "FullyQualifiedName~Momento.Sdk.Tests.Integration.Auth"
+UNIT_TESTS_FILTER := "FullyQualifiedName~Momento.Sdk.Tests.Unit"
+
 
 ## Generate sync unit tests, format, lint, and test
 all: precommit
@@ -67,15 +100,84 @@ test: ${TEST_TARGETS}
 
 
 ## Run unit and integration tests on the .NET 6.0 runtime
-test-dotnet6:
-	@echo "Running tests on .NET 6.0..."
-	@dotnet test ${TEST_LOGGER_OPTIONS} -f ${DOTNET_VERSION}
+test-dotnet6: test-dotnet6-integration test-dotnet6-unit
+
+
+## Run integration tests on the .NET 6.0 runtime
+test-dotnet6-integration: test-dotnet6-cache test-dotnet6-control test-dotnet6-token
+
+
+## Run integration tests on the .NET 6.0 runtime against the cache endpoint
+test-dotnet6-cache:
+	@echo "Running integration tests on the .NET 6.0 runtime against the cache endpoint..."
+	@dotnet test ${TEST_LOGGER_OPTIONS} -f ${DOTNET_VERSION} --filter ${CACHE_ENDPOINT_TESTS_FILTER}
+
+
+## Run integration tests on the .NET 6.0 runtime against the control endpoint
+test-dotnet6-control:
+	@echo "Running integration tests on the .NET 6.0 runtime against the control endpoint..."
+	@dotnet test ${TEST_LOGGER_OPTIONS} -f ${DOTNET_VERSION} --filter ${CONTROL_ENDPOINT_TESTS_FILTER}
+
+
+## Run integration tests on the .NET 6.0 runtime against the token endpoint
+test-dotnet6-token:
+	@echo "Running integration tests on the .NET 6.0 runtime against the token endpoint..."
+	@dotnet test ${TEST_LOGGER_OPTIONS} -f ${DOTNET_VERSION} --filter ${TOKEN_ENDPOINT_TESTS_FILTER}
+
+
+## Run unit tests on the .NET 6.0 runtime
+test-dotnet6-unit:
+	@echo "Running unit tests on the .NET 6.0 runtime..."
+	@dotnet test ${TEST_LOGGER_OPTIONS} -f ${DOTNET_VERSION} --filter ${UNIT_TESTS_FILTER}
 
 
 ## Run unit and integration tests on the .NET Framework runtime (Windows only)
-test-dotnet-framework:
-	@echo "Running tests on .NET Framework 4.62 (Windows only)..."
-	@dotnet test ${TEST_LOGGER_OPTIONS} -f net462
+test-dotnet-framework: test-dotnet-framework-integration test-dotnet-framework-unit
+
+
+## Run integration tests on the .NET Framework runtime (Windows only)
+test-dotnet-framework-integration: test-dotnet-framework-cache test-dotnet-framework-control test-dotnet-framework-token
+
+
+## Run integration tests on the .NET Framework runtime against the cache endpoint (Windows only)
+test-dotnet-framework-cache:
+	@echo "Running integration tests on the .NET Framework runtime against the cache endpoint..."
+	@dotnet test ${TEST_LOGGER_OPTIONS} -f ${DOTNET_FRAMEWORK_VERSION} --filter ${CACHE_ENDPOINT_TESTS_FILTER}
+
+
+## Run integration tests on the .NET Framework runtime against the control endpoint (Windows only)
+test-dotnet-framework-control:
+	@echo "Running integration tests on the .NET Framework runtime against the control endpoint..."
+	@dotnet test ${TEST_LOGGER_OPTIONS} -f ${DOTNET_FRAMEWORK_VERSION} --filter ${CONTROL_ENDPOINT_TESTS_FILTER}
+
+
+## Run integration tests on the .NET Framework runtime against the token endpoint (Windows only)
+test-dotnet-framework-token:
+	@echo "Running integration tests on the .NET Framework runtime against the token endpoint..."
+	@dotnet test ${TEST_LOGGER_OPTIONS} -f ${DOTNET_FRAMEWORK_VERSION} --filter ${TOKEN_ENDPOINT_TESTS_FILTER}
+
+
+## Run unit tests on the .NET Framework runtime (Windows only)
+test-dotnet-framework-unit:
+	@echo "Running unit tests on the .NET Framework runtime..."
+	@dotnet test ${TEST_LOGGER_OPTIONS} -f ${DOTNET_FRAMEWORK_VERSION} --filter ${UNIT_TESTS_FILTER}
+
+
+## Run cache endpoint tests
+test-cache: ${TEST_TARGETS_CACHE}
+
+
+## Run control endpoint tests
+test-control: ${TEST_TARGETS_CONTROL}
+
+
+## Run token endpoint tests
+test-token: ${TEST_TARGETS_TOKEN}
+
+
+## Run storage endpoint tests
+test-storage:
+	@echo "Storage tests are not yet implemented."
 
 
 ## Run example applications and snippets

--- a/Makefile
+++ b/Makefile
@@ -30,14 +30,14 @@ TEST_LOGGER_OPTIONS := --logger "console;verbosity=detailed"
 # Windows-specific settings
 # This tests if "NT" is in the OS string, which would indicate Windows.
 ifneq (,$(findstring NT,$(OS)))
-    BUILD_TARGETS := build-dotnet6 build-dotnet-framework
-    TEST_TARGETS := test-dotnet6 test-dotnet-framework
+	BUILD_TARGETS := build-dotnet6 build-dotnet-framework
+	TEST_TARGETS := test-dotnet6 test-dotnet-framework
 	TEST_TARGETS_CACHE := test-dotnet6-cache test-dotnet-framework-cache
 	TEST_TARGETS_CONTROL := test-dotnet6-control test-dotnet-framework-control
 	TEST_TARGETS_TOKEN := test-dotnet6-token test-dotnet-framework-token
 else
-    BUILD_TARGETS := build-dotnet6
-    TEST_TARGETS := test-dotnet6
+	BUILD_TARGETS := build-dotnet6
+	TEST_TARGETS := test-dotnet6
 	TEST_TARGETS_CACHE := test-dotnet6-cache
 	TEST_TARGETS_CONTROL := test-dotnet6-control
 	TEST_TARGETS_TOKEN := test-dotnet6-token
@@ -46,7 +46,7 @@ endif
 # Enable gRPC-Web if requested
 GRPC_WEB_FLAG :=
 ifeq ($(GRPC_WEB), true)
-    GRPC_WEB_FLAG := -p:DefineConstants=USE_GRPC_WEB
+	GRPC_WEB_FLAG := -p:DefineConstants=USE_GRPC_WEB
 endif
 
 # Various test filters

--- a/tests/Integration/Momento.Sdk.Tests/Auth/AuthClientCacheTest.cs
+++ b/tests/Integration/Momento.Sdk.Tests/Auth/AuthClientCacheTest.cs
@@ -4,7 +4,7 @@ using Momento.Sdk.Auth;
 using Momento.Sdk.Auth.AccessControl;
 using Momento.Sdk.Config;
 
-namespace Momento.Sdk.Tests;
+namespace Momento.Sdk.Tests.Integration.Auth;
 
 [Collection("AuthClient")]
 public class AuthClientCacheTest : IClassFixture<CacheClientFixture>, IClassFixture<AuthClientFixture>

--- a/tests/Integration/Momento.Sdk.Tests/Auth/AuthClientTopicTest.cs
+++ b/tests/Integration/Momento.Sdk.Tests/Auth/AuthClientTopicTest.cs
@@ -5,7 +5,7 @@ using Momento.Sdk.Auth.AccessControl;
 using Momento.Sdk.Config;
 using System.Collections.Generic;
 
-namespace Momento.Sdk.Tests;
+namespace Momento.Sdk.Tests.Integration.Auth;
 
 [Collection("AuthClient")]
 public class AuthClientTopicTest : IClassFixture<CacheClientFixture>, IClassFixture<AuthClientFixture>, IClassFixture<TopicClientFixture>

--- a/tests/Integration/Momento.Sdk.Tests/Cache/Control/CacheControlTest.cs
+++ b/tests/Integration/Momento.Sdk.Tests/Cache/Control/CacheControlTest.cs
@@ -3,7 +3,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Momento.Sdk.Auth;
 
-namespace Momento.Sdk.Tests;
+namespace Momento.Sdk.Tests.Integration.Cache.Control;
 
 [Collection("CacheClient")]
 public class CacheControlTest : TestBase

--- a/tests/Integration/Momento.Sdk.Tests/Cache/Data/CacheEagerConnectionTest.cs
+++ b/tests/Integration/Momento.Sdk.Tests/Cache/Data/CacheEagerConnectionTest.cs
@@ -3,7 +3,7 @@ using Momento.Sdk.Auth;
 using Momento.Sdk.Config;
 using Momento.Sdk.Config.Transport;
 
-namespace Momento.Sdk.Tests.Integration;
+namespace Momento.Sdk.Tests.Integration.Cache.Data;
 
 public class CacheEagerConnectionTest
 {
@@ -38,7 +38,7 @@ public class CacheEagerConnectionTest
         config = config.WithTransportStrategy(config.TransportStrategy
                                                     .WithGrpcConfig(grpcConfiguration)
                                                     .WithMaxConcurrentRequests(2));
-       
+
         // just validating that we can construct the client wh
         var client = new CacheClient(config, authProvider, defaultTtl);
         // still 2; clients shouldn't know we are doing 2/10 magic internally
@@ -52,7 +52,7 @@ public class CacheEagerConnectionTest
         var config = Configurations.Laptop.Latest(loggerFactory);
         var authProviderWithBadCacheEndpoint = authProvider.WithCacheEndpoint("cache.cell-external-beta-1.prod.a.momentohq.com:65000");
         Console.WriteLine($"Hello developer!  We are about to run a test that verifies that the cache client is still operational even if our eager connection (ping) fails.  So you will see the test log a warning message about that.  It's expected, don't worry!");
-        
+
         await Assert.ThrowsAsync<ConnectionException>(async () => await CacheClient.CreateAsync(config, authProviderWithBadCacheEndpoint, defaultTtl, TimeSpan.FromSeconds(2)));
     }
 }

--- a/tests/Integration/Momento.Sdk.Tests/Cache/Data/CacheScalarTest.cs
+++ b/tests/Integration/Momento.Sdk.Tests/Cache/Data/CacheScalarTest.cs
@@ -4,7 +4,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Momento.Sdk.Internal.ExtensionMethods;
 
-namespace Momento.Sdk.Tests;
+namespace Momento.Sdk.Tests.Integration.Cache.Data;
 
 [Collection("CacheClient")]
 public class CacheDataTest : TestBase

--- a/tests/Integration/Momento.Sdk.Tests/Cache/Data/DictionaryTest.cs
+++ b/tests/Integration/Momento.Sdk.Tests/Cache/Data/DictionaryTest.cs
@@ -3,7 +3,7 @@ using System.Threading.Tasks;
 using Momento.Sdk.Internal.ExtensionMethods;
 using Momento.Sdk.Requests;
 
-namespace Momento.Sdk.Tests;
+namespace Momento.Sdk.Tests.Integration.Cache.Data;
 
 [Collection("CacheClient")]
 public class DictionaryTest : TestBase

--- a/tests/Integration/Momento.Sdk.Tests/Cache/Data/ListTest.cs
+++ b/tests/Integration/Momento.Sdk.Tests/Cache/Data/ListTest.cs
@@ -6,7 +6,7 @@ using Momento.Sdk.Requests;
 using Momento.Sdk.Responses;
 using Momento.Sdk.Tests;
 
-namespace Momento.Sdk.Tests;
+namespace Momento.Sdk.Tests.Integration.Cache.Data;
 
 [Collection("CacheClient")]
 public class ListTest : TestBase
@@ -140,7 +140,7 @@ public class ListTest : TestBase
     public async Task ListRetainAsync_InvalidIndices_AreError()
     {
         var listName = Utils.NewGuidString();
-        
+
         // the positive startIndex is larger than the positive endIndex
         CacheListRetainResponse fetchResponse = await client.ListRetainAsync(cacheName, listName, 3, 1);
         Assert.True(fetchResponse is CacheListRetainResponse.Error, $"Unexpected response: {fetchResponse}");
@@ -156,7 +156,7 @@ public class ListTest : TestBase
         Assert.True(fetchResponse is CacheListRetainResponse.Error, $"Unexpected response: {fetchResponse}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheListRetainResponse.Error)fetchResponse).ErrorCode);
     }
-    
+
     [Fact]
     public async Task ListRetainAsync_HappyPath()
     {
@@ -182,7 +182,7 @@ public class ListTest : TestBase
         Assert.True(fetchResponse is CacheListFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
         var hitResponse = (CacheListFetchResponse.Hit)fetchResponse;
         Assert.Equal(new string[] { value2, value3, value4 }, hitResponse.ValueListString);
-        
+
         await resetList();
         retainResponse = await client.ListRetainAsync(cacheName, listName, 2, -1);
         Assert.True(retainResponse is CacheListRetainResponse.Success, $"Unexpected response: {retainResponse}");
@@ -190,7 +190,7 @@ public class ListTest : TestBase
         Assert.True(fetchResponse is CacheListFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
         hitResponse = (CacheListFetchResponse.Hit)fetchResponse;
         Assert.Equal(new string[] { value3, value4, value5 }, hitResponse.ValueListString);
-        
+
         await resetList();
         retainResponse = await client.ListRetainAsync(cacheName, listName, -4, -1);
         Assert.True(retainResponse is CacheListRetainResponse.Success, $"Unexpected response: {retainResponse}");
@@ -198,8 +198,8 @@ public class ListTest : TestBase
         Assert.True(fetchResponse is CacheListFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
         hitResponse = (CacheListFetchResponse.Hit)fetchResponse;
         Assert.Equal(new string[] { value3, value4, value5 }, hitResponse.ValueListString);
-        
-        await resetList();        
+
+        await resetList();
         // valid case for a negative startIndex and null endIndex
         retainResponse = await client.ListRetainAsync(cacheName, listName, -3, null);
         Assert.True(retainResponse is CacheListRetainResponse.Success, $"Unexpected response: {retainResponse}");
@@ -216,7 +216,7 @@ public class ListTest : TestBase
         Assert.True(fetchResponse is CacheListFetchResponse.Hit, $"Unexpected response: {fetchResponse}");
         hitResponse = (CacheListFetchResponse.Hit)fetchResponse;
         Assert.Equal(new string[] { value3, value4, value5, value6 }, hitResponse.ValueListString);
-        
+
         await resetList();
         // valid case for null startIndex and positive endIndex
         retainResponse = await client.ListRetainAsync(cacheName, listName, null, 1);

--- a/tests/Integration/Momento.Sdk.Tests/Cache/Data/SetTest.cs
+++ b/tests/Integration/Momento.Sdk.Tests/Cache/Data/SetTest.cs
@@ -6,7 +6,7 @@ using Momento.Sdk.Responses;
 using Momento.Sdk.Tests;
 using Xunit.Abstractions;
 
-namespace Momento.Sdk.Tests;
+namespace Momento.Sdk.Tests.Integration.Cache.Data;
 
 [Collection("CacheClient")]
 public class SetTest : TestBase
@@ -577,7 +577,7 @@ public class SetTest : TestBase
         var set2 = hitResponse.ValueSetString;
         Assert.Same(set1, set2);
     }
-    
+
     [Theory]
     [InlineData(null, "my-set", 100)]
     [InlineData("cache", null, 100)]
@@ -588,7 +588,7 @@ public class SetTest : TestBase
         Assert.True(response is CacheSetSampleResponse.Error, $"Unexpected response: {response}");
         Assert.Equal(MomentoErrorCode.INVALID_ARGUMENT_ERROR, ((CacheSetSampleResponse.Error)response).ErrorCode);
     }
-    
+
     [Fact]
     public async Task SetSampleAsync_Missing_HappyPath()
     {
@@ -609,17 +609,17 @@ public class SetTest : TestBase
         Assert.True(allElementsResponse is CacheSetSampleResponse.Hit, $"Unexpected response: {allElementsResponse}");
         var allElementsHitValues = ((CacheSetSampleResponse.Hit)allElementsResponse).ValueSetString;
         Assert.True(allValues.SetEquals(allElementsHitValues), $"Expected sample with with limit matching set size to return the entire set; expected ({String.Join(", ", allValues)}), got ({String.Join(", ", allElementsHitValues)})");
-        
+
         CacheSetSampleResponse limitGreaterThanSetSizeResponse = await client.SetSampleAsync(cacheName, setName, 1000);
         Assert.True(limitGreaterThanSetSizeResponse is CacheSetSampleResponse.Hit, $"Unexpected response: {limitGreaterThanSetSizeResponse}");
         var limitGreaterThanSetSizeHitValues = ((CacheSetSampleResponse.Hit)limitGreaterThanSetSizeResponse).ValueSetString;
         Assert.True(allValues.SetEquals(limitGreaterThanSetSizeHitValues), $"Expected sample with with limit greater than set size to return the entire set; expected ({String.Join(", ", allValues)}), got ({String.Join(", ", limitGreaterThanSetSizeHitValues)})");
-        
+
         CacheSetSampleResponse limitZeroResponse = await client.SetSampleAsync(cacheName, setName, 0);
         var emptySet = new HashSet<String>();
         var limitZeroHitValues = ((CacheSetSampleResponse.Hit)limitZeroResponse).ValueSetString;
         Assert.True(emptySet.SetEquals(limitZeroHitValues), $"Expected sample with with limit zero to return empty set; got ({limitZeroHitValues})");
-        
+
         for (int i = 0; i < 10; i++)
         {
             CacheSetSampleResponse response = await client.SetSampleAsync(cacheName, setName, allValues.Count - 2);
@@ -630,7 +630,7 @@ public class SetTest : TestBase
                 $"Expected hit values ({String.Join(", ", hitValues)}) to be subset of all values ({String.Join(", ", allValues)}), but it is not!");
         }
     }
-    
+
 
     [Fact]
     public async Task CacheSetFetchResponse_ToString_HappyPath()
@@ -675,7 +675,7 @@ public class SetTest : TestBase
         fetchResponse = await client.SetFetchAsync(cacheName, setName);
         Assert.True(fetchResponse is CacheSetFetchResponse.Miss, $"Unexpected response: {fetchResponse}");
     }
-    
+
     [Fact]
     public async Task SetLengthAsync_SetIsMissing()
     {

--- a/tests/Integration/Momento.Sdk.Tests/Cache/Data/TtlTest.cs
+++ b/tests/Integration/Momento.Sdk.Tests/Cache/Data/TtlTest.cs
@@ -4,7 +4,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Momento.Sdk.Internal.ExtensionMethods;
 
-namespace Momento.Sdk.Tests;
+namespace Momento.Sdk.Tests.Integration.Cache.Data;
 
 [Collection("CacheClient")]
 public class TtlTest : TestBase

--- a/tests/Integration/Momento.Sdk.Tests/Fixtures.cs
+++ b/tests/Integration/Momento.Sdk.Tests/Fixtures.cs
@@ -2,7 +2,7 @@ using Microsoft.Extensions.Logging;
 using Momento.Sdk.Auth;
 using Momento.Sdk.Config;
 
-namespace Momento.Sdk.Tests;
+namespace Momento.Sdk.Tests.Integration;
 
 /// <summary>
 /// A cache client fixture.

--- a/tests/Integration/Momento.Sdk.Tests/TestBase.cs
+++ b/tests/Integration/Momento.Sdk.Tests/TestBase.cs
@@ -1,7 +1,7 @@
 ﻿using Momento.Sdk.Auth;
 using Momento.Sdk.Tests;
 
-namespace Momento.Sdk.Tests;
+namespace Momento.Sdk.Tests.Integration;
 
 public class TestBase
 {

--- a/tests/Integration/Momento.Sdk.Tests/TestCacheClient.cs
+++ b/tests/Integration/Momento.Sdk.Tests/TestCacheClient.cs
@@ -4,7 +4,7 @@ using Momento.Sdk.Auth;
 using Momento.Sdk.Config;
 using Momento.Sdk.Requests;
 
-namespace Momento.Sdk.Tests;
+namespace Momento.Sdk.Tests.Integration;
 
 /// <summary>
 /// Client call wrapper to make test expectations easier to write.
@@ -26,7 +26,8 @@ public class TestCacheClient : ICacheClient
     /// Momento in the same datacenter. From your laptop you'll pretty much always pay 10
     /// milliseconds to lightspeed tax, at least in 2023.
     /// </summary>
-    private async Task Quiesce() {
+    private async Task Quiesce()
+    {
         await Task.Delay(TimeSpan.FromMilliseconds(10));
     }
 
@@ -316,7 +317,7 @@ public class TestCacheClient : ICacheClient
     {
         return ((ICacheClient)client).SetFetchAsync(cacheName, setName);
     }
-    
+
     public Task<CacheSetSampleResponse> SetSampleAsync(string cacheName, string setName, int limit)
     {
         return ((ICacheClient)client).SetSampleAsync(cacheName, setName, limit);

--- a/tests/Integration/Momento.Sdk.Tests/Topics/Data/TopicTest.cs
+++ b/tests/Integration/Momento.Sdk.Tests/Topics/Data/TopicTest.cs
@@ -5,8 +5,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
-// ReSharper disable once CheckNamespace
-namespace Momento.Sdk.Tests;
+namespace Momento.Sdk.Tests.Integration.Topics.Data;
 
 public class TopicTest : IClassFixture<CacheClientFixture>, IClassFixture<TopicClientFixture>
 {
@@ -207,7 +206,7 @@ public class TopicTest : IClassFixture<CacheClientFixture>, IClassFixture<TopicC
                 throw new Exception("subscription error");
         }
     }
-    
+
     [Fact]
     public async Task MultipleSubscriptions_HappyPath()
     {
@@ -217,7 +216,7 @@ public class TopicTest : IClassFixture<CacheClientFixture>, IClassFixture<TopicC
             Enumerable.Range(1, numTopics).Select(i =>
                 topicClient.SubscribeAsync(cacheName, $"topic{i}")
                     .ContinueWith(r => Tuple.Create(i, r.Result))).ToList());
-        
+
         var subscriptions = subscriptionResponses.Select(t =>
         {
             var (topicNum, subscriptionResponse) = t;
@@ -232,7 +231,7 @@ public class TopicTest : IClassFixture<CacheClientFixture>, IClassFixture<TopicC
         var subscribers = subscriptions.Select(t => Task.Run(async () =>
         {
             var (topicNum, subscription) = t;
- 
+
             int messageCount = 0;
             await foreach (var message in subscription)
             {
@@ -246,7 +245,7 @@ public class TopicTest : IClassFixture<CacheClientFixture>, IClassFixture<TopicC
 
             return messageCount;
         })).ToList();
-    
+
         await Task.Delay(100);
 
         const int numMessagesToPublish = 50;
@@ -263,15 +262,15 @@ public class TopicTest : IClassFixture<CacheClientFixture>, IClassFixture<TopicC
 
             await Task.Delay(100);
         }
-    
+
         await Task.Delay(1_000);
-        
+
         foreach (var subscriptionTuple in subscriptions)
         {
             var (_, subscription) = subscriptionTuple;
             subscription.Dispose();
         }
-    
+
         var subscriberResults = await Task.WhenAll(subscribers);
         var numMessagesReceived = subscriberResults.Sum();
         Assert.Equal(numMessagesToPublish, numMessagesReceived);

--- a/tests/Integration/Momento.Sdk.Tests/Usings.cs
+++ b/tests/Integration/Momento.Sdk.Tests/Usings.cs
@@ -2,5 +2,6 @@ global using System;
 global using Momento.Sdk;
 global using Momento.Sdk.Exceptions;
 global using Momento.Sdk.Responses;
+global using Momento.Sdk.Tests.Integration;
 global using Xunit;
 global using Utils = Momento.Sdk.Tests.Integration.Utils;

--- a/tests/Unit/Momento.Sdk.Tests/Auth/CredentialProviderTest.cs
+++ b/tests/Unit/Momento.Sdk.Tests/Auth/CredentialProviderTest.cs
@@ -3,7 +3,7 @@ using Momento.Sdk.Exceptions;
 using System;
 using Xunit;
 
-namespace Momento.Sdk.Tests;
+namespace Momento.Sdk.Tests.Unit;
 
 
 public class CredentialProviderTests

--- a/tests/Unit/Momento.Sdk.Tests/CacheClientConstructorTest.cs
+++ b/tests/Unit/Momento.Sdk.Tests/CacheClientConstructorTest.cs
@@ -4,6 +4,8 @@ using Momento.Sdk.Auth;
 using Momento.Sdk.Config;
 using Xunit;
 
+namespace Momento.Sdk.Tests.Unit;
+
 public class CacheClientConstructorTest
 {
     // this token can be parsed by the JWT parser, so it works for validating the constructors.  It is not a valid token, though, and cannot be used to make actual requests.

--- a/tests/Unit/Momento.Sdk.Tests/ConfigTest.cs
+++ b/tests/Unit/Momento.Sdk.Tests/ConfigTest.cs
@@ -3,6 +3,8 @@ using Momento.Sdk.Config;
 using Momento.Sdk.Config.Transport;
 using Xunit;
 
+namespace Momento.Sdk.Tests.Unit;
+
 public class ConfigTest
 {
     [Fact]

--- a/tests/Unit/Momento.Sdk.Tests/Internal/ExtensionMethods/ByteArrayExtensionsTest.cs
+++ b/tests/Unit/Momento.Sdk.Tests/Internal/ExtensionMethods/ByteArrayExtensionsTest.cs
@@ -2,6 +2,8 @@ using System;
 using Momento.Sdk.Internal.ExtensionMethods;
 using Xunit;
 
+namespace Momento.Sdk.Tests.Unit;
+
 public class ByteArrayExtensionsTest
 {
     [Fact]

--- a/tests/Unit/Momento.Sdk.Tests/Internal/ExtensionMethods/StringExtensionsTest.cs
+++ b/tests/Unit/Momento.Sdk.Tests/Internal/ExtensionMethods/StringExtensionsTest.cs
@@ -2,6 +2,8 @@ using System;
 using Momento.Sdk.Internal.ExtensionMethods;
 using Xunit;
 
+namespace Momento.Sdk.Tests.Unit;
+
 public class StringExtensionsTest
 {
     [Fact]

--- a/tests/Unit/Momento.Sdk.Tests/Responses/CacheGetResponseTest.cs
+++ b/tests/Unit/Momento.Sdk.Tests/Responses/CacheGetResponseTest.cs
@@ -3,7 +3,7 @@ using Momento.Protos.CacheClient;
 using Momento.Sdk.Responses;
 using Xunit;
 
-namespace Momento.Sdk.Tests.Responses;
+namespace Momento.Sdk.Tests.Unit;
 
 public class CacheGetResponseTest
 {


### PR DESCRIPTION
This PR introduces to changes:
1. Groups the tests by integration vs unit tests first, with namespaces; then by service (cache, topics, auth); then by control vs data. This is to ease filtering by the Makefile targets.
2. Adds Makefile targets for each of the endpoints (cache, control, token, storage). Because we test Windows-only builds as well, we make each of these OS-conditional.

A caller wishing to run all the tests can run `make test`. On Windows this will run against both .NET Framework 4.62 (which is Windows only) as well as .NET 6.0. On Linux or Mac OS this will only run against .NET 6.0.

Similarly, a caller wishing to run only the control endpoint tests can run `make test-control-endpoint` (or `test-cache-endpoint`, `test-token-endpoint`, `test-storage-endpoint` for other endpoints).