### PR TITLE
chore: improve resource exhausted error message

### DIFF
--- a/src/Momento.Sdk/Exceptions/CacheExceptionMapper.cs
+++ b/src/Momento.Sdk/Exceptions/CacheExceptionMapper.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Threading.Tasks;
 using Grpc.Core;
 using Microsoft.Extensions.Logging;
@@ -79,7 +80,7 @@ public class CacheExceptionMapper
                     return new AuthenticationException(ex.Message, transportDetails);
 
                 case StatusCode.ResourceExhausted:
-                    return new LimitExceededException(ex.Message, transportDetails);
+                    return new LimitExceededException(ex.Message, transportDetails, ex);
 
                 case StatusCode.NotFound:
                     return new NotFoundException(ex.Message, transportDetails);

--- a/src/Momento.Sdk/Exceptions/CacheExceptionMapper.cs
+++ b/src/Momento.Sdk/Exceptions/CacheExceptionMapper.cs
@@ -78,7 +78,7 @@ public class CacheExceptionMapper
                     return new AuthenticationException(ex.Message, transportDetails);
 
                 case StatusCode.ResourceExhausted:
-                    return new LimitExceededException(ex.Message, transportDetails, ex);
+                    return LimitExceededException.CreateWithMessageWrapper(ex.Message, transportDetails, ex);
 
                 case StatusCode.NotFound:
                     return new NotFoundException(ex.Message, transportDetails);

--- a/src/Momento.Sdk/Exceptions/CacheExceptionMapper.cs
+++ b/src/Momento.Sdk/Exceptions/CacheExceptionMapper.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Linq;
-using System.Threading.Tasks;
 using Grpc.Core;
 using Microsoft.Extensions.Logging;
 

--- a/src/Momento.Sdk/Exceptions/LimitExceededException.cs
+++ b/src/Momento.Sdk/Exceptions/LimitExceededException.cs
@@ -14,31 +14,31 @@ public class LimitExceededException : SdkException
         if (errMetadata != null) {
             this.MessageWrapper = errMetadata switch
             {
-                "topic_subscriptions_limit_exceeded" => LimitExceededMessageWrapper.TopicSubscriptionsLimitExceeded.Value,
-                "operations_rate_limit_exceeded" => LimitExceededMessageWrapper.OperationsRateLimitExceeded.Value,
-                "throughput_rate_limit_exceeded" => LimitExceededMessageWrapper.ThroughputRateLimitExceeded.Value,
-                "request_size_limit_exceeded" => LimitExceededMessageWrapper.RequestSizeLimitExceeded.Value,
-                "item_size_limit_exceeded" => LimitExceededMessageWrapper.ItemSizeLimitExceeded.Value,
-                "element_size_limit_exceeded" => LimitExceededMessageWrapper.ElementSizeLimitExceeded.Value,
-                _ => LimitExceededMessageWrapper.UnknownLimitExceeded.Value,
+                "topic_subscriptions_limit_exceeded" => LimitExceededMessageWrapper.TopicSubscriptionsLimitExceeded,
+                "operations_rate_limit_exceeded" => LimitExceededMessageWrapper.OperationsRateLimitExceeded,
+                "throughput_rate_limit_exceeded" => LimitExceededMessageWrapper.ThroughputRateLimitExceeded,
+                "request_size_limit_exceeded" => LimitExceededMessageWrapper.RequestSizeLimitExceeded,
+                "item_size_limit_exceeded" => LimitExceededMessageWrapper.ItemSizeLimitExceeded,
+                "element_size_limit_exceeded" => LimitExceededMessageWrapper.ElementSizeLimitExceeded,
+                _ => LimitExceededMessageWrapper.UnknownLimitExceeded,
             };
         } else {
             var lowerCasedMessage = message.ToLower();
-            this.MessageWrapper = LimitExceededMessageWrapper.UnknownLimitExceeded.Value;
+            this.MessageWrapper = LimitExceededMessageWrapper.UnknownLimitExceeded;
             if (lowerCasedMessage.Contains("subscribers")) {
-                this.MessageWrapper = LimitExceededMessageWrapper.TopicSubscriptionsLimitExceeded.Value;
+                this.MessageWrapper = LimitExceededMessageWrapper.TopicSubscriptionsLimitExceeded;
             } else if (lowerCasedMessage.Contains("operations")) {
-                this.MessageWrapper = LimitExceededMessageWrapper.OperationsRateLimitExceeded.Value;
+                this.MessageWrapper = LimitExceededMessageWrapper.OperationsRateLimitExceeded;
             } else if (lowerCasedMessage.Contains("throughput")) {
-                this.MessageWrapper = LimitExceededMessageWrapper.ThroughputRateLimitExceeded.Value;
+                this.MessageWrapper = LimitExceededMessageWrapper.ThroughputRateLimitExceeded;
             } else if (lowerCasedMessage.Contains("request limit")) {
-                this.MessageWrapper = LimitExceededMessageWrapper.RequestSizeLimitExceeded.Value;
+                this.MessageWrapper = LimitExceededMessageWrapper.RequestSizeLimitExceeded;
             } else if (lowerCasedMessage.Contains("item size")) {
-                this.MessageWrapper = LimitExceededMessageWrapper.ItemSizeLimitExceeded.Value;
+                this.MessageWrapper = LimitExceededMessageWrapper.ItemSizeLimitExceeded;
             } else if (lowerCasedMessage.Contains("element size")) {
-                this.MessageWrapper = LimitExceededMessageWrapper.ElementSizeLimitExceeded.Value;
+                this.MessageWrapper = LimitExceededMessageWrapper.ElementSizeLimitExceeded;
             } else {
-                this.MessageWrapper = LimitExceededMessageWrapper.UnknownLimitExceeded.Value;
+                this.MessageWrapper = LimitExceededMessageWrapper.UnknownLimitExceeded;
             }
         }
     }
@@ -47,45 +47,35 @@ public class LimitExceededException : SdkException
 /// <summary>
 /// Provides a specific reason for the limit exceeded error.
 /// </summary>
-public sealed class LimitExceededMessageWrapper
+public static class LimitExceededMessageWrapper
 {
     /// <summary>
     /// Topic subscriptions limit exceeded for this account.
     /// </summary>
-    public static readonly LimitExceededMessageWrapper TopicSubscriptionsLimitExceeded = new LimitExceededMessageWrapper("Topic subscriptions limit exceeded for this account");
+    public static string TopicSubscriptionsLimitExceeded = "Topic subscriptions limit exceeded for this account";
     /// <summary>
     /// Request rate limit exceeded for this account.
     /// </summary>
-    public static readonly LimitExceededMessageWrapper OperationsRateLimitExceeded = new LimitExceededMessageWrapper("Request rate limit exceeded for this account");
+    public static string OperationsRateLimitExceeded = "Request rate limit exceeded for this account";
 
     /// <summary>
     /// Bandwidth limit exceeded for this account.
     /// </summary>
-    public static readonly LimitExceededMessageWrapper ThroughputRateLimitExceeded = new LimitExceededMessageWrapper("Bandwidth limit exceeded for this account");
+    public static string ThroughputRateLimitExceeded = "Bandwidth limit exceeded for this account";
     /// <summary>
     /// Request size limit exceeded for this account.
     /// </summary>
-    public static readonly LimitExceededMessageWrapper RequestSizeLimitExceeded = new LimitExceededMessageWrapper("Request size limit exceeded for this account");
+    public static string RequestSizeLimitExceeded = "Request size limit exceeded for this account";
     /// <summary>
     /// Item size limit exceeded for this account.
     /// </summary>
-    public static readonly LimitExceededMessageWrapper ItemSizeLimitExceeded = new LimitExceededMessageWrapper("Item size limit exceeded for this account");
+    public static string ItemSizeLimitExceeded = "Item size limit exceeded for this account";
     /// <summary>
     /// Element size limit exceeded for this account.
     /// </summary>
-    public static readonly LimitExceededMessageWrapper ElementSizeLimitExceeded = new LimitExceededMessageWrapper("Element size limit exceeded for this account");
+    public static string ElementSizeLimitExceeded = "Element size limit exceeded for this account";
     /// <summary>
     /// Unknown limit exceeded for this account.
     /// </summary>
-    public static readonly LimitExceededMessageWrapper UnknownLimitExceeded = new LimitExceededMessageWrapper("Limit exceeded for this account");
-
-    private LimitExceededMessageWrapper(string value)
-    {
-        Value = value;
-    }
-
-    /// <summary>
-    /// The value of the LimitExceededMessageWrapper.
-    /// </summary>
-    public string Value { get; private set; }
+    public static string UnknownLimitExceeded = "Limit exceeded for this account";
 }

--- a/src/Momento.Sdk/Exceptions/LimitExceededException.cs
+++ b/src/Momento.Sdk/Exceptions/LimitExceededException.cs
@@ -1,6 +1,7 @@
 ﻿namespace Momento.Sdk.Exceptions;
 
 using System;
+using Grpc.Core;
 
 /// <summary>
 /// Requested operation couldn't be completed because system limits were hit.
@@ -8,8 +9,84 @@ using System;
 public class LimitExceededException : SdkException
 {
     /// <include file="../docs.xml" path='docs/class[@name="SdkException"]/constructor/*' />
-    public LimitExceededException(string message, MomentoErrorTransportDetails transportDetails, Exception? e = null) : base(MomentoErrorCode.LIMIT_EXCEEDED_ERROR, message, transportDetails, e)
+    public LimitExceededException(string message, MomentoErrorTransportDetails transportDetails, RpcException? e = null) : base(MomentoErrorCode.LIMIT_EXCEEDED_ERROR, message, transportDetails, e)
     {
-        this.MessageWrapper = "Request rate exceeded the limits for this account.  To resolve this error, reduce your request rate, or contact us at support@momentohq.com to request a limit increase";
+        var errMetadata = e?.Trailers.Get("err")?.Value;
+        if (errMetadata != null) {
+            this.MessageWrapper = errMetadata switch
+            {
+                "topic_subscriptions_limit_exceeded" => LimitExceededMessageWrapper.TopicSubscriptionsLimitExceeded.Value,
+                "operations_rate_limit_exceeded" => LimitExceededMessageWrapper.OperationsRateLimitExceeded.Value,
+                "throughput_rate_limit_exceeded" => LimitExceededMessageWrapper.ThroughputRateLimitExceeded.Value,
+                "request_size_limit_exceeded" => LimitExceededMessageWrapper.RequestSizeLimitExceeded.Value,
+                "item_size_limit_exceeded" => LimitExceededMessageWrapper.ItemSizeLimitExceeded.Value,
+                "element_size_limit_exceeded" => LimitExceededMessageWrapper.ElementSizeLimitExceeded.Value,
+                _ => LimitExceededMessageWrapper.UnknownLimitExceeded.Value,
+            };
+        } else {
+            var lowerCasedMessage = message.ToLower();
+            this.MessageWrapper = LimitExceededMessageWrapper.UnknownLimitExceeded.Value;
+            if (lowerCasedMessage.Contains("subscribers")) {
+                this.MessageWrapper = LimitExceededMessageWrapper.TopicSubscriptionsLimitExceeded.Value;
+            } else if (lowerCasedMessage.Contains("operations")) {
+                this.MessageWrapper = LimitExceededMessageWrapper.OperationsRateLimitExceeded.Value;
+            } else if (lowerCasedMessage.Contains("throughput")) {
+                this.MessageWrapper = LimitExceededMessageWrapper.ThroughputRateLimitExceeded.Value;
+            } else if (lowerCasedMessage.Contains("request limit")) {
+                this.MessageWrapper = LimitExceededMessageWrapper.RequestSizeLimitExceeded.Value;
+            } else if (lowerCasedMessage.Contains("item size")) {
+                this.MessageWrapper = LimitExceededMessageWrapper.ItemSizeLimitExceeded.Value;
+            } else if (lowerCasedMessage.Contains("element size")) {
+                this.MessageWrapper = LimitExceededMessageWrapper.ElementSizeLimitExceeded.Value;
+            } else {
+                this.MessageWrapper = LimitExceededMessageWrapper.UnknownLimitExceeded.Value;
+            }
+        }
     }
+}
+
+/// <summary>
+/// Provides a specific reason for the limit exceeded error.
+/// </summary>
+public sealed class LimitExceededMessageWrapper
+{
+    /// <summary>
+    /// Topic subscriptions limit exceeded for this account.
+    /// </summary>
+    public static readonly LimitExceededMessageWrapper TopicSubscriptionsLimitExceeded = new LimitExceededMessageWrapper("Topic subscriptions limit exceeded for this account");
+    /// <summary>
+    /// Request rate limit exceeded for this account.
+    /// </summary>
+    public static readonly LimitExceededMessageWrapper OperationsRateLimitExceeded = new LimitExceededMessageWrapper("Request rate limit exceeded for this account");
+
+    /// <summary>
+    /// Bandwidth limit exceeded for this account.
+    /// </summary>
+    public static readonly LimitExceededMessageWrapper ThroughputRateLimitExceeded = new LimitExceededMessageWrapper("Bandwidth limit exceeded for this account");
+    /// <summary>
+    /// Request size limit exceeded for this account.
+    /// </summary>
+    public static readonly LimitExceededMessageWrapper RequestSizeLimitExceeded = new LimitExceededMessageWrapper("Request size limit exceeded for this account");
+    /// <summary>
+    /// Item size limit exceeded for this account.
+    /// </summary>
+    public static readonly LimitExceededMessageWrapper ItemSizeLimitExceeded = new LimitExceededMessageWrapper("Item size limit exceeded for this account");
+    /// <summary>
+    /// Element size limit exceeded for this account.
+    /// </summary>
+    public static readonly LimitExceededMessageWrapper ElementSizeLimitExceeded = new LimitExceededMessageWrapper("Element size limit exceeded for this account");
+    /// <summary>
+    /// Unknown limit exceeded for this account.
+    /// </summary>
+    public static readonly LimitExceededMessageWrapper UnknownLimitExceeded = new LimitExceededMessageWrapper("Limit exceeded for this account");
+
+    private LimitExceededMessageWrapper(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The value of the LimitExceededMessageWrapper.
+    /// </summary>
+    public string Value { get; private set; }
 }

--- a/src/Momento.Sdk/Exceptions/LimitExceededException.cs
+++ b/src/Momento.Sdk/Exceptions/LimitExceededException.cs
@@ -1,6 +1,5 @@
 ﻿namespace Momento.Sdk.Exceptions;
 
-using System;
 using Grpc.Core;
 
 /// <summary>


### PR DESCRIPTION
Closes https://github.com/momentohq/dev-eco-issue-tracker/issues/1039

Passes the `RpcException` to the `LimitExceededError` so it can parse the trailer metadata or error details to determine the most specific error message wrapper to return.