### PR TITLE
chore: update doc example apis to use advanced api

### DIFF
--- a/examples/DocExampleApis/DocExampleApis.csproj
+++ b/examples/DocExampleApis/DocExampleApis.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Momento.Sdk" Version="1.36.1" />
+    <PackageReference Include="Momento.Sdk" Version="1.37.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Use the "all events" API in the doc examples.
