### PR TITLE
refactor: organize targets by service not endpoint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@
 #   - On other operating systems `make build` (test) we only runs the .NET 6.0 build (test) targets.
 # - We also have a GRPC_WEB flag that can be set to true to enable gRPC-Web support.
 #   - The caller can run `make GRPC_WEB=true build` to enable gRPC-Web support.
-# - We additionally group the integration tests by service (cache, control, token).
+# - We additionally group the integration tests by service (auth, cache, topics).
 #   - This is to allow for more granular testing by service.
 #   - Similar to `build` and `test` targets, we have `test-cache-service`, `test-topics-service`, `test-auth-service` targets
 #	  that are conditionally run based on the operating system.
@@ -16,7 +16,7 @@
 .PHONY: all build build-dotnet6 build-dotnet-framework clean clean-build precommit restore test \
 	test-dotnet6 test-dotnet6-integration test-dotnet6-cache-service test-dotnet6-topics-service test-dotnet6-auth-service \
 	test-dotnet-framework test-dotnet-framework-integration test-dotnet-framework-cache-service test-dotnet-framework-topics-service test-dotnet-framework-auth-service \
-	test-control-service test-cache-service test-token-service \
+	test-auth-service test-cache-service test-leaderboard-service test-storage-service test-topics-service  \
 	run-examples help
 
 # Determine the operating system
@@ -32,15 +32,15 @@ TEST_LOGGER_OPTIONS := --logger "console;verbosity=detailed"
 ifneq (,$(findstring NT,$(OS)))
 	BUILD_TARGETS := build-dotnet6 build-dotnet-framework
 	TEST_TARGETS := test-dotnet6 test-dotnet-framework
+	TEST_TARGETS_AUTH_SERVICE := test-dotnet6-auth-service test-dotnet-framework-auth-service
 	TEST_TARGETS_CACHE_SERVICE := test-dotnet6-cache-service test-dotnet-framework-cache-service
 	TEST_TARGETS_TOPICS_SERVICE := test-dotnet6-topics-service test-dotnet-framework-topics-service
-	TEST_TARGETS_AUTH_SERVICE := test-dotnet6-auth-service test-dotnet-framework-auth-service
 else
 	BUILD_TARGETS := build-dotnet6
 	TEST_TARGETS := test-dotnet6
+	TEST_TARGETS_AUTH_SERVICE := test-dotnet6-auth-service
 	TEST_TARGETS_CACHE_SERVICE := test-dotnet6-cache-service
 	TEST_TARGETS_TOPICS_SERVICE := test-dotnet6-topics-service
-	TEST_TARGETS_AUTH_SERVICE := test-dotnet6-auth-service
 endif
 
 # Enable gRPC-Web if requested
@@ -146,16 +146,26 @@ test-dotnet-framework-auth-service:
 	@dotnet test ${TEST_LOGGER_OPTIONS} -f ${DOTNET_FRAMEWORK_VERSION} --filter ${AUTH_SERVICE_TESTS_FILTER}
 
 
+## Run auth service tests
+test-auth-service: ${TEST_TARGETS_AUTH_SERVICE}
+
+
 ## Run cache service tests
 test-cache-service: ${TEST_TARGETS_CACHE_SERVICE}
 
 
+## Run leaderboard service tests
+test-leaderboard-service:
+	@echo "Leaderboard client not implemented yet."
+
+
+## Run storage service tests
+test-storage-service:
+	@echo "Storage client not implemented yet."
+
+
 ## Run topics service tests
 test-topics-service: ${TEST_TARGETS_TOPICS_SERVICE}
-
-
-## Run auth service tests
-test-auth-service: ${TEST_TARGETS_AUTH_SERVICE}
 
 
 ## Run example applications and snippets

--- a/Makefile
+++ b/Makefile
@@ -8,15 +8,15 @@
 #   - On other operating systems `make build` (test) we only runs the .NET 6.0 build (test) targets.
 # - We also have a GRPC_WEB flag that can be set to true to enable gRPC-Web support.
 #   - The caller can run `make GRPC_WEB=true build` to enable gRPC-Web support.
-# - We additionally group the integration tests by endpoint (cache, control, token).
-#   - This is to allow for more granular testing by endpoint.
-#   - Similar to `build` and `test` targets, we have `test-cache-endpoint`, `test-control-endpoint`, `test-token-endpoint`, and `test-storage-endpoint` targets
+# - We additionally group the integration tests by service (cache, control, token).
+#   - This is to allow for more granular testing by service.
+#   - Similar to `build` and `test` targets, we have `test-cache-service`, `test-topics-service`, `test-auth-service` targets
 #	  that are conditionally run based on the operating system.
 
 .PHONY: all build build-dotnet6 build-dotnet-framework clean clean-build precommit restore test \
-	test-dotnet6 test-dotnet6-integration test-dotnet6-cache-endpoint test-dotnet6-control-endpoint test-dotnet6-token-endpoint \
-	test-dotnet-framework test-dotnet-framework-integration test-dotnet-framework-cache-endpoint test-dotnet-framework-control-endpoint test-dotnet-framework-token-endpoint \
-	test-control-endpoint test-cache-endpoint test-token-endpoint test-storage-endpoint \
+	test-dotnet6 test-dotnet6-integration test-dotnet6-cache-service test-dotnet6-topics-service test-dotnet6-auth-service \
+	test-dotnet-framework test-dotnet-framework-integration test-dotnet-framework-cache-service test-dotnet-framework-topics-service test-dotnet-framework-auth-service \
+	test-control-service test-cache-service test-token-service \
 	run-examples help
 
 # Determine the operating system
@@ -32,15 +32,15 @@ TEST_LOGGER_OPTIONS := --logger "console;verbosity=detailed"
 ifneq (,$(findstring NT,$(OS)))
 	BUILD_TARGETS := build-dotnet6 build-dotnet-framework
 	TEST_TARGETS := test-dotnet6 test-dotnet-framework
-	TEST_TARGETS_CACHE_ENDPOINT := test-dotnet6-cache-endpoint test-dotnet-framework-cache-endpoint
-	TEST_TARGETS_CONTROL_ENDPOINT := test-dotnet6-control-endpoint test-dotnet-framework-control-endpoint
-	TEST_TARGETS_TOKEN_ENDPOINT := test-dotnet6-token-endpoint test-dotnet-framework-token-endpoint
+	TEST_TARGETS_CACHE_SERVICE := test-dotnet6-cache-service test-dotnet-framework-cache-service
+	TEST_TARGETS_TOPICS_SERVICE := test-dotnet6-topics-service test-dotnet-framework-topics-service
+	TEST_TARGETS_AUTH_SERVICE := test-dotnet6-auth-service test-dotnet-framework-auth-service
 else
 	BUILD_TARGETS := build-dotnet6
 	TEST_TARGETS := test-dotnet6
-	TEST_TARGETS_CACHE_ENDPOINT := test-dotnet6-cache-endpoint
-	TEST_TARGETS_CONTROL_ENDPOINT := test-dotnet6-control-endpoint
-	TEST_TARGETS_TOKEN_ENDPOINT := test-dotnet6-token-endpoint
+	TEST_TARGETS_CACHE_SERVICE := test-dotnet6-cache-service
+	TEST_TARGETS_TOPICS_SERVICE := test-dotnet6-topics-service
+	TEST_TARGETS_AUTH_SERVICE := test-dotnet6-auth-service
 endif
 
 # Enable gRPC-Web if requested
@@ -50,9 +50,9 @@ ifeq ($(GRPC_WEB), true)
 endif
 
 # Various test filters
-CACHE_ENDPOINT_TESTS_FILTER := "FullyQualifiedName~Momento.Sdk.Tests.Integration.Cache.Data|FullyQualifiedName~Momento.Sdk.Tests.Integration.Topics.Data"
-CONTROL_ENDPOINT_TESTS_FILTER := "FullyQualifiedName~Momento.Sdk.Tests.Integration.Cache.Control"
-TOKEN_ENDPOINT_TESTS_FILTER := "FullyQualifiedName~Momento.Sdk.Tests.Integration.Auth"
+CACHE_SERVICE_TESTS_FILTER := "FullyQualifiedName~Momento.Sdk.Tests.Integration.Cache"
+TOPICS_SERVICE_TESTS_FILTER := "FullyQualifiedName~Momento.Sdk.Tests.Integration.Topics"
+AUTH_SERVICE_TESTS_FILTER := "FullyQualifiedName~Momento.Sdk.Tests.Integration.Auth"
 
 
 ## Generate sync unit tests, format, lint, and test
@@ -104,22 +104,22 @@ test-dotnet6:
 	@dotnet test ${TEST_LOGGER_OPTIONS} -f ${DOTNET_VERSION}
 
 
-## Run integration tests on the .NET 6.0 runtime against the cache endpoint
-test-dotnet6-cache-endpoint:
-	@echo "Running integration tests on the .NET 6.0 runtime against the cache endpoint..."
-	@dotnet test ${TEST_LOGGER_OPTIONS} -f ${DOTNET_VERSION} --filter ${CACHE_ENDPOINT_TESTS_FILTER}
+## Run integration tests on the .NET 6.0 runtime against the cache service
+test-dotnet6-cache-service:
+	@echo "Running integration tests on the .NET 6.0 runtime against the cache service..."
+	@dotnet test ${TEST_LOGGER_OPTIONS} -f ${DOTNET_VERSION} --filter ${CACHE_SERVICE_TESTS_FILTER}
 
 
-## Run integration tests on the .NET 6.0 runtime against the control endpoint
-test-dotnet6-control-endpoint:
-	@echo "Running integration tests on the .NET 6.0 runtime against the control endpoint..."
-	@dotnet test ${TEST_LOGGER_OPTIONS} -f ${DOTNET_VERSION} --filter ${CONTROL_ENDPOINT_TESTS_FILTER}
+## Run integration tests on the .NET 6.0 runtime against the topics service
+test-dotnet6-topics-service:
+	@echo "Running integration tests on the .NET 6.0 runtime against the topics service..."
+	@dotnet test ${TEST_LOGGER_OPTIONS} -f ${DOTNET_VERSION} --filter ${TOPICS_SERVICE_TESTS_FILTER}
 
 
-## Run integration tests on the .NET 6.0 runtime against the token endpoint
-test-dotnet6-token-endpoint:
-	@echo "Running integration tests on the .NET 6.0 runtime against the token endpoint..."
-	@dotnet test ${TEST_LOGGER_OPTIONS} -f ${DOTNET_VERSION} --filter ${TOKEN_ENDPOINT_TESTS_FILTER}
+## Run integration tests on the .NET 6.0 runtime against the auth service
+test-dotnet6-auth-service:
+	@echo "Running integration tests on the .NET 6.0 runtime against the auth service..."
+	@dotnet test ${TEST_LOGGER_OPTIONS} -f ${DOTNET_VERSION} --filter ${AUTH_SERVICE_TESTS_FILTER}
 
 
 ## Run unit and integration tests on the .NET Framework runtime (Windows only)
@@ -128,39 +128,34 @@ test-dotnet-framework:
 	@dotnet test ${TEST_LOGGER_OPTIONS} -f ${DOTNET_FRAMEWORK_VERSION}
 
 
-## Run integration tests on the .NET Framework runtime against the cache endpoint (Windows only)
-test-dotnet-framework-cache-endpoint:
-	@echo "Running integration tests on the .NET Framework runtime against the cache endpoint..."
-	@dotnet test ${TEST_LOGGER_OPTIONS} -f ${DOTNET_FRAMEWORK_VERSION} --filter ${CACHE_ENDPOINT_TESTS_FILTER}
+## Run integration tests on the .NET Framework runtime against the cache service (Windows only)
+test-dotnet-framework-cache-service:
+	@echo "Running integration tests on the .NET Framework runtime against the cache service..."
+	@dotnet test ${TEST_LOGGER_OPTIONS} -f ${DOTNET_FRAMEWORK_VERSION} --filter ${CACHE_SERVICE_TESTS_FILTER}
 
 
-## Run integration tests on the .NET Framework runtime against the control endpoint (Windows only)
-test-dotnet-framework-control-endpoint:
-	@echo "Running integration tests on the .NET Framework runtime against the control endpoint..."
-	@dotnet test ${TEST_LOGGER_OPTIONS} -f ${DOTNET_FRAMEWORK_VERSION} --filter ${CONTROL_ENDPOINT_TESTS_FILTER}
+## Run integration tests on the .NET Framework runtime against the topics service (Windows only)
+test-dotnet-framework-topics-service:
+	@echo "Running integration tests on the .NET Framework runtime against the topics service..."
+	@dotnet test ${TEST_LOGGER_OPTIONS} -f ${DOTNET_FRAMEWORK_VERSION} --filter ${TOPICS_SERVICE_TESTS_FILTER}
 
 
-## Run integration tests on the .NET Framework runtime against the token endpoint (Windows only)
-test-dotnet-framework-token-endpoint:
-	@echo "Running integration tests on the .NET Framework runtime against the token endpoint..."
-	@dotnet test ${TEST_LOGGER_OPTIONS} -f ${DOTNET_FRAMEWORK_VERSION} --filter ${TOKEN_ENDPOINT_TESTS_FILTER}
+## Run integration tests on the .NET Framework runtime against the auth service (Windows only)
+test-dotnet-framework-auth-service:
+	@echo "Running integration tests on the .NET Framework runtime against the auth service..."
+	@dotnet test ${TEST_LOGGER_OPTIONS} -f ${DOTNET_FRAMEWORK_VERSION} --filter ${AUTH_SERVICE_TESTS_FILTER}
 
 
-## Run cache endpoint tests
-test-cache-endpoint: ${TEST_TARGETS_CACHE_ENDPOINT}
+## Run cache service tests
+test-cache-service: ${TEST_TARGETS_CACHE_SERVICE}
 
 
-## Run control endpoint tests
-test-control-endpoint: ${TEST_TARGETS_CONTROL_ENDPOINT}
+## Run topics service tests
+test-topics-service: ${TEST_TARGETS_TOPICS_SERVICE}
 
 
-## Run token endpoint tests
-test-token-endpoint: ${TEST_TARGETS_TOKEN_ENDPOINT}
-
-
-## Run storage endpoint tests
-test-storage-endpoint:
-	@echo "Storage tests are not yet implemented."
+## Run auth service tests
+test-auth-service: ${TEST_TARGETS_AUTH_SERVICE}
 
 
 ## Run example applications and snippets

--- a/tests/Integration/Momento.Sdk.Tests/Cache/CacheControlTest.cs
+++ b/tests/Integration/Momento.Sdk.Tests/Cache/CacheControlTest.cs
@@ -3,7 +3,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Momento.Sdk.Auth;
 
-namespace Momento.Sdk.Tests.Integration.Cache.Control;
+namespace Momento.Sdk.Tests.Integration.Cache;
 
 [Collection("CacheClient")]
 public class CacheControlTest : TestBase

--- a/tests/Integration/Momento.Sdk.Tests/Cache/CacheEagerConnectionTest.cs
+++ b/tests/Integration/Momento.Sdk.Tests/Cache/CacheEagerConnectionTest.cs
@@ -3,7 +3,7 @@ using Momento.Sdk.Auth;
 using Momento.Sdk.Config;
 using Momento.Sdk.Config.Transport;
 
-namespace Momento.Sdk.Tests.Integration.Cache.Data;
+namespace Momento.Sdk.Tests.Integration.Cache;
 
 public class CacheEagerConnectionTest
 {

--- a/tests/Integration/Momento.Sdk.Tests/Cache/CacheScalarTest.cs
+++ b/tests/Integration/Momento.Sdk.Tests/Cache/CacheScalarTest.cs
@@ -4,13 +4,13 @@ using System.Text;
 using System.Threading.Tasks;
 using Momento.Sdk.Internal.ExtensionMethods;
 
-namespace Momento.Sdk.Tests.Integration.Cache.Data;
+namespace Momento.Sdk.Tests.Integration.Cache;
 
 [Collection("CacheClient")]
-public class CacheDataTest : TestBase
+public class CacheScalarTest : TestBase
 {
     // Test initialization
-    public CacheDataTest(CacheClientFixture fixture) : base(fixture)
+    public CacheScalarTest(CacheClientFixture fixture) : base(fixture)
     {
     }
 

--- a/tests/Integration/Momento.Sdk.Tests/Cache/DictionaryTest.cs
+++ b/tests/Integration/Momento.Sdk.Tests/Cache/DictionaryTest.cs
@@ -3,7 +3,7 @@ using System.Threading.Tasks;
 using Momento.Sdk.Internal.ExtensionMethods;
 using Momento.Sdk.Requests;
 
-namespace Momento.Sdk.Tests.Integration.Cache.Data;
+namespace Momento.Sdk.Tests.Integration.Cache;
 
 [Collection("CacheClient")]
 public class DictionaryTest : TestBase

--- a/tests/Integration/Momento.Sdk.Tests/Cache/ListTest.cs
+++ b/tests/Integration/Momento.Sdk.Tests/Cache/ListTest.cs
@@ -6,7 +6,7 @@ using Momento.Sdk.Requests;
 using Momento.Sdk.Responses;
 using Momento.Sdk.Tests;
 
-namespace Momento.Sdk.Tests.Integration.Cache.Data;
+namespace Momento.Sdk.Tests.Integration.Cache;
 
 [Collection("CacheClient")]
 public class ListTest : TestBase

--- a/tests/Integration/Momento.Sdk.Tests/Cache/SetTest.cs
+++ b/tests/Integration/Momento.Sdk.Tests/Cache/SetTest.cs
@@ -6,7 +6,7 @@ using Momento.Sdk.Responses;
 using Momento.Sdk.Tests;
 using Xunit.Abstractions;
 
-namespace Momento.Sdk.Tests.Integration.Cache.Data;
+namespace Momento.Sdk.Tests.Integration.Cache;
 
 [Collection("CacheClient")]
 public class SetTest : TestBase

--- a/tests/Integration/Momento.Sdk.Tests/Cache/TtlTest.cs
+++ b/tests/Integration/Momento.Sdk.Tests/Cache/TtlTest.cs
@@ -4,7 +4,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Momento.Sdk.Internal.ExtensionMethods;
 
-namespace Momento.Sdk.Tests.Integration.Cache.Data;
+namespace Momento.Sdk.Tests.Integration.Cache;
 
 [Collection("CacheClient")]
 public class TtlTest : TestBase

--- a/tests/Integration/Momento.Sdk.Tests/Topics/TopicTest.cs
+++ b/tests/Integration/Momento.Sdk.Tests/Topics/TopicTest.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Momento.Sdk.Tests.Integration.Topics.Data;
+namespace Momento.Sdk.Tests.Integration.Topics;
 
 public class TopicTest : IClassFixture<CacheClientFixture>, IClassFixture<TopicClientFixture>
 {


### PR DESCRIPTION
Previously we organized the make targets by endpoint. This isn't
granular enough to test when some services aren't deployed at an
endpoint (eg leaderboards in the cache endpoint).

With this change we test by service. Because of this we simplify the
test organization by not grouping by control vs data.
