### PR TITLE
feat: add CredentialProvider for momento-local connections

### DIFF
--- a/src/Momento.Sdk/Auth/EnvMomentoTokenProvider.cs
+++ b/src/Momento.Sdk/Auth/EnvMomentoTokenProvider.cs
@@ -19,6 +19,8 @@ public class EnvMomentoTokenProvider : ICredentialProvider
     public string CacheEndpoint { get; private set; }
     /// <inheritdoc />
     public string TokenEndpoint { get; private set; }
+    /// <inheritdoc />
+    public bool SecureEndpoints { get; private set; } = true;
 
     /// <summary>
     /// Reads and parses a JWT token stored as an environment variable.

--- a/src/Momento.Sdk/Auth/ICredentialProvider.cs
+++ b/src/Momento.Sdk/Auth/ICredentialProvider.cs
@@ -21,6 +21,12 @@ public interface ICredentialProvider
     /// The host which the Momento client will connect to the token endpoint
     /// </summary>
     string TokenEndpoint { get; }
+    /// <summary>
+    /// Indicates whether secure (SSL) connections should be created when connecting
+    /// to the endpoint. Note: momento-local uses insecure endpoints.
+    /// Defaults to true (use secure endpoints).
+    /// </summary>
+    bool SecureEndpoints { get; }
 
     /// <summary>
     /// Copy constructor to override the CacheEndpoint

--- a/src/Momento.Sdk/Auth/MomentoLocalProvider.cs
+++ b/src/Momento.Sdk/Auth/MomentoLocalProvider.cs
@@ -1,0 +1,89 @@
+namespace Momento.Sdk.Auth;
+
+using System;
+using Momento.Sdk.Exceptions;
+
+/// <summary>
+/// Sets the endpoint and port for connecting to momento-local.
+/// </summary>
+public class MomentoLocalProvider : ICredentialProvider 
+{
+    /// <summary>
+    /// The port for connecting to momento-local.
+    /// </summary>
+    public int Port { get; private set; }
+    /// <inheritdoc />
+    public string AuthToken { get; private set; }
+    /// <inheritdoc />
+    public string ControlEndpoint { get; private set; }
+    /// <inheritdoc />
+    public string CacheEndpoint { get; private set; }
+    /// <inheritdoc />
+    public string TokenEndpoint { get; private set; }
+    /// <inheritdoc />
+    public bool SecureEndpoints { get; private set; } = false;
+
+    /// <summary>
+    /// Default constructor for MomentoLocalProvider. 
+    /// Uses localhost and port 8080 to connect to momento-local.
+    /// </summary>
+    public MomentoLocalProvider()
+    {
+        AuthToken = "";
+        Port = 8080;
+        string endpoint = $"127.0.0.1:{Port}";
+        ControlEndpoint = endpoint;
+        CacheEndpoint = endpoint;
+        TokenEndpoint = endpoint;
+    }
+
+    /// <summary>
+    /// Constructor for MomentoLocalProvider.
+    /// Uses the provided hostname and default port (8080) to connect to momento-local.
+    /// </summary>
+    public MomentoLocalProvider(string hostname)
+    {
+        AuthToken = "";
+        Port = 8080;
+        string endpoint = $"{hostname}:{8080}";
+        ControlEndpoint = endpoint;
+        CacheEndpoint = endpoint;
+        TokenEndpoint = endpoint;
+        
+    }
+
+    /// <summary>
+    /// Constructor for MomentoLocalProvider.
+    /// Uses the default hostname (localhost) and provided port to connect to momento-local.
+    /// </summary>
+    public MomentoLocalProvider(int port)
+    {
+        AuthToken = "";
+        Port = port;
+        string endpoint = $"127.0.0.1:{port}";
+        ControlEndpoint = endpoint;
+        CacheEndpoint = endpoint;
+        TokenEndpoint = endpoint;
+        
+    }
+
+    /// <summary>
+    /// Constructor for MomentoLocalProvider.
+    /// Uses the provided hostname and provided port to connect to momento-local.
+    /// </summary>
+    public MomentoLocalProvider(string hostname, int port)
+    {
+        AuthToken = "";
+        Port = port;
+        string endpoint = $"{hostname}:{port}";
+        ControlEndpoint = endpoint;
+        CacheEndpoint = endpoint;
+        TokenEndpoint = endpoint;
+    }
+
+    /// <inheritdoc />
+    public ICredentialProvider WithCacheEndpoint(string cacheEndpoint)
+    {
+        return new MomentoLocalProvider(cacheEndpoint, this.Port);
+    }
+}

--- a/src/Momento.Sdk/Auth/MomentoLocalProvider.cs
+++ b/src/Momento.Sdk/Auth/MomentoLocalProvider.cs
@@ -45,7 +45,7 @@ public class MomentoLocalProvider : ICredentialProvider
     {
         AuthToken = "";
         Port = 8080;
-        string endpoint = $"{hostname}:{8080}";
+        string endpoint = $"{hostname}:{Port}";
         ControlEndpoint = endpoint;
         CacheEndpoint = endpoint;
         TokenEndpoint = endpoint;
@@ -60,7 +60,7 @@ public class MomentoLocalProvider : ICredentialProvider
     {
         AuthToken = "";
         Port = port;
-        string endpoint = $"127.0.0.1:{port}";
+        string endpoint = $"127.0.0.1:{Port}";
         ControlEndpoint = endpoint;
         CacheEndpoint = endpoint;
         TokenEndpoint = endpoint;
@@ -75,7 +75,7 @@ public class MomentoLocalProvider : ICredentialProvider
     {
         AuthToken = "";
         Port = port;
-        string endpoint = $"{hostname}:{port}";
+        string endpoint = $"{hostname}:{Port}";
         ControlEndpoint = endpoint;
         CacheEndpoint = endpoint;
         TokenEndpoint = endpoint;

--- a/src/Momento.Sdk/Auth/StringMomentoTokenProvider.cs
+++ b/src/Momento.Sdk/Auth/StringMomentoTokenProvider.cs
@@ -19,6 +19,8 @@ public class StringMomentoTokenProvider : ICredentialProvider
     public string CacheEndpoint { get; private set; }
     /// <inheritdoc />
     public string TokenEndpoint { get; private set; }
+    /// <inheritdoc />
+    public bool SecureEndpoints { get; private set; } = true;
 
     /// <summary>
     /// Reads and parses a JWT token from a string.

--- a/src/Momento.Sdk/AuthClient.cs
+++ b/src/Momento.Sdk/AuthClient.cs
@@ -22,7 +22,7 @@ public class AuthClient : IAuthClient
     /// <param name="authProvider">The auth provider.</param>
     public AuthClient(IAuthConfiguration config, ICredentialProvider authProvider)
     {
-        scsTokenClient = new ScsTokenClient(config, authProvider.AuthToken, authProvider.TokenEndpoint);
+        scsTokenClient = new ScsTokenClient(config, authProvider);
     }
     
     /// <inheritdoc />

--- a/src/Momento.Sdk/CacheClient.cs
+++ b/src/Momento.Sdk/CacheClient.cs
@@ -76,7 +76,7 @@ public class CacheClient : ICacheClient
         this.config = config;
         this._logger = config.LoggerFactory.CreateLogger<CacheClient>();
         Utils.ArgumentStrictlyPositive(defaultTtl, "defaultTtl");
-        this.controlClient = new(config, authProvider.AuthToken, authProvider.ControlEndpoint);
+        this.controlClient = new(config, authProvider);
         this.dataClients = new List<ScsDataClient>();
         int minNumGrpcChannels = this.config.TransportStrategy.GrpcConfig.MinNumGrpcChannels;
         int currentMaxConcurrentRequests = this.config.TransportStrategy.MaxConcurrentRequests;
@@ -119,7 +119,7 @@ public class CacheClient : ICacheClient
         }
         for (var i = 1; i <= minNumGrpcChannels; i++)
         {
-            this.dataClients.Add(new(config, authProvider.AuthToken, authProvider.CacheEndpoint, defaultTtl));
+            this.dataClients.Add(new(config, authProvider, defaultTtl));
         }
     }
 

--- a/src/Momento.Sdk/Internal/AuthGrpcManager.cs
+++ b/src/Momento.Sdk/Internal/AuthGrpcManager.cs
@@ -12,6 +12,7 @@ using Grpc.Net.Client.Web;
 #endif
 using Microsoft.Extensions.Logging;
 using Momento.Protos.TokenClient;
+using Momento.Sdk.Auth;
 using Momento.Sdk.Config;
 using Momento.Sdk.Config.Middleware;
 using Momento.Sdk.Internal.Middleware;
@@ -49,7 +50,7 @@ public class AuthGrpcManager : GrpcManager
 {
     public IAuthClient Client { get; }
 
-    public AuthGrpcManager(IAuthConfiguration config, string authToken, string endpoint): base(config.TransportStrategy.GrpcConfig, config.LoggerFactory, authToken, endpoint, "AuthGrpcManager")
+    public AuthGrpcManager(IAuthConfiguration config, ICredentialProvider authProvider): base(config.TransportStrategy.GrpcConfig, config.LoggerFactory, authProvider, authProvider.TokenEndpoint, "AuthGrpcManager")
     {
         var middlewares = new List<IMiddleware> {
             new HeaderMiddleware(config.LoggerFactory, this.headers)

--- a/src/Momento.Sdk/Internal/ControlGrpcManager.cs
+++ b/src/Momento.Sdk/Internal/ControlGrpcManager.cs
@@ -10,6 +10,7 @@ using Grpc.Net.Client.Web;
 #endif
 using Microsoft.Extensions.Logging;
 using Momento.Protos.ControlClient;
+using Momento.Sdk.Auth;
 using Momento.Sdk.Config;
 using Momento.Sdk.Config.Middleware;
 using Momento.Sdk.Internal.Middleware;
@@ -75,7 +76,7 @@ internal sealed class ControlGrpcManager : GrpcManager
 {
     public IControlClient Client { get; }
 
-    public ControlGrpcManager(IConfiguration config, string authToken, string endpoint): base(config.TransportStrategy.GrpcConfig, config.LoggerFactory, authToken, endpoint, "ControlGrpcManager")
+    public ControlGrpcManager(IConfiguration config, ICredentialProvider authProvider): base(config.TransportStrategy.GrpcConfig, config.LoggerFactory, authProvider, authProvider.ControlEndpoint, "ControlGrpcManager")
     {
         var middlewares = new List<IMiddleware> 
         {

--- a/src/Momento.Sdk/Internal/DataGrpcManager.cs
+++ b/src/Momento.Sdk/Internal/DataGrpcManager.cs
@@ -7,6 +7,7 @@ using Grpc.Core;
 using Microsoft.Extensions.Logging;
 using Momento.Protos.CacheClient;
 using Momento.Protos.CachePing;
+using Momento.Sdk.Auth;
 using Momento.Sdk.Config;
 using Momento.Sdk.Config.Middleware;
 using Momento.Sdk.Config.Retry;
@@ -248,7 +249,7 @@ public class DataGrpcManager : GrpcManager
 {
     public readonly IDataClient Client;
 
-    internal DataGrpcManager(IConfiguration config, string authToken, string endpoint): base(config.TransportStrategy.GrpcConfig, config.LoggerFactory, authToken, endpoint, "DataGrpcManager")
+    internal DataGrpcManager(IConfiguration config, ICredentialProvider authProvider): base(config.TransportStrategy.GrpcConfig, config.LoggerFactory, authProvider, authProvider.CacheEndpoint, "DataGrpcManager")
     {
         // Not sending a head concern header is treated the same as sending a balanced read concern header
         if (config.ReadConcern != ReadConcern.Balanced)

--- a/src/Momento.Sdk/Internal/GrpcManager.cs
+++ b/src/Momento.Sdk/Internal/GrpcManager.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using Microsoft.Extensions.Logging;
 using Momento.Sdk.Internal.Middleware;
 using Momento.Sdk.Config.Transport;
+using Momento.Sdk.Auth;
 using Grpc.Core;
 using Grpc.Net.Client;
 #if USE_GRPC_WEB
@@ -47,16 +48,16 @@ public class GrpcManager : IDisposable
     /// </summary>
     /// <param name="grpcConfig"></param>
     /// <param name="loggerFactory"></param>
-    /// <param name="authToken"></param>
+    /// <param name="authProvider"></param>
     /// <param name="endpoint"></param>
     /// <param name="loggerName"></param>
-    internal GrpcManager(IGrpcConfiguration grpcConfig, ILoggerFactory loggerFactory, string authToken, string endpoint, string loggerName)
+    internal GrpcManager(IGrpcConfiguration grpcConfig, ILoggerFactory loggerFactory, ICredentialProvider authProvider, string endpoint, string loggerName)
     {
         this._logger = loggerFactory.CreateLogger(loggerName);
 
         this.headerTuples = new List<Tuple<string, string>>
         {
-            new(Header.AuthorizationKey, authToken),
+            new(Header.AuthorizationKey, authProvider.AuthToken),
             new(Header.AgentKey, version),
             new(Header.RuntimeVersionKey, runtimeVersion)
         };
@@ -64,10 +65,20 @@ public class GrpcManager : IDisposable
 
         // Set all channel opens and create the grpc connection
         var channelOptions = grpcConfig.GrpcChannelOptions;
-        channelOptions.Credentials = ChannelCredentials.SecureSsl;
         channelOptions.LoggerFactory ??= loggerFactory;
         // Always disable gRPC service config 
         channelOptions.ServiceConfig = null;
+
+        // If connecting to momento-local, must use http and Insecure channel credentials.
+        if (authProvider.SecureEndpoints)
+        {
+            channelOptions.Credentials = ChannelCredentials.SecureSsl;
+        }
+        else
+        {
+            channelOptions.Credentials = ChannelCredentials.Insecure;
+        }
+        
 #if NET5_0_OR_GREATER
         if (SocketsHttpHandler.IsSupported) // see: https://github.com/grpc/grpc-dotnet/blob/098dca892a3949ade411c3f2f66003f7b330dfd2/src/Shared/HttpHandlerFactory.cs#L28-L30
         {
@@ -85,7 +96,12 @@ public class GrpcManager : IDisposable
         // Note: all web SDK requests are routed to a `web.` subdomain to allow us flexibility on the server
         endpoint = $"web.{endpoint}";
 #endif
+        // If connecting to momento-local, must use http and Insecure channel credentials.
         var uri = $"https://{endpoint}";
+        if (!authProvider.SecureEndpoints)
+        {
+            uri = $"http://{endpoint}";
+        }
         this.channel = GrpcChannel.ForAddress(uri, channelOptions);
         this.invoker = this.channel.CreateCallInvoker();
     }

--- a/src/Momento.Sdk/Internal/ScsControlClient.cs
+++ b/src/Momento.Sdk/Internal/ScsControlClient.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Grpc.Core;
 using Microsoft.Extensions.Logging;
 using Momento.Protos.ControlClient;
+using Momento.Sdk.Auth;
 using Momento.Sdk.Config;
 using Momento.Sdk.Config.Transport;
 using Momento.Sdk.Exceptions;
@@ -19,7 +20,7 @@ internal sealed class ScsControlClient : IDisposable
     private readonly ILogger _logger;
     private readonly CacheExceptionMapper _exceptionMapper;
 
-    public ScsControlClient(IConfiguration config, string authToken, string endpoint)
+    public ScsControlClient(IConfiguration config, ICredentialProvider authProvider)
     {
         // Override the sockets http handler options to disable keepalive
         var overrideKeepalive = SocketsHttpHandlerOptions.Of(
@@ -31,8 +32,8 @@ internal sealed class ScsControlClient : IDisposable
         );
         var controlConfig = config.WithTransportStrategy(config.TransportStrategy.WithSocketsHttpHandlerOptions(overrideKeepalive));
         
-        this.grpcManager = new ControlGrpcManager(controlConfig, authToken, endpoint);
-        this.authToken = authToken;
+        this.grpcManager = new ControlGrpcManager(controlConfig, authProvider);
+        this.authToken = authProvider.AuthToken;
         this._logger = config.LoggerFactory.CreateLogger<ScsControlClient>();
         this._exceptionMapper = new CacheExceptionMapper(config.LoggerFactory);
     }

--- a/src/Momento.Sdk/Internal/ScsDataClient.cs
+++ b/src/Momento.Sdk/Internal/ScsDataClient.cs
@@ -10,6 +10,7 @@ using Grpc.Core;
 using Microsoft.Extensions.Logging;
 using Momento.Protos.CacheClient;
 using Momento.Protos.Common;
+using Momento.Sdk.Auth;
 using Momento.Sdk.Config;
 using Momento.Sdk.Exceptions;
 using Momento.Sdk.Internal.ExtensionMethods;
@@ -28,9 +29,9 @@ public class ScsDataClientBase : IDisposable
 
     protected readonly CacheExceptionMapper _exceptionMapper;
 
-    public ScsDataClientBase(IConfiguration config, string authToken, string endpoint, TimeSpan defaultTtl)
+    public ScsDataClientBase(IConfiguration config, ICredentialProvider authProvider, TimeSpan defaultTtl)
     {
-        this.grpcManager = new(config, authToken, endpoint);
+        this.grpcManager = new(config, authProvider);
         this.defaultTtl = defaultTtl;
         this.dataClientOperationTimeout = config.TransportStrategy.GrpcConfig.Deadline;
         this._logger = config.LoggerFactory.CreateLogger<ScsDataClient>();
@@ -85,8 +86,8 @@ internal sealed class ScsDataClient : ScsDataClientBase
 {
     private readonly ILogger _logger;
 
-    public ScsDataClient(IConfiguration config, string authToken, string endpoint, TimeSpan defaultTtl)
-        : base(config, authToken, endpoint, defaultTtl)
+    public ScsDataClient(IConfiguration config, ICredentialProvider authProvider, TimeSpan defaultTtl)
+        : base(config, authProvider, defaultTtl)
     {
         this._logger = config.LoggerFactory.CreateLogger<ScsDataClient>();
     }

--- a/src/Momento.Sdk/Internal/ScsTokenClient.cs
+++ b/src/Momento.Sdk/Internal/ScsTokenClient.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Grpc.Core;
 using Microsoft.Extensions.Logging;
 
+using Momento.Sdk.Auth;
 using Momento.Sdk.Auth.AccessControl;
 using Momento.Sdk.Config;
 using Momento.Sdk.Exceptions;
@@ -24,10 +25,10 @@ internal sealed class ScsTokenClient : IDisposable
     private readonly ILogger _logger;
     private bool hasSentOnetimeHeaders = false;
     private readonly CacheExceptionMapper _exceptionMapper;
-    public ScsTokenClient(IAuthConfiguration config, string authToken, string endpoint)
+    public ScsTokenClient(IAuthConfiguration config, ICredentialProvider authProvider)
     {
-        this.grpcManager = new AuthGrpcManager(config, authToken, endpoint);
-        this.authToken = authToken;
+        this.grpcManager = new AuthGrpcManager(config, authProvider);
+        this.authToken = authProvider.AuthToken;
         this.authClientOperationTimeout = config.TransportStrategy.GrpcConfig.Deadline;
         this._logger = config.LoggerFactory.CreateLogger<ScsTokenClient>();
         this._exceptionMapper = new CacheExceptionMapper(config.LoggerFactory);

--- a/src/Momento.Sdk/Internal/ScsTopicClient.cs
+++ b/src/Momento.Sdk/Internal/ScsTopicClient.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Grpc.Core;
 using Microsoft.Extensions.Logging;
 using Momento.Protos.CacheClient.Pubsub;
+using Momento.Sdk.Auth;
 using Momento.Sdk.Config;
 using Momento.Sdk.Exceptions;
 using Momento.Sdk.Internal.ExtensionMethods;
@@ -23,9 +24,9 @@ public class ScsTopicClientBase : IDisposable
 
     protected readonly CacheExceptionMapper _exceptionMapper;
 
-    public ScsTopicClientBase(ITopicConfiguration config, string authToken, string endpoint)
+    public ScsTopicClientBase(ITopicConfiguration config, ICredentialProvider authProvider)
     {
-        this.grpcManager = new TopicGrpcManager(config, authToken, endpoint);
+        this.grpcManager = new TopicGrpcManager(config, authProvider);
         this.dataClientOperationTimeout = config.TransportStrategy.GrpcConfig.Deadline;
         this._logger = config.LoggerFactory.CreateLogger<ScsDataClient>();
         this._exceptionMapper = new CacheExceptionMapper(config.LoggerFactory);
@@ -58,8 +59,8 @@ internal sealed class ScsTopicClient : ScsTopicClientBase
 {
     private readonly ILogger _logger;
 
-    public ScsTopicClient(ITopicConfiguration config, string authToken, string endpoint)
-        : base(config, authToken, endpoint)
+    public ScsTopicClient(ITopicConfiguration config, ICredentialProvider authProvider)
+        : base(config, authProvider)
     {
         this._logger = config.LoggerFactory.CreateLogger<ScsTopicClient>();
     }

--- a/src/Momento.Sdk/Internal/TopicGrpcManager.cs
+++ b/src/Momento.Sdk/Internal/TopicGrpcManager.cs
@@ -13,6 +13,7 @@ using Grpc.Net.Client.Web;
 using Microsoft.Extensions.Logging;
 using Momento.Protos.CacheClient.Pubsub;
 using Momento.Protos.Common;
+using Momento.Sdk.Auth;
 using Momento.Sdk.Config;
 using Momento.Sdk.Config.Middleware;
 using Momento.Sdk.Config.Retry;
@@ -70,7 +71,7 @@ public class TopicGrpcManager : GrpcManager
 {
     public readonly IPubsubClient Client;
 
-    internal TopicGrpcManager(ITopicConfiguration config, string authToken, string endpoint) : base(config.TransportStrategy.GrpcConfig, config.LoggerFactory, authToken, endpoint, "TopicGrpcManager")
+    internal TopicGrpcManager(ITopicConfiguration config, ICredentialProvider authProvider) : base(config.TransportStrategy.GrpcConfig, config.LoggerFactory, authProvider, authProvider.CacheEndpoint, "TopicGrpcManager")
     {
         var middlewares = new List<IMiddleware>
         {

--- a/src/Momento.Sdk/TopicClient.cs
+++ b/src/Momento.Sdk/TopicClient.cs
@@ -23,7 +23,7 @@ public class TopicClient : ITopicClient
     /// <param name="authProvider">Momento auth provider.</param>
     public TopicClient(ITopicConfiguration config, ICredentialProvider authProvider)
     {
-        scsTopicClient = new ScsTopicClient(config, authProvider.AuthToken, authProvider.CacheEndpoint);
+        scsTopicClient = new ScsTopicClient(config, authProvider);
     }
 
     /// <inheritdoc />

--- a/tests/Unit/Momento.Sdk.Tests/Auth/MomentoLocalProviderTest.cs
+++ b/tests/Unit/Momento.Sdk.Tests/Auth/MomentoLocalProviderTest.cs
@@ -1,0 +1,50 @@
+using Momento.Sdk.Auth;
+using Momento.Sdk.Exceptions;
+using System;
+using Xunit;
+
+namespace Momento.Sdk.Tests.Unit;
+
+
+public class MomentoLocalProviderTests
+{
+    [Fact]
+    public void MomentoLocalProvider_DefaultConstructor() {
+        var provider = new MomentoLocalProvider();
+        Assert.Equal("", provider.AuthToken);
+        Assert.Equal(8080, provider.Port);
+        Assert.Equal("127.0.0.1:8080", provider.ControlEndpoint);
+        Assert.Equal("127.0.0.1:8080", provider.CacheEndpoint);
+        Assert.Equal("127.0.0.1:8080", provider.TokenEndpoint);
+    }
+
+    [Fact]
+    public void MomentoLocalProvider_ConstructorWithHostnameAndPort() {
+        var provider = new MomentoLocalProvider("localhost", 9090);
+        Assert.Equal("", provider.AuthToken);
+        Assert.Equal(9090, provider.Port);
+        Assert.Equal("localhost:9090", provider.ControlEndpoint);
+        Assert.Equal("localhost:9090", provider.CacheEndpoint);
+        Assert.Equal("localhost:9090", provider.TokenEndpoint);
+    }
+
+    [Fact]
+    public void MomentoLocalProvider_ConstructorWithHostname() {
+        var provider = new MomentoLocalProvider("localhost");
+        Assert.Equal("", provider.AuthToken);
+        Assert.Equal(8080, provider.Port);
+        Assert.Equal("localhost:8080", provider.ControlEndpoint);
+        Assert.Equal("localhost:8080", provider.CacheEndpoint);
+        Assert.Equal("localhost:8080", provider.TokenEndpoint);
+    }
+
+    [Fact]
+    public void MomentoLocalProvider_ConstructorWithPort() {
+        var provider = new MomentoLocalProvider(9090);
+        Assert.Equal("", provider.AuthToken);
+        Assert.Equal(9090, provider.Port);
+        Assert.Equal("127.0.0.1:9090", provider.ControlEndpoint);
+        Assert.Equal("127.0.0.1:9090", provider.CacheEndpoint);
+        Assert.Equal("127.0.0.1:9090", provider.TokenEndpoint);
+    }
+}


### PR DESCRIPTION
Closes https://github.com/momentohq/dev-eco-issue-tracker/issues/1193

- Adds `MomentoLocalProvider`, an implementation of `ICredentialProvider`, to connect clients to momento-local servers.
- Piped the credential provider through to the base `GrpcManager` to be able to check whether to use secure endpoints (SSL channel credentials and https) or insecure because momento-local uses insecure connections).
- Adds unit tests for MomentoLocalProvider

Tested locally and confirmed the `MomentoUsage` example can create a `MomentoLocalProvider` and connect to a running momento-local docker container.