### PR TITLE
chore: remove unnecessary MomentoLocalProvider non-default constructor

### DIFF
--- a/src/Momento.Sdk/Auth/MomentoLocalProvider.cs
+++ b/src/Momento.Sdk/Auth/MomentoLocalProvider.cs
@@ -54,21 +54,6 @@ public class MomentoLocalProvider : ICredentialProvider
 
     /// <summary>
     /// Constructor for MomentoLocalProvider.
-    /// Uses the default hostname (localhost) and provided port to connect to momento-local.
-    /// </summary>
-    public MomentoLocalProvider(int port)
-    {
-        AuthToken = "";
-        Port = port;
-        string endpoint = $"127.0.0.1:{Port}";
-        ControlEndpoint = endpoint;
-        CacheEndpoint = endpoint;
-        TokenEndpoint = endpoint;
-        
-    }
-
-    /// <summary>
-    /// Constructor for MomentoLocalProvider.
     /// Uses the provided hostname and provided port to connect to momento-local.
     /// </summary>
     public MomentoLocalProvider(string hostname, int port)

--- a/tests/Unit/Momento.Sdk.Tests/Auth/MomentoLocalProviderTest.cs
+++ b/tests/Unit/Momento.Sdk.Tests/Auth/MomentoLocalProviderTest.cs
@@ -37,14 +37,4 @@ public class MomentoLocalProviderTests
         Assert.Equal("localhost:8080", provider.CacheEndpoint);
         Assert.Equal("localhost:8080", provider.TokenEndpoint);
     }
-
-    [Fact]
-    public void MomentoLocalProvider_ConstructorWithPort() {
-        var provider = new MomentoLocalProvider(9090);
-        Assert.Equal("", provider.AuthToken);
-        Assert.Equal(9090, provider.Port);
-        Assert.Equal("127.0.0.1:9090", provider.ControlEndpoint);
-        Assert.Equal("127.0.0.1:9090", provider.CacheEndpoint);
-        Assert.Equal("127.0.0.1:9090", provider.TokenEndpoint);
-    }
 }


### PR DESCRIPTION
Addressing a previous [PR comment](https://github.com/momentohq/client-sdk-dotnet/pull/598#discussion_r2004415537)