### PR TITLE
feat: fixed timeout retry strategy and tests

### DIFF
--- a/src/Momento.Sdk/Config/Retry/FixedCountRetryStrategy.cs
+++ b/src/Momento.Sdk/Config/Retry/FixedCountRetryStrategy.cs
@@ -85,4 +85,10 @@ public class FixedCountRetryStrategy : IRetryStrategy
     {
         return base.GetHashCode();
     }
+
+    /// <inheritdoc/>
+    public double? GetResponseDataReceivedTimeoutMillis()
+    {
+        return null;
+    }
 }

--- a/src/Momento.Sdk/Config/Retry/FixedTimeoutRetryStrategy.cs
+++ b/src/Momento.Sdk/Config/Retry/FixedTimeoutRetryStrategy.cs
@@ -22,8 +22,7 @@ public class FixedTimeoutRetryStrategy : IRetryStrategy
     /// </summary>
     public static readonly TimeSpan DEFAULT_RESPONSE_DATA_RECEIVED_TIMEOUT = TimeSpan.FromMilliseconds(1000);
 
-    private ILoggerFactory _loggerFactory;
-    private ILogger _logger;
+    private readonly ILogger _logger;
     private readonly IRetryEligibilityStrategy _eligibilityStrategy;
     private readonly TimeSpan _retryDelayInterval;
     private readonly TimeSpan _responseDataReceivedTimeout;
@@ -37,7 +36,6 @@ public class FixedTimeoutRetryStrategy : IRetryStrategy
     /// <param name="responseDataReceivedTimeout">How long to wait for a retry attempt to succeed or timeout.</param>
     public FixedTimeoutRetryStrategy(ILoggerFactory loggerFactory, IRetryEligibilityStrategy? eligibilityStrategy = null, TimeSpan? retryDelayInterval = null, TimeSpan? responseDataReceivedTimeout = null)
     {
-        _loggerFactory = loggerFactory;
         _logger = loggerFactory.CreateLogger<FixedTimeoutRetryStrategy>();
         _eligibilityStrategy = eligibilityStrategy ?? new DefaultRetryEligibilityStrategy(loggerFactory);
         _retryDelayInterval = retryDelayInterval ?? DEFAULT_RETRY_DELAY_INTERVAL;
@@ -76,7 +74,6 @@ public class FixedTimeoutRetryStrategy : IRetryStrategy
         var other = (FixedTimeoutRetryStrategy)obj;
         return _retryDelayInterval.Equals(other._retryDelayInterval) &&
             _responseDataReceivedTimeout.Equals(other._responseDataReceivedTimeout) &&
-            _loggerFactory.Equals(other._loggerFactory) &&
             _eligibilityStrategy.Equals(other._eligibilityStrategy);
     }
 

--- a/src/Momento.Sdk/Config/Retry/FixedTimeoutRetryStrategy.cs
+++ b/src/Momento.Sdk/Config/Retry/FixedTimeoutRetryStrategy.cs
@@ -1,0 +1,88 @@
+using System;
+using Grpc.Core;
+using Microsoft.Extensions.Logging;
+using Momento.Sdk.Internal.Retry;
+
+namespace Momento.Sdk.Config.Retry;
+
+/// <summary>
+/// Retry failed requests up until the client's timeout has been reached.
+/// Retries are attempted at fixed intervals (retryDelayIntervalMillis) +/- jitter.
+/// Retry attempts time out after responseDataReceivedTimeoutMillis to be able to 
+/// allow multiple retries before the client's timeout is reached.
+/// </summary>
+public class FixedTimeoutRetryStrategy : IRetryStrategy
+{
+    private ILoggerFactory _loggerFactory;
+    private ILogger _logger;
+    private readonly IRetryEligibilityStrategy _eligibilityStrategy;
+    private readonly TimeSpan _retryDelayIntervalMillis;
+    private readonly TimeSpan _responseDataReceivedTimeoutMillis;
+
+    /// <summary>
+    /// Constructor for the FixedTimeoutRetryStrategy.
+    /// </summary>
+    /// <param name="loggerFactory"></param>
+    /// <param name="eligibilityStrategy"></param>
+    /// <param name="retryDelayIntervalMillis">Amount of time between retry attempts.</param>
+    /// <param name="responseDataReceivedTimeoutMillis">How long to wait for a retry attempt to succeed or timeout.</param>
+    public FixedTimeoutRetryStrategy(ILoggerFactory loggerFactory, IRetryEligibilityStrategy? eligibilityStrategy = null, TimeSpan? retryDelayIntervalMillis = null, TimeSpan? responseDataReceivedTimeoutMillis = null)
+    {
+        _loggerFactory = loggerFactory;
+        _logger = loggerFactory.CreateLogger<FixedCountRetryStrategy>();
+        _eligibilityStrategy = eligibilityStrategy ?? new DefaultRetryEligibilityStrategy(loggerFactory);
+        _retryDelayIntervalMillis = retryDelayIntervalMillis ?? TimeSpan.FromMilliseconds(100);
+        _responseDataReceivedTimeoutMillis = responseDataReceivedTimeoutMillis ?? TimeSpan.FromMilliseconds(1000);
+    }
+
+    /// <inheritdoc/>
+    public int? DetermineWhenToRetryRequest<TRequest>(Status grpcStatus, TRequest grpcRequest, int attemptNumber) where TRequest : class
+    {
+        _logger.LogDebug($"Determining whether request is eligible for retry; status code: {grpcStatus.StatusCode}, request type: {grpcRequest.GetType()}, attemptNumber: {attemptNumber}");
+        if (!_eligibilityStrategy.IsEligibleForRetry(grpcStatus, grpcRequest))
+        {
+            return null;
+        }
+        _logger.LogDebug($"Request is eligible for retry (attempt {attemptNumber}), retrying after {_retryDelayIntervalMillis} +/- jitter.");
+        return AddJitter((int)_retryDelayIntervalMillis.TotalMilliseconds);
+    }
+
+    private int AddJitter(int whenToRetry)
+    {
+        return Convert.ToInt32((0.2 * new Random().NextDouble() + 0.9) * whenToRetry);
+    }
+
+    /// <summary>
+    /// Test equality by value.
+    /// </summary>
+    /// <param name="obj"></param>
+    /// <returns></returns>
+    public override bool Equals(object obj)
+    {
+        if ((obj == null) || !this.GetType().Equals(obj.GetType()))
+        {
+            return false;
+        }
+
+        var other = (FixedTimeoutRetryStrategy)obj;
+        return _retryDelayIntervalMillis.Equals(other._retryDelayIntervalMillis) &&
+            _responseDataReceivedTimeoutMillis.Equals(other._responseDataReceivedTimeoutMillis) &&
+            _loggerFactory.Equals(other._loggerFactory) &&
+            _eligibilityStrategy.Equals(other._eligibilityStrategy);
+    }
+
+    /// <summary>
+    /// Trivial hash code implementation.
+    /// </summary>
+    /// <returns></returns>
+    public override int GetHashCode()
+    {
+        return base.GetHashCode();
+    }
+
+    /// <inheritdoc/>
+    public double? GetResponseDataReceivedTimeoutMillis()
+    {
+        return _responseDataReceivedTimeoutMillis.TotalMilliseconds;
+    }
+}

--- a/src/Momento.Sdk/Config/Retry/FixedTimeoutRetryStrategy.cs
+++ b/src/Momento.Sdk/Config/Retry/FixedTimeoutRetryStrategy.cs
@@ -29,7 +29,7 @@ public class FixedTimeoutRetryStrategy : IRetryStrategy
     public FixedTimeoutRetryStrategy(ILoggerFactory loggerFactory, IRetryEligibilityStrategy? eligibilityStrategy = null, TimeSpan? retryDelayIntervalMillis = null, TimeSpan? responseDataReceivedTimeoutMillis = null)
     {
         _loggerFactory = loggerFactory;
-        _logger = loggerFactory.CreateLogger<FixedCountRetryStrategy>();
+        _logger = loggerFactory.CreateLogger<FixedTimeoutRetryStrategy>();
         _eligibilityStrategy = eligibilityStrategy ?? new DefaultRetryEligibilityStrategy(loggerFactory);
         _retryDelayIntervalMillis = retryDelayIntervalMillis ?? TimeSpan.FromMilliseconds(100);
         _responseDataReceivedTimeoutMillis = responseDataReceivedTimeoutMillis ?? TimeSpan.FromMilliseconds(1000);

--- a/src/Momento.Sdk/Config/Retry/IRetryStrategy.cs
+++ b/src/Momento.Sdk/Config/Retry/IRetryStrategy.cs
@@ -15,4 +15,10 @@ public interface IRetryStrategy
     /// <param name="attemptNumber"></param>
     /// <returns>Returns number of milliseconds after which the request should be retried, or <see langword="null"/> if the request should not be retried.</returns>
     public int? DetermineWhenToRetryRequest<TRequest>(Status grpcStatus, TRequest grpcRequest, int attemptNumber) where TRequest : class;
+
+    /// <summary>
+    /// Get the time to wait for a response from a retried request before timing out.
+    /// </summary>
+    /// <returns></returns>
+    public double? GetResponseDataReceivedTimeoutMillis();
 }

--- a/src/Momento.Sdk/Internal/DataGrpcManager.cs
+++ b/src/Momento.Sdk/Internal/DataGrpcManager.cs
@@ -260,7 +260,7 @@ public class DataGrpcManager : GrpcManager
 
         var middlewares = config.Middlewares.Concat(
             new List<IMiddleware> {
-                new RetryMiddleware(config.LoggerFactory, config.RetryStrategy),
+                new RetryMiddleware(config.LoggerFactory, config.RetryStrategy, config.TransportStrategy.GrpcConfig.Deadline),
                 new HeaderMiddleware(config.LoggerFactory, headers),
                 new MaxConcurrentRequestsMiddleware(config.LoggerFactory, config.TransportStrategy.MaxConcurrentRequests)
             }

--- a/src/Momento.Sdk/Internal/Middleware/RetryMiddleware.cs
+++ b/src/Momento.Sdk/Internal/Middleware/RetryMiddleware.cs
@@ -30,7 +30,6 @@ namespace Momento.Sdk.Config.Retry
             // in case we're using the FixedTimeoutRetryStrategy
             DateTime _overallDeadline = callOptions.Deadline ?? Utils.CalculateDeadline(_clientTimeout);
             
-            var foo = request.GetType();
             MiddlewareResponseState<TResponse> nextState;
             int attemptNumber = 0;
             int? retryAfterMillis = 0;

--- a/src/Momento.Sdk/Internal/Middleware/RetryMiddleware.cs
+++ b/src/Momento.Sdk/Internal/Middleware/RetryMiddleware.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Grpc.Core;
 using Microsoft.Extensions.Logging;
 using Momento.Sdk.Config.Middleware;
+using Momento.Sdk.Internal;
 
 namespace Momento.Sdk.Config.Retry
 {
@@ -10,11 +11,13 @@ namespace Momento.Sdk.Config.Retry
     {
         private readonly ILogger _logger;
         private readonly IRetryStrategy _retryStrategy;
+        private readonly TimeSpan _clientTimeout;
 
-        public RetryMiddleware(ILoggerFactory loggerFactory, IRetryStrategy retryStrategy)
+        public RetryMiddleware(ILoggerFactory loggerFactory, IRetryStrategy retryStrategy, TimeSpan clientTimeout)
         {
             _logger = loggerFactory.CreateLogger<RetryMiddleware>();
             _retryStrategy = retryStrategy;
+            _clientTimeout = clientTimeout;
         }
 
         public async Task<MiddlewareResponseState<TResponse>> WrapRequest<TRequest, TResponse>(
@@ -23,6 +26,10 @@ namespace Momento.Sdk.Config.Retry
             Func<TRequest, CallOptions, Task<MiddlewareResponseState<TResponse>>> continuation
         ) where TRequest : class where TResponse : class
         {
+            // The first time we enter WrapRequest, we capture the overall deadline for the request
+            // in case we're using the FixedTimeoutRetryStrategy
+            DateTime _overallDeadline = callOptions.Deadline ?? Utils.CalculateDeadline(_clientTimeout);
+            
             var foo = request.GetType();
             MiddlewareResponseState<TResponse> nextState;
             int attemptNumber = 0;
@@ -57,6 +64,24 @@ namespace Momento.Sdk.Config.Retry
                     _logger.LogDebug($"Request failed with status {status.StatusCode}, checking to see if we should retry; attempt Number: {attemptNumber}");
                     _logger.LogTrace($"Failed request status: {status}");
                     retryAfterMillis = _retryStrategy.DetermineWhenToRetryRequest(nextState.GetStatus(), request, attemptNumber);
+
+                    // Calculate the deadline for the next retry attempt.
+                    // If using FixedTimeoutRetryStrategy, the deadline will be current time + responseDataReceivedTimeoutMillis.
+                    // Otherwise the deadline will remain unchanged (set to the overall deadline).
+                    double? nextTimeout = _retryStrategy.GetResponseDataReceivedTimeoutMillis();
+                    if (nextTimeout != null)
+                    {
+                        var retryDeadline = DateTime.UtcNow.AddMilliseconds((double)nextTimeout);
+
+                        // Check if new deadline would exceed overall deadline. Use overall if so.
+                        if (retryDeadline > _overallDeadline)
+                        {
+                            callOptions = callOptions.WithDeadline(_overallDeadline);
+                        } else
+                        {
+                            callOptions = callOptions.WithDeadline(retryDeadline);
+                        }
+                    }
                 }
             }
             while (retryAfterMillis != null);

--- a/src/Momento.Sdk/Internal/ScsControlClient.cs
+++ b/src/Momento.Sdk/Internal/ScsControlClient.cs
@@ -44,7 +44,7 @@ internal sealed class ScsControlClient : IDisposable
         {
             CheckValidCacheName(cacheName);
             _CreateCacheRequest request = new _CreateCacheRequest() { CacheName = cacheName };
-            await this.grpcManager.Client.CreateCacheAsync(request, new CallOptions(deadline: CalculateDeadline()));
+            await this.grpcManager.Client.CreateCacheAsync(request, new CallOptions(deadline: Utils.CalculateDeadline(deadline)));
             return new CreateCacheResponse.Success();
         }
         catch (Exception e)
@@ -63,7 +63,7 @@ internal sealed class ScsControlClient : IDisposable
         {
             CheckValidCacheName(cacheName);
             _DeleteCacheRequest request = new _DeleteCacheRequest() { CacheName = cacheName };
-            await this.grpcManager.Client.DeleteCacheAsync(request, new CallOptions(deadline: CalculateDeadline()));
+            await this.grpcManager.Client.DeleteCacheAsync(request, new CallOptions(deadline: Utils.CalculateDeadline(deadline)));
             return new DeleteCacheResponse.Success();
         }
         catch (Exception e)
@@ -78,7 +78,7 @@ internal sealed class ScsControlClient : IDisposable
         {
             CheckValidCacheName(cacheName);
             _FlushCacheRequest request = new() { CacheName = cacheName };
-            await this.grpcManager.Client.FlushCacheAsync(request, new CallOptions(deadline: CalculateDeadline()));
+            await this.grpcManager.Client.FlushCacheAsync(request, new CallOptions(deadline: Utils.CalculateDeadline(deadline)));
             return new FlushCacheResponse.Success();
         }
         catch (Exception e)
@@ -92,7 +92,7 @@ internal sealed class ScsControlClient : IDisposable
         _ListCachesRequest request = new _ListCachesRequest() { NextToken = nextPageToken == null ? "" : nextPageToken };
         try
         {
-            _ListCachesResponse result = await this.grpcManager.Client.ListCachesAsync(request, new CallOptions(deadline: CalculateDeadline()));
+            _ListCachesResponse result = await this.grpcManager.Client.ListCachesAsync(request, new CallOptions(deadline: Utils.CalculateDeadline(deadline)));
             return new ListCachesResponse.Success(result);
         }
         catch (Exception e)
@@ -108,11 +108,6 @@ internal sealed class ScsControlClient : IDisposable
             throw new InvalidArgumentException("Cache name must be nonempty");
         }
         return true;
-    }
-
-    private DateTime CalculateDeadline()
-    {
-        return DateTime.UtcNow.Add(deadline);
     }
 
     public void Dispose()

--- a/src/Momento.Sdk/Internal/ScsTokenClient.cs
+++ b/src/Momento.Sdk/Internal/ScsTokenClient.cs
@@ -45,12 +45,6 @@ internal sealed class ScsTokenClient : IDisposable
         string runtimeVer = System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription;
         return new Metadata() { { "agent", $"dotnet:auth:{sdkVersion}" }, { "runtime-version", runtimeVer } };
     }
-
-    private DateTime CalculateDeadline()
-    {
-        return DateTime.UtcNow.Add(authClientOperationTimeout);
-    }
-
     private const string RequestTypeAuthGenerateDisposableToken = "GENERATE_DISPOSABLE_TOKEN";
 
     public async Task<GenerateDisposableTokenResponse> GenerateDisposableToken(
@@ -83,7 +77,7 @@ internal sealed class ScsTokenClient : IDisposable
             var metadata = Metadata();
             _logger.LogTraceExecutingGenericRequest(RequestTypeAuthGenerateDisposableToken);
             var response = await grpcManager.Client.generateDisposableToken(
-                request, new CallOptions(headers: metadata, deadline: CalculateDeadline())
+                request, new CallOptions(headers: metadata, deadline: Utils.CalculateDeadline(authClientOperationTimeout))
             );
             return _logger.LogTraceGenericRequestSuccess(RequestTypeAuthGenerateDisposableToken,
                 new GenerateDisposableTokenResponse.Success(response));

--- a/src/Momento.Sdk/Internal/Utils.cs
+++ b/src/Momento.Sdk/Internal/Utils.cs
@@ -3,15 +3,10 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using Microsoft.Extensions.Logging;
-using Grpc.Core;
-using Grpc.Net.Client;
-using System.Net.Http;
 #if USE_GRPC_WEB
 using Grpc.Net.Client.Web;
 #endif
 
-using Momento.Sdk.Config.Transport;
 using Momento.Sdk.Exceptions;
 
 namespace Momento.Sdk.Internal;
@@ -199,4 +194,15 @@ public static class Utils
         }
         return;
     }
+
+    /// <summary>
+    /// Calculate the deadline given a timeout.
+    /// </summary>
+    /// <param name="timeout"></param>
+    /// <returns></returns>
+    public static DateTime CalculateDeadline(TimeSpan timeout)
+    {
+        return DateTime.UtcNow.Add(timeout);
+    }
 }
+

--- a/tests/Integration/Momento.Sdk.Tests/Retry/FixedTimeoutRetryStrategyTest.cs
+++ b/tests/Integration/Momento.Sdk.Tests/Retry/FixedTimeoutRetryStrategyTest.cs
@@ -1,0 +1,148 @@
+using System.Collections.Generic;
+using Microsoft.Extensions.Logging;
+using Momento.Sdk.Auth;
+using Momento.Sdk.Config;
+using Momento.Sdk.Config.Retry;
+
+namespace Momento.Sdk.Tests.Integration.Retry;
+
+[Collection("Retry")]
+public class FixedTimeoutRetryStrategyTests
+{
+    private readonly ICredentialProvider _authProvider;
+    private readonly ILoggerFactory _loggerFactory;
+    private readonly IConfiguration _cacheConfig;
+    private readonly TimeSpan CLIENT_TIMEOUT_MILLIS = TimeSpan.FromMilliseconds(3000);
+    private readonly TimeSpan RETRY_DELAY_MILLIS = TimeSpan.FromMilliseconds(100);
+    private readonly TimeSpan RESPONSE_DATA_RECEIVED_TIMEOUT_MILLIS = TimeSpan.FromMilliseconds(1000);
+
+    public FixedTimeoutRetryStrategyTests()
+    {
+        _authProvider = new MomentoLocalProvider();
+        _loggerFactory = LoggerFactory.Create(builder =>
+        {
+            builder.AddSimpleConsole(options =>
+            {
+                options.IncludeScopes = true;
+                options.SingleLine = true;
+                options.TimestampFormat = "hh:mm:ss ";
+            });
+            builder.AddFilter("Grpc.Net.Client", LogLevel.Error);
+            builder.SetMinimumLevel(LogLevel.Information);
+        });
+        _cacheConfig = Configurations.Laptop.Latest(_loggerFactory).WithClientTimeout(CLIENT_TIMEOUT_MILLIS);
+    }
+
+    [Fact]
+    public void FixedTimeoutRetryStrategy_IneligibleRpc() 
+    {
+        var testProps = new MomentoLocalCacheAndCacheClient(_authProvider, _loggerFactory, _cacheConfig, null, new FixedTimeoutRetryStrategy(_loggerFactory));
+        testProps.CacheClient.IncrementAsync(testProps.CacheName, "key").Wait();
+        Assert.Equal(0, testProps.TestMetricsCollector.GetTotalRetryCount(testProps.CacheName, MomentoRpcMethod.Increment));
+    }
+
+    [Fact]
+    public void FixedTimeoutRetryStrategy_EligibleRpc_FullOutage_ShortDelays() 
+    {
+        var maxAttempts = Convert.ToInt32(
+            CLIENT_TIMEOUT_MILLIS.TotalMilliseconds / RETRY_DELAY_MILLIS.TotalMilliseconds
+        );
+        var middlewareArgs = new MomentoLocalMiddlewareArgs {
+            ReturnError = MomentoErrorCode.SERVER_UNAVAILABLE.ToStringValue(),
+            ErrorRpcList = new List<string> { MomentoRpcMethod.Get.ToMomentoLocalMetadataString() },
+            DelayMillis = Convert.ToInt32(RETRY_DELAY_MILLIS.TotalMilliseconds)+100,
+            DelayRpcList = new List<string> { MomentoRpcMethod.Get.ToMomentoLocalMetadataString() },
+        };
+        var testProps = new MomentoLocalCacheAndCacheClient(
+            _authProvider, 
+            _loggerFactory, 
+            _cacheConfig, 
+            middlewareArgs, 
+            new FixedTimeoutRetryStrategy(
+                _loggerFactory, 
+                retryDelayIntervalMillis: RETRY_DELAY_MILLIS, 
+                responseDataReceivedTimeoutMillis: RESPONSE_DATA_RECEIVED_TIMEOUT_MILLIS
+            )
+        );
+        testProps.CacheClient.GetAsync(testProps.CacheName, "key").Wait();
+        Assert.InRange(testProps.TestMetricsCollector.GetTotalRetryCount(testProps.CacheName, MomentoRpcMethod.Get), 1, maxAttempts);
+    }
+
+    [Fact]
+    public void FixedTimeoutRetryStrategy_EligibleRpc_FullOutage_LongDelays() 
+    {
+        var maxAttempts = Convert.ToInt32(
+            CLIENT_TIMEOUT_MILLIS.TotalMilliseconds / RESPONSE_DATA_RECEIVED_TIMEOUT_MILLIS.TotalMilliseconds
+        );
+        var middlewareArgs = new MomentoLocalMiddlewareArgs {
+            ReturnError = MomentoErrorCode.SERVER_UNAVAILABLE.ToStringValue(),
+            ErrorRpcList = new List<string> { MomentoRpcMethod.Get.ToMomentoLocalMetadataString() },
+            DelayMillis = Convert.ToInt32(RESPONSE_DATA_RECEIVED_TIMEOUT_MILLIS.TotalMilliseconds)+100,
+            DelayRpcList = new List<string> { MomentoRpcMethod.Get.ToMomentoLocalMetadataString() },
+        };
+        var testProps = new MomentoLocalCacheAndCacheClient(
+            _authProvider, 
+            _loggerFactory, 
+            _cacheConfig, 
+            middlewareArgs, 
+            new FixedTimeoutRetryStrategy(
+                _loggerFactory, 
+                retryDelayIntervalMillis: RETRY_DELAY_MILLIS, 
+                responseDataReceivedTimeoutMillis: RESPONSE_DATA_RECEIVED_TIMEOUT_MILLIS
+            )
+        );
+        testProps.CacheClient.GetAsync(testProps.CacheName, "key").Wait();
+        Assert.InRange(testProps.TestMetricsCollector.GetTotalRetryCount(testProps.CacheName, MomentoRpcMethod.Get), 1, maxAttempts);
+    }
+
+    [Fact]
+    public void FixedTimeoutRetryStrategy_EligibleRpc_FullOutage_NoDelays() 
+    {
+        var maxAttempts = Convert.ToInt32(
+            CLIENT_TIMEOUT_MILLIS.TotalMilliseconds / RETRY_DELAY_MILLIS.TotalMilliseconds
+        );
+        var middlewareArgs = new MomentoLocalMiddlewareArgs {
+            ReturnError = MomentoErrorCode.SERVER_UNAVAILABLE.ToStringValue(),
+            ErrorRpcList = new List<string> { MomentoRpcMethod.Get.ToMomentoLocalMetadataString() },
+        };
+        var testProps = new MomentoLocalCacheAndCacheClient(
+            _authProvider, 
+            _loggerFactory, 
+            _cacheConfig, 
+            middlewareArgs, 
+            new FixedTimeoutRetryStrategy(
+                _loggerFactory, 
+                retryDelayIntervalMillis: RETRY_DELAY_MILLIS, 
+                responseDataReceivedTimeoutMillis: RESPONSE_DATA_RECEIVED_TIMEOUT_MILLIS
+            )
+        );
+        testProps.CacheClient.GetAsync(testProps.CacheName, "key").Wait();
+        Assert.InRange(testProps.TestMetricsCollector.GetTotalRetryCount(testProps.CacheName, MomentoRpcMethod.Get), 1, maxAttempts);
+    }
+
+    [Fact]
+    public void FixedTimeoutRetryStrategy_EligibleRpc_TemporaryOutage() 
+    {
+        var middlewareArgs = new MomentoLocalMiddlewareArgs {
+            ReturnError = MomentoErrorCode.SERVER_UNAVAILABLE.ToStringValue(),
+            ErrorRpcList = new List<string> { MomentoRpcMethod.Get.ToMomentoLocalMetadataString() },
+            ErrorCount = 2
+        };
+        var testProps = new MomentoLocalCacheAndCacheClient(
+            _authProvider, 
+            _loggerFactory, 
+            _cacheConfig, 
+            middlewareArgs, 
+            new FixedTimeoutRetryStrategy(
+                _loggerFactory, 
+                retryDelayIntervalMillis: RETRY_DELAY_MILLIS, 
+                responseDataReceivedTimeoutMillis: RESPONSE_DATA_RECEIVED_TIMEOUT_MILLIS
+            )
+        );
+        testProps.CacheClient.GetAsync(testProps.CacheName, "key").Wait();
+        var maxAttempts = Convert.ToInt32(
+            CLIENT_TIMEOUT_MILLIS.TotalMilliseconds / RESPONSE_DATA_RECEIVED_TIMEOUT_MILLIS.TotalMilliseconds
+        );
+        Assert.InRange(testProps.TestMetricsCollector.GetTotalRetryCount(testProps.CacheName, MomentoRpcMethod.Get), 1, maxAttempts);
+    }
+}

--- a/tests/Integration/Momento.Sdk.Tests/Retry/MomentoLocalMiddlewareTest.cs
+++ b/tests/Integration/Momento.Sdk.Tests/Retry/MomentoLocalMiddlewareTest.cs
@@ -1,6 +1,5 @@
 using Momento.Sdk.Auth;
 using Momento.Sdk.Config;
-using Momento.Sdk.Config.Retry;
 using Microsoft.Extensions.Logging;
 using Momento.Sdk.Config.Middleware;
 using System.Threading.Tasks;
@@ -78,18 +77,6 @@ public class MomentoLocalMiddlewareTests
         cacheClient.GetAsync(cacheName, "key").Wait();
         cacheClient.SetAsync(cacheName, "another-key", "value").Wait();
         cacheClient.GetAsync(cacheName, "another-key").Wait();
-
-        // print all metrics
-        foreach (var cache in testMetricsCollector.AllMetrics)
-        {
-            foreach (var method in cache.Value)
-            {
-                foreach (var timestamp in method.Value)
-                {
-                    Console.WriteLine($"Cache: {cache.Key}, Method: {method.Key}, Timestamp: {timestamp}");
-                }
-            }
-        }
 
         // Should contain only a single entry in the outer dictionary for the one cache
         Assert.Single(testMetricsCollector.AllMetrics);

--- a/tests/Integration/Momento.Sdk.Tests/Retry/TestRetryMetricsCollectorTest.cs
+++ b/tests/Integration/Momento.Sdk.Tests/Retry/TestRetryMetricsCollectorTest.cs
@@ -1,5 +1,3 @@
-using Momento.Sdk.Config.Retry;
-
 namespace Momento.Sdk.Tests.Integration.Retry;
 
 [Collection("Retry")]

--- a/tests/Integration/Momento.Sdk.Tests/Retry/utils/MomentoLocalMiddleware.cs
+++ b/tests/Integration/Momento.Sdk.Tests/Retry/utils/MomentoLocalMiddleware.cs
@@ -104,7 +104,7 @@ public class MomentoLocalMiddleware : IMiddleware
 
         // Then convert to the approrpriate enum
         var rpcMethod = MomentoRpcMethodExtensions.FromString(requestName);
-        TestMetricsCollector.AddTimestamp(cacheName, rpcMethod, 1);
+        TestMetricsCollector.AddTimestamp(cacheName, rpcMethod, DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
 
         var nextState = await continuation(request, callOptionsWithHeaders);
         return new MiddlewareResponseState<TResponse>(

--- a/tests/Integration/Momento.Sdk.Tests/Retry/utils/MomentoLocalMiddleware.cs
+++ b/tests/Integration/Momento.Sdk.Tests/Retry/utils/MomentoLocalMiddleware.cs
@@ -4,7 +4,6 @@ using System.Threading.Tasks;
 using Grpc.Core;
 using Microsoft.Extensions.Logging;
 using Momento.Sdk.Config.Middleware;
-using Momento.Sdk.Config.Retry;
 using Momento.Sdk.Internal.ExtensionMethods;
 
 namespace Momento.Sdk.Tests.Integration.Retry;

--- a/tests/Integration/Momento.Sdk.Tests/Retry/utils/MomentoRpcMethod.cs
+++ b/tests/Integration/Momento.Sdk.Tests/Retry/utils/MomentoRpcMethod.cs
@@ -1,5 +1,4 @@
 #pragma warning disable 1591
-using System;
 
 namespace Momento.Sdk.Tests.Integration.Retry;
 

--- a/tests/Integration/Momento.Sdk.Tests/Retry/utils/TestRetryMetricsCollector.cs
+++ b/tests/Integration/Momento.Sdk.Tests/Retry/utils/TestRetryMetricsCollector.cs
@@ -1,4 +1,3 @@
-using Momento.Sdk.Config.Retry;
 using System.Collections.Generic;
 
 namespace Momento.Sdk.Tests.Integration.Retry;


### PR DESCRIPTION
Work towards https://github.com/momentohq/dev-eco-issue-tracker/issues/1195

Adds fixed timeout retry strategy (used [JS](https://github.com/momentohq/client-sdk-javascript/blob/main/packages/client-sdk-nodejs/src/config/retry/fixed-timeout-retry-strategy.ts) and [Java](https://github.com/momentohq/client-sdk-java/blob/main/momento-sdk/src/main/java/momento/sdk/retry/FixedTimeoutRetryStrategy.java) implementations for reference).
Adds momento-local tests exercising the fixed timeout strategy.
