### PR TITLE
feat: use ulong and topics and plumb through `resumeAt` subscription arguments

### DIFF
--- a/src/Momento.Sdk/Internal/ScsTopicClient.cs
+++ b/src/Momento.Sdk/Internal/ScsTopicClient.cs
@@ -123,7 +123,7 @@ internal sealed class ScsTopicClient : ScsTopicClientBase
         {
             _logger.LogTraceExecutingTopicRequest(RequestTypeTopicSubscribe, cacheName, topicName);
             subscriptionWrapper = new SubscriptionWrapper(grpcManager, cacheName, topicName,
-                resumeAtTopicSequenceNumber ?? 0, resumeAtTopicSequencePage ?? 0, _exceptionMapper, _logger);
+                resumeAtTopicSequenceNumber, resumeAtTopicSequencePage, _exceptionMapper, _logger);
             await subscriptionWrapper.Subscribe();
         }
         catch (Exception e)
@@ -153,14 +153,14 @@ internal sealed class ScsTopicClient : ScsTopicClientBase
         private bool _subscribed;
 
         public SubscriptionWrapper(TopicGrpcManager grpcManager, string cacheName,
-            string topicName, ulong resumeAtTopicSequenceNumber, ulong resumeAtTopicSequencePage,
+            string topicName, ulong? resumeAtTopicSequenceNumber, ulong? resumeAtTopicSequencePage,
             CacheExceptionMapper exceptionMapper, ILogger logger)
         {
             _grpcManager = grpcManager;
             _cacheName = cacheName;
             _topicName = topicName;
-            _lastSequenceNumber = resumeAtTopicSequenceNumber;
-            _lastSequencePage = resumeAtTopicSequencePage;
+            _lastSequenceNumber = resumeAtTopicSequenceNumber ?? 0;
+            _lastSequencePage = resumeAtTopicSequencePage ?? 0;
             _exceptionMapper = exceptionMapper;
             _logger = logger;
         }

--- a/src/Momento.Sdk/Responses/Topic/TopicMessage.cs
+++ b/src/Momento.Sdk/Responses/Topic/TopicMessage.cs
@@ -42,7 +42,7 @@ public abstract class TopicMessage : ITopicEvent
         /// <summary>
         /// A topic message containing a text value.
         /// </summary>
-        public Text(_TopicValue topicValue, long topicSequenceNumber, long topicSequencePage, string? tokenId = null)
+        public Text(_TopicValue topicValue, ulong topicSequenceNumber, ulong topicSequencePage, string? tokenId = null)
         {
             Value = topicValue.Text;
             TopicSequenceNumber = topicSequenceNumber;
@@ -58,12 +58,12 @@ public abstract class TopicMessage : ITopicEvent
         /// <summary>
         /// The sequence number of this message.
         /// </summary>
-        public long TopicSequenceNumber { get; }
+        public ulong TopicSequenceNumber { get; }
 
         /// <summary>
         /// The sequence page of this message.
         /// </summary>
-        public long TopicSequencePage { get; }
+        public ulong TopicSequencePage { get; }
 
         /// <summary>
         /// The TokenId that was used to publish the message, or null if the token did not have an id.
@@ -86,7 +86,7 @@ public abstract class TopicMessage : ITopicEvent
         /// <summary>
         /// A topic message containing a binary value.
         /// </summary>
-        public Binary(_TopicValue topicValue, long topicSequenceNumber, long topicSequencePage, string? tokenId = null)
+        public Binary(_TopicValue topicValue, ulong topicSequenceNumber, ulong topicSequencePage, string? tokenId = null)
         {
             Value = topicValue.Binary.ToByteArray();
             TopicSequenceNumber = topicSequenceNumber;
@@ -103,12 +103,12 @@ public abstract class TopicMessage : ITopicEvent
         /// <summary>
         /// The sequence number of this message.
         /// </summary>
-        public long TopicSequenceNumber { get; }
+        public ulong TopicSequenceNumber { get; }
 
         /// <summary>
         /// The sequence page of this message.
         /// </summary>
-        public long TopicSequencePage { get; }
+        public ulong TopicSequencePage { get; }
 
         /// <summary>
         /// The TokenId that was used to publish the message, or null if the token did not have an id.

--- a/src/Momento.Sdk/Responses/Topic/TopicSystemEvent.cs
+++ b/src/Momento.Sdk/Responses/Topic/TopicSystemEvent.cs
@@ -33,7 +33,7 @@ public abstract class TopicSystemEvent : ITopicEvent
         /// <param name="lastKnownSequenceNumber">The last known sequence number before the discontinuity.</param>
         /// <param name="sequenceNumber">The sequence number of the discontinuity.</param>
         /// <param name="sequencePage">The sequence page of the discontinuity.</param>
-        public Discontinuity(long lastKnownSequenceNumber, long sequenceNumber, long sequencePage)
+        public Discontinuity(ulong lastKnownSequenceNumber, ulong sequenceNumber, ulong sequencePage)
         {
             LastKnownSequenceNumber = lastKnownSequenceNumber;
             SequenceNumber = sequenceNumber;
@@ -43,17 +43,17 @@ public abstract class TopicSystemEvent : ITopicEvent
         /// <summary>
         /// The last known sequence number before the discontinuity.
         /// </summary>
-        public long LastKnownSequenceNumber { get; }
+        public ulong LastKnownSequenceNumber { get; }
 
         /// <summary>
         /// The sequence number of the discontinuity.
         /// </summary>
-        public long SequenceNumber { get; }
+        public ulong SequenceNumber { get; }
 
         /// <summary>
         /// The sequence page of the discontinuity.
         /// </summary>
-        public long SequencePage { get; }
+        public ulong SequencePage { get; }
 
         /// <inheritdoc/>
         public override string ToString()

--- a/tests/Integration/Momento.Sdk.Tests/Topics/TopicTest.cs
+++ b/tests/Integration/Momento.Sdk.Tests/Topics/TopicTest.cs
@@ -145,7 +145,7 @@ public class TopicTest : IClassFixture<CacheClientFixture>, IClassFixture<TopicC
         {
             var textMessage = (TopicMessage.Text)consumedMessages[i];
             Assert.Equal(textMessage.Value, valuesToSend[i]);
-            Assert.Equal(textMessage.TopicSequenceNumber, checked((ulong)(i + 1));
+            Assert.Equal(textMessage.TopicSequenceNumber, checked((ulong)(i + 1)));
         }
     }
 

--- a/tests/Integration/Momento.Sdk.Tests/Topics/TopicTest.cs
+++ b/tests/Integration/Momento.Sdk.Tests/Topics/TopicTest.cs
@@ -183,7 +183,7 @@ public class TopicTest : IClassFixture<CacheClientFixture>, IClassFixture<TopicC
             {
                 case TopicMessage.Text textMessage:
                     Assert.Equal(textMessage.Value, valuesToSend[messageCount]);
-                    Assert.Equal(textMessage.TopicSequenceNumber, messageCount + 1);
+                    Assert.Equal(textMessage.TopicSequenceNumber, checked((ulong)(messageCount + 1)));
                     messageCount++;
                     break;
                 case TopicSystemEvent.Heartbeat:

--- a/tests/Integration/Momento.Sdk.Tests/Topics/TopicTest.cs
+++ b/tests/Integration/Momento.Sdk.Tests/Topics/TopicTest.cs
@@ -145,7 +145,7 @@ public class TopicTest : IClassFixture<CacheClientFixture>, IClassFixture<TopicC
         {
             var textMessage = (TopicMessage.Text)consumedMessages[i];
             Assert.Equal(textMessage.Value, valuesToSend[i]);
-            Assert.Equal(textMessage.TopicSequenceNumber, i + 1);
+            Assert.Equal(textMessage.TopicSequenceNumber, checked((ulong)(i + 1));
         }
     }
 


### PR DESCRIPTION
Changes TopicItem and TopicSystemEvent to store the sequence number/page as `ulong`. This removes a checked cast under the hood.

Also plumbs through `resumeAtTopicSequenceNumber` (page) to the subscription wrapper.

I tested these changes on both topics examples successfully without any changes on the example side.