### PR TITLE
fix: disable dynamic DNS service config

### DIFF
--- a/src/Momento.Sdk/Internal/GrpcManager.cs
+++ b/src/Momento.Sdk/Internal/GrpcManager.cs
@@ -66,6 +66,8 @@ public class GrpcManager : IDisposable
         var channelOptions = grpcConfig.GrpcChannelOptions;
         channelOptions.Credentials = ChannelCredentials.SecureSsl;
         channelOptions.LoggerFactory ??= loggerFactory;
+        // Always disable gRPC service config 
+        channelOptions.ServiceConfig = null;
 #if NET5_0_OR_GREATER
         if (SocketsHttpHandler.IsSupported) // see: https://github.com/grpc/grpc-dotnet/blob/098dca892a3949ade411c3f2f66003f7b330dfd2/src/Shared/HttpHandlerFactory.cs#L28-L30
         {


### PR DESCRIPTION
## PR Description:
- On reasearching [grpc-dotnet behavior](https://github.com/googleapis/gax-dotnet/commit/ac695425d9f25314ab60316d72f1d4eed57ef581#diff-22029e198e06de6cfa24f7f6ba052ee14aa03dc179776e5e6f5f065a7f64c9b9R31), I found that the grpc service config is by default disabled. But, this pr still explicitly sets it to null to disable the grpc service config. 

### `tcpdump` when running existing example without adding the flag explicitly:
```
$ sudo tcpdump -i any -vvv port 53 | grep -i cache.cell-alpha-dev.preprod.a.momentohq.com          

tcpdump: data link type PKTAP
tcpdump: listening on any, link-type PKTAP (Apple DLT_PKTAP), snapshot length 524288 bytes
    pd1nsc3.st.vc.shawcable.net.domain > 10.0.0.249.51445: [udp sum ok] 30325 q: A? control.cell-alpha-dev.preprod.a.momentohq.com. 2/0/0 control.cell-alpha-dev.preprod.a.momentohq.com. [5m] CNAME cache.cell-alpha-dev.preprod.a.momentohq.com., cache.cell-alpha-dev.preprod.a.momentohq.com. [1m] A 54.186.170.81 (100)
    pd1nsc3.st.vc.shawcable.net.domain > 10.0.0.249.53066: [udp sum ok] 45075 q: AAAA? control.cell-alpha-dev.preprod.a.momentohq.com. 1/1/0 control.cell-alpha-dev.preprod.a.momentohq.com. [5m] CNAME cache.cell-alpha-dev.preprod.a.momentohq.com. ns: cell-alpha-dev.preprod.a.momentohq.com. [2m4s] SOA ns-1810.awsdns-34.co.uk. awsdns-hostmaster.amazon.com. 1 7200 900 1209600 86400 (168)
```

You can observe that there are no TXT record lookups with existing sdk version [v1.39.0](https://github.com/momentohq/client-sdk-dotnet/releases/tag/v1.39.0)

### Relevant Research Links:
[Link](https://github.com/googleapis/gax-dotnet/commit/ac695425d9f25314ab60316d72f1d4eed57ef581#diff-22029e198e06de6cfa24f7f6ba052ee14aa03dc179776e5e6f5f065a7f64c9b9R31)

## Issue
https://github.com/momentohq/dev-eco-issue-tracker/issues/1132

