### PR TITLE
feat: add MomentoRpcMethod enum and TestRetryMetricsCollector

### DIFF
--- a/src/Momento.Sdk/Config/Retry/MomentoRpcMethod.cs
+++ b/src/Momento.Sdk/Config/Retry/MomentoRpcMethod.cs
@@ -1,0 +1,116 @@
+using System;
+
+namespace Momento.Sdk.Config.Retry;
+
+public enum MomentoRpcMethod {
+    Get,
+    Set,
+    Delete,
+    Increment,
+    SetIf,
+    SetIfNotExists,
+    GetBatch,
+    SetBatch,
+    KeysExist,
+    UpdateTtl,
+    ItemGetTtl,
+    ItemGetType,
+    DictionaryGet,
+    DictionarySet,
+    DictionaryIncrement,
+    DictionaryDelete,
+    DictionaryLength,
+    SetFetch,
+    SetSample,
+    SetUnion,
+    SetDifference,
+    SetContains,
+    SetLength,
+    SetPop,
+    ListPushFront,
+    ListPushBack,
+    ListPopFront,
+    ListPopBack,
+    ListErase,
+    ListRemove,
+    ListFetch,
+    ListLength,
+    ListConcatenateFront,
+    ListConcatenateBack,
+    ListRetain,
+    SortedSetPut,
+    SortedSetFetch,
+    SortedSetGetScore,
+    SortedSetRemove,
+    SortedSetIncrement,
+    SortedSetGetRank,
+    SortedSetLength,
+    SortedSetLengthByScore,
+    TopicPublish,
+    TopicSubscribe
+}
+
+/// <summary>
+/// Extension methods for the MomentoRpcMethod enum.
+/// </summary>
+public static class MomentoRpcMethodExtensions
+{
+    /// <summary>
+    /// Converts the rpc method to a string value.
+    /// </summary>
+    /// <param name="rpcMethod">to convert to a string</param>
+    /// <returns></returns>
+    /// <exception cref="ArgumentOutOfRangeException">if given an unknown rpc method</exception>
+    public static string ToStringValue(this MomentoRpcMethod rpcMethod)
+    {
+        return rpcMethod switch
+        {
+            MomentoRpcMethod.Get => "_GetRequest",
+            MomentoRpcMethod.Set => "_SetRequest",
+            MomentoRpcMethod.Delete => "_DeleteRequest",
+            MomentoRpcMethod.Increment => "_IncrementRequest",
+            MomentoRpcMethod.SetIf => "_SetIfRequest",
+            MomentoRpcMethod.SetIfNotExists => "_SetIfNotExistsRequest",
+            MomentoRpcMethod.GetBatch => "_GetBatchRequest",
+            MomentoRpcMethod.SetBatch => "_SetBatchRequest",
+            MomentoRpcMethod.KeysExist => "_KeysExistRequest",
+            MomentoRpcMethod.UpdateTtl => "_UpdateTtlRequest",
+            MomentoRpcMethod.ItemGetTtl => "_ItemGetTtlRequest",
+            MomentoRpcMethod.ItemGetType => "_ItemGetTypeRequest",
+            MomentoRpcMethod.DictionaryGet => "_DictionaryGetRequest",
+            MomentoRpcMethod.DictionarySet => "_DictionarySetRequest",
+            MomentoRpcMethod.DictionaryIncrement => "_DictionaryIncrementRequest",
+            MomentoRpcMethod.DictionaryDelete => "_DictionaryDeleteRequest",
+            MomentoRpcMethod.DictionaryLength => "_DictionaryLengthRequest",
+            MomentoRpcMethod.SetFetch => "_SetFetchRequest",
+            MomentoRpcMethod.SetSample => "_SetSampleRequest",
+            MomentoRpcMethod.SetUnion => "_SetUnionRequest",
+            MomentoRpcMethod.SetDifference => "_SetDifferenceRequest",
+            MomentoRpcMethod.SetContains => "_SetContainsRequest",
+            MomentoRpcMethod.SetLength => "_SetLengthRequest",
+            MomentoRpcMethod.SetPop => "_SetPopRequest",
+            MomentoRpcMethod.ListPushFront => "_ListPushFrontRequest",
+            MomentoRpcMethod.ListPushBack => "_ListPushBackRequest",
+            MomentoRpcMethod.ListPopFront => "_ListPopFrontRequest",
+            MomentoRpcMethod.ListPopBack => "_ListPopBackRequest",
+            MomentoRpcMethod.ListErase => "_ListEraseRequest",
+            MomentoRpcMethod.ListRemove => "_ListRemoveRequest",
+            MomentoRpcMethod.ListFetch => "_ListFetchRequest",
+            MomentoRpcMethod.ListLength => "_ListLengthRequest",
+            MomentoRpcMethod.ListConcatenateFront => "_ListConcatenateFrontRequest",
+            MomentoRpcMethod.ListConcatenateBack => "_ListConcatenateBackRequest",
+            MomentoRpcMethod.ListRetain => "_ListRetainRequest",
+            MomentoRpcMethod.SortedSetPut => "_SortedSetPutRequest",
+            MomentoRpcMethod.SortedSetFetch => "_SortedSetFetchRequest",
+            MomentoRpcMethod.SortedSetGetScore => "_SortedSetGetScoreRequest",
+            MomentoRpcMethod.SortedSetRemove => "_SortedSetRemoveRequest",
+            MomentoRpcMethod.SortedSetIncrement => "_SortedSetIncrementRequest",
+            MomentoRpcMethod.SortedSetGetRank => "_SortedSetGetRankRequest",
+            MomentoRpcMethod.SortedSetLength => "_SortedSetLengthRequest",
+            MomentoRpcMethod.SortedSetLengthByScore => "_SortedSetLengthByScoreRequest",
+            MomentoRpcMethod.TopicPublish => "_PublishRequest",
+            MomentoRpcMethod.TopicSubscribe => "_SubscribeRequest",
+            _ => throw new ArgumentOutOfRangeException()
+        };
+    }
+}

--- a/tests/Integration/Momento.Sdk.Tests/Retry/utils/TestRetryMetricsCollector.cs
+++ b/tests/Integration/Momento.Sdk.Tests/Retry/utils/TestRetryMetricsCollector.cs
@@ -1,0 +1,63 @@
+using Momento.Sdk.Config.Retry;
+using System.Collections.Generic;
+
+namespace Momento.Sdk.Tests.Integration.Cache;
+
+public class TestRetryMetricsCollector
+{
+    /// <summary>
+    /// Data structure to store timestamps for all requests: cacheName -> requestName -> [timestamps]
+    /// </summary>
+    public Dictionary<string, Dictionary<MomentoRpcMethod, List<long>>> AllMetrics { get; private set; }
+    
+    public TestRetryMetricsCollector()
+    {
+        AllMetrics = new Dictionary<string, Dictionary<MomentoRpcMethod, List<long>>>();
+    }
+
+    public void AddTimestamp(string cacheName, MomentoRpcMethod requestName, long timestamp)
+    {
+        if (!AllMetrics.ContainsKey(cacheName))
+        {
+            AllMetrics[cacheName] = new Dictionary<MomentoRpcMethod, List<long>>();
+        }
+        if (!AllMetrics[cacheName].ContainsKey(requestName))
+        {
+            AllMetrics[cacheName][requestName] = new List<long>();
+        }
+        AllMetrics[cacheName][requestName].Add(timestamp);
+    }
+
+    public long GetTotalRetryCount(string cacheName, MomentoRpcMethod requestName)
+    {
+        if (!AllMetrics.ContainsKey(cacheName) || !AllMetrics[cacheName].ContainsKey(requestName))
+        {
+            return 0;
+        }
+        // The first timestamp is the initial request, not a retry, so we subtract 1.
+        return Math.Max(0, AllMetrics[cacheName][requestName].Count - 1);
+    }
+
+    public long GetAverageTimeBetweenRetries(string cacheName, MomentoRpcMethod requestName)
+    {
+        if (!AllMetrics.ContainsKey(cacheName) || !AllMetrics[cacheName].ContainsKey(requestName))
+        {
+            // No retries occurred.
+            return 0;
+        }
+        var timestamps = AllMetrics[cacheName][requestName];
+        if (timestamps.Count < 2)
+        {
+            // No retries occurred.
+            return 0;
+        }
+
+        long total = 0;
+        for (int i = 1; i < timestamps.Count; i++)
+        {
+            total += timestamps[i] - timestamps[i - 1];
+        }
+
+        return total / (timestamps.Count - 1);
+    }
+} 

--- a/tests/Integration/Momento.Sdk.Tests/Retry/utils/TestRetryMetricsCollectorTest.cs
+++ b/tests/Integration/Momento.Sdk.Tests/Retry/utils/TestRetryMetricsCollectorTest.cs
@@ -1,0 +1,88 @@
+using Momento.Sdk.Config.Retry;
+
+namespace Momento.Sdk.Tests.Integration.Cache;
+
+[Collection("Retry")]
+public class TestRetryMetricsCollectorTests
+{
+    [Fact]
+    public void TestRetryMetricsCollector_NoData()
+    {
+        var collector = new TestRetryMetricsCollector();
+        Assert.Empty(collector.AllMetrics);
+        Assert.Equal(0, collector.GetTotalRetryCount("cache", MomentoRpcMethod.Get));
+        Assert.Equal(0, collector.GetAverageTimeBetweenRetries("cache", MomentoRpcMethod.Get));
+    }
+
+    [Fact]
+    public void TestRetryMetricsCollector_AddTimestamp()
+    {
+        var collector = new TestRetryMetricsCollector();
+        collector.AddTimestamp("cache", MomentoRpcMethod.Get, 1);
+        Assert.Single(collector.AllMetrics);
+        Assert.Single(collector.AllMetrics["cache"]);
+        Assert.Single(collector.AllMetrics["cache"][MomentoRpcMethod.Get]);
+        Assert.Equal(1, collector.AllMetrics["cache"][MomentoRpcMethod.Get][0]);
+    }
+
+    [Fact]
+    public void TestRetryMetricsCollector_GetAllMetrics()
+    {
+        var collector = new TestRetryMetricsCollector();
+        collector.AddTimestamp("cache1", MomentoRpcMethod.Get, 1000);
+        collector.AddTimestamp("cache1", MomentoRpcMethod.Set, 2000);
+        collector.AddTimestamp("cache2", MomentoRpcMethod.Set, 3000);
+
+        // Should have 2 keys in outer dictionary: cache1 and cache2.
+        Assert.Equal(2, collector.AllMetrics.Count);
+
+        // cache1 should have 2 entries: Get and Set. cache2 should have 1 entry: Set.
+        Assert.Equal(2, collector.AllMetrics["cache1"].Count);
+        Assert.Equal(1, collector.AllMetrics["cache2"].Count);
+
+        // Should have 1 timestamp for each method and cache that we added timestamps for.
+        Assert.Single(collector.AllMetrics["cache1"][MomentoRpcMethod.Get]);
+        Assert.Single(collector.AllMetrics["cache1"][MomentoRpcMethod.Set]);
+        Assert.Single(collector.AllMetrics["cache2"][MomentoRpcMethod.Set]);
+    }
+
+    [Fact]
+    public void TestRetryMetricsCollector_GetTotalRetryCount_NoRetries()
+    {
+        var collector = new TestRetryMetricsCollector();
+        Assert.Equal(0, collector.GetTotalRetryCount("cache", MomentoRpcMethod.Get));
+
+        collector.AddTimestamp("cache", MomentoRpcMethod.Get, 1000);
+        Assert.Equal(0, collector.GetTotalRetryCount("cache", MomentoRpcMethod.Get));
+    }
+
+    [Fact]
+    public void TestRetryMetricsCollector_GetTotalRetryCount_WithRetries()
+    {
+        var collector = new TestRetryMetricsCollector();
+        collector.AddTimestamp("cache", MomentoRpcMethod.Get, 1000);
+        collector.AddTimestamp("cache", MomentoRpcMethod.Get, 2000);
+        collector.AddTimestamp("cache", MomentoRpcMethod.Get, 3000);
+        Assert.Equal(2, collector.GetTotalRetryCount("cache", MomentoRpcMethod.Get));
+    }
+
+    [Fact]
+    public void TestRetryMetricsCollector_GetAverageTimeBetweenRetries_NoRetries()
+    {
+        var collector = new TestRetryMetricsCollector();
+        Assert.Equal(0, collector.GetAverageTimeBetweenRetries("cache", MomentoRpcMethod.Get));
+
+        collector.AddTimestamp("cache", MomentoRpcMethod.Get, 1000);
+        Assert.Equal(0, collector.GetAverageTimeBetweenRetries("cache", MomentoRpcMethod.Get));
+    }
+
+    [Fact]
+    public void TestRetryMetricsCollector_GetAverageTimeBetweenRetries_WithRetries()
+    {
+        var collector = new TestRetryMetricsCollector();
+        collector.AddTimestamp("cache", MomentoRpcMethod.Get, 1000);
+        collector.AddTimestamp("cache", MomentoRpcMethod.Get, 2000);
+        collector.AddTimestamp("cache", MomentoRpcMethod.Get, 4000);
+        Assert.Equal(1500, collector.GetAverageTimeBetweenRetries("cache", MomentoRpcMethod.Get));
+    }
+}


### PR DESCRIPTION
Work towards https://github.com/momentohq/dev-eco-issue-tracker/issues/1191

Adds the MomentoRpcMethod enum for specifying Momento RPCs in the metrics collector (and in middleware in a future PR).
Adds the TestRetryMetricsCollector class and unit tests to prepare for writing momento-local tests exercising cache retry strategies.