### PR TITLE
feat: add ExponentialBackoffRetryStrategy and fix test middleware timestamp bug

### DIFF
--- a/src/Momento.Sdk/Config/Retry/ExponentialBackoffRetryStrategy.cs
+++ b/src/Momento.Sdk/Config/Retry/ExponentialBackoffRetryStrategy.cs
@@ -1,0 +1,129 @@
+using System;
+using Grpc.Core;
+using Microsoft.Extensions.Logging;
+using Momento.Sdk.Internal.Retry;
+
+namespace Momento.Sdk.Config.Retry;
+
+/// <summary>
+/// TODO
+/// </summary>
+public class ExponentialBackoffRetryStrategy : IRetryStrategy
+{
+    /// <summary>
+    /// TODO
+    /// </summary>
+    public static readonly double DEFAULT_INITIAL_DELAY_MS = 0.5;
+    /// <summary>
+    /// TODO
+    /// </summary>
+    public static readonly double DEFAULT_GROWTH_FACTOR = 2;
+    /// <summary>
+    /// TODO
+    /// </summary>
+
+    public static readonly double DEFAULT_MAX_BACKOFF_MS = 1000;
+    private ILoggerFactory _loggerFactory;
+    private ILogger _logger;
+    private readonly IRetryEligibilityStrategy _eligibilityStrategy;
+    
+    private readonly double _initialDelayMillis;
+    private readonly double _growthFactor;
+    private readonly double _maxBackoffMillis;
+
+    /// <summary>
+    /// TODO
+    /// </summary>
+    /// <param name="loggerFactory"></param>
+    /// <param name="eligibilityStrategy"></param>
+    /// <param name="initialDelayMillis"></param>
+    /// <param name="maxBackoffMillis"></param>
+    public ExponentialBackoffRetryStrategy(ILoggerFactory loggerFactory, IRetryEligibilityStrategy? eligibilityStrategy = null, double? initialDelayMillis = null, double? maxBackoffMillis = null) 
+    {
+        _loggerFactory = loggerFactory;
+        _logger = loggerFactory.CreateLogger<ExponentialBackoffRetryStrategy>();
+        _eligibilityStrategy = eligibilityStrategy ?? new DefaultRetryEligibilityStrategy(loggerFactory);
+        _initialDelayMillis = initialDelayMillis ?? DEFAULT_INITIAL_DELAY_MS;
+        _growthFactor = DEFAULT_GROWTH_FACTOR;
+        _maxBackoffMillis = maxBackoffMillis ?? DEFAULT_MAX_BACKOFF_MS;
+    }
+
+    /// <inheritdoc/>
+    public int? DetermineWhenToRetryRequest<TRequest>(Status grpcStatus, TRequest grpcRequest, int attemptNumber) where TRequest : class
+    {
+        _logger.LogDebug($"Determining whether request is eligible for retry; status code: {grpcStatus.StatusCode}, request type: {grpcRequest.GetType()}, attemptNumber: {attemptNumber}");
+        if (!_eligibilityStrategy.IsEligibleForRetry(grpcStatus, grpcRequest))
+        {
+            return null;
+        }
+
+        double baseDelay = computeBaseDelay(attemptNumber);
+        double previousBaseDelay = computePreviousBaseDelay(baseDelay);
+        double maxDelay = previousBaseDelay * 3;
+        double jitteredDelay = randomInRange(baseDelay, maxDelay);
+        int jitteredDelayMs = Convert.ToInt32(jitteredDelay);
+
+        _logger.LogDebug($"Request is eligible for retry (attempt {attemptNumber}), retrying after {jitteredDelayMs}ms.");
+        return jitteredDelayMs;
+    }
+
+    private double computeBaseDelay(int attemptNumber) {
+      if (attemptNumber <= 0) {
+        return _initialDelayMillis;
+      }
+
+        double multiplier = Math.Pow(_growthFactor, attemptNumber);
+        double baseDelay = _initialDelayMillis * multiplier;
+        return Math.Min(baseDelay, _maxBackoffMillis);
+    }
+
+    private double computePreviousBaseDelay(double currentBaseDelay) {
+      if (currentBaseDelay == _initialDelayMillis) {
+        return _initialDelayMillis;
+      }
+
+      return currentBaseDelay / _growthFactor;
+    }
+
+    private double randomInRange(double min, double max) {
+      if (min >= max) {
+        return min;
+      }
+      return min + (new Random().NextDouble() * (max - min));
+    }
+
+    /// <summary>
+    /// Test equality by value.
+    /// </summary>
+    /// <param name="obj"></param>
+    /// <returns></returns>
+    public override bool Equals(object obj)
+    {
+        if ((obj == null) || !this.GetType().Equals(obj.GetType()))
+        {
+            return false;
+        }
+
+        var other = (ExponentialBackoffRetryStrategy)obj;
+        return _initialDelayMillis.Equals(other._initialDelayMillis) &&
+            _growthFactor.Equals(other._growthFactor) &&
+            _maxBackoffMillis.Equals(other._maxBackoffMillis) &&
+            _loggerFactory.Equals(other._loggerFactory) &&
+            _eligibilityStrategy.Equals(other._eligibilityStrategy);
+    }
+
+    /// <summary>
+    /// Trivial hash code implementation.
+    /// </summary>
+    /// <returns></returns>
+    public override int GetHashCode()
+    {
+        return base.GetHashCode();
+    }
+
+    /// <inheritdoc/>
+    public double? GetResponseDataReceivedTimeoutMillis()
+    {
+        return null;
+    }
+}

--- a/src/Momento.Sdk/Config/Retry/ExponentialBackoffRetryStrategy.cs
+++ b/src/Momento.Sdk/Config/Retry/ExponentialBackoffRetryStrategy.cs
@@ -63,11 +63,11 @@ public class ExponentialBackoffRetryStrategy : IRetryStrategy
             return null;
         }
 
-        double baseDelay = ComputeBaseDelay(attemptNumber);
-        double previousBaseDelay = ComputePreviousBaseDelay(baseDelay);
-        double maxDelay = previousBaseDelay * 3;
-        double jitteredDelay = RandomInRange(baseDelay, maxDelay);
-        int jitteredDelayMs = Convert.ToInt32(jitteredDelay);
+        var baseDelay = ComputeBaseDelay(attemptNumber);
+        var previousBaseDelay = ComputePreviousBaseDelay(baseDelay);
+        var maxDelay = previousBaseDelay * 3;
+        var jitteredDelay = RandomInRange(baseDelay, maxDelay);
+        var jitteredDelayMs = Convert.ToInt32(jitteredDelay);
 
         _logger.LogDebug($"Request is eligible for retry (attempt {attemptNumber}), retrying after {jitteredDelayMs}ms.");
         return jitteredDelayMs;
@@ -77,8 +77,8 @@ public class ExponentialBackoffRetryStrategy : IRetryStrategy
         if (attemptNumber <= 0) {
             return _initialDelay.TotalMilliseconds;
         }
-        double multiplier = Math.Pow(_growthFactor, attemptNumber);
-        double baseDelay = _initialDelay.TotalMilliseconds * multiplier;
+        var multiplier = Math.Pow(_growthFactor, attemptNumber);
+        var baseDelay = _initialDelay.TotalMilliseconds * multiplier;
         return Math.Min(baseDelay, _maxBackoff.TotalMilliseconds);
     }
 

--- a/src/Momento.Sdk/Config/Retry/ExponentialBackoffRetryStrategy.cs
+++ b/src/Momento.Sdk/Config/Retry/ExponentialBackoffRetryStrategy.cs
@@ -28,7 +28,6 @@ public class ExponentialBackoffRetryStrategy : IRetryStrategy
     /// </summary>
     public static readonly TimeSpan DEFAULT_MAX_BACKOFF = TimeSpan.FromMilliseconds(1000);
 
-    private ILoggerFactory _loggerFactory;
     private ILogger _logger;
     private readonly IRetryEligibilityStrategy _eligibilityStrategy;
     
@@ -46,7 +45,6 @@ public class ExponentialBackoffRetryStrategy : IRetryStrategy
     /// <param name="maxBackoff"></param>
     public ExponentialBackoffRetryStrategy(ILoggerFactory loggerFactory, IRetryEligibilityStrategy? eligibilityStrategy = null, TimeSpan? initialDelay = null, TimeSpan? maxBackoff = null) 
     {
-        _loggerFactory = loggerFactory;
         _logger = loggerFactory.CreateLogger<ExponentialBackoffRetryStrategy>();
         _eligibilityStrategy = eligibilityStrategy ?? new DefaultRetryEligibilityStrategy(loggerFactory);
         _initialDelay = initialDelay ?? DEFAULT_INITIAL_DELAY;
@@ -112,7 +110,6 @@ public class ExponentialBackoffRetryStrategy : IRetryStrategy
         return _initialDelay.Equals(other._initialDelay) &&
             _growthFactor.Equals(other._growthFactor) &&
             _maxBackoff.Equals(other._maxBackoff) &&
-            _loggerFactory.Equals(other._loggerFactory) &&
             _eligibilityStrategy.Equals(other._eligibilityStrategy);
     }
 

--- a/src/Momento.Sdk/Config/Retry/ExponentialBackoffRetryStrategy.cs
+++ b/src/Momento.Sdk/Config/Retry/ExponentialBackoffRetryStrategy.cs
@@ -30,6 +30,7 @@ public class ExponentialBackoffRetryStrategy : IRetryStrategy
     private readonly double _initialDelayMillis;
     private readonly double _growthFactor;
     private readonly double _maxBackoffMillis;
+    private readonly Random _random = new Random();
 
     /// <summary>
     /// TODO
@@ -89,7 +90,7 @@ public class ExponentialBackoffRetryStrategy : IRetryStrategy
       if (min >= max) {
         return min;
       }
-      return min + (new Random().NextDouble() * (max - min));
+      return min + (_random.NextDouble() * (max - min));
     }
 
     /// <summary>

--- a/src/Momento.Sdk/Config/Retry/ExponentialBackoffRetryStrategy.cs
+++ b/src/Momento.Sdk/Config/Retry/ExponentialBackoffRetryStrategy.cs
@@ -6,23 +6,28 @@ using Momento.Sdk.Internal.Retry;
 namespace Momento.Sdk.Config.Retry;
 
 /// <summary>
-/// TODO
+/// Retry strategy that uses exponential backoff with decorrelated jitter.
+/// - The first retry has a fixed delay of `initialDelayMillis`
+/// - Backoff for subsequent retries is calculated as `initialDelayMillis * 2^attemptNumber`
+/// - Subsequent retries have a delay that is a random value between 
+/// the current backoff and 3 times the previous backoff, with the 
+/// current backoff capped at `maxBackoffMillis`
 /// </summary>
 public class ExponentialBackoffRetryStrategy : IRetryStrategy
 {
     /// <summary>
-    /// TODO
+    /// Default initial delay for the first retry (in milliseconds)
     /// </summary>
     public static readonly double DEFAULT_INITIAL_DELAY_MS = 0.5;
     /// <summary>
-    /// TODO
+    /// Default growth factor for exponential backoff
     /// </summary>
     public static readonly double DEFAULT_GROWTH_FACTOR = 2;
     /// <summary>
-    /// TODO
+    /// Default maximum delay to cap the exponential growth (in milliseconds)
     /// </summary>
-
     public static readonly double DEFAULT_MAX_BACKOFF_MS = 1000;
+
     private ILoggerFactory _loggerFactory;
     private ILogger _logger;
     private readonly IRetryEligibilityStrategy _eligibilityStrategy;
@@ -33,7 +38,7 @@ public class ExponentialBackoffRetryStrategy : IRetryStrategy
     private readonly Random _random = new Random();
 
     /// <summary>
-    /// TODO
+    /// Constructor for ExponentialBackoffRetryStrategy
     /// </summary>
     /// <param name="loggerFactory"></param>
     /// <param name="eligibilityStrategy"></param>

--- a/tests/Integration/Momento.Sdk.Tests/Retry/ExponentialBackoffRetryStrategyTest.cs
+++ b/tests/Integration/Momento.Sdk.Tests/Retry/ExponentialBackoffRetryStrategyTest.cs
@@ -1,0 +1,121 @@
+using System.Collections.Generic;
+using Grpc.Core;
+using Microsoft.Extensions.Logging;
+using Momento.Protos.CacheClient;
+using Momento.Sdk.Auth;
+using Momento.Sdk.Config;
+using Momento.Sdk.Config.Retry;
+
+namespace Momento.Sdk.Tests.Integration.Retry;
+
+[Collection("Retry")]
+public class ExponentialBackoffRetryStrategyTests
+{
+    private readonly ICredentialProvider _authProvider;
+    private readonly ILoggerFactory _loggerFactory;
+    private readonly IConfiguration _cacheConfig;
+    private readonly TimeSpan CLIENT_TIMEOUT_MILLIS = TimeSpan.FromMilliseconds(3000);
+
+    public ExponentialBackoffRetryStrategyTests()
+    {
+        _authProvider = new MomentoLocalProvider();
+        _loggerFactory = LoggerFactory.Create(builder =>
+        {
+            builder.AddSimpleConsole(options =>
+            {
+                options.IncludeScopes = true;
+                options.SingleLine = true;
+                options.TimestampFormat = "hh:mm:ss ";
+            });
+            builder.AddFilter("Grpc.Net.Client", LogLevel.Error);
+            builder.SetMinimumLevel(LogLevel.Information);
+        });
+        _cacheConfig = Configurations.Laptop.Latest(_loggerFactory).WithClientTimeout(CLIENT_TIMEOUT_MILLIS);
+    }
+
+    [Fact]
+    public void ExponentialBackoffRetryStrategy_IneligibleRpc() 
+    {
+        var retryStrategy = new ExponentialBackoffRetryStrategy(_loggerFactory);
+        var testProps = new MomentoLocalCacheAndCacheClient(_authProvider, _loggerFactory, _cacheConfig, null, retryStrategy);
+        testProps.CacheClient.IncrementAsync(testProps.CacheName, "key").Wait();
+        Assert.Equal(0, testProps.TestMetricsCollector.GetTotalRetryCount(testProps.CacheName, MomentoRpcMethod.Increment));
+    }
+
+    [Fact]
+    public void ExponentialBackoffRetryStrategy_FirstAttemptReturnsInitialDelayWithJitter()
+    {
+        var retryStrategy = new ExponentialBackoffRetryStrategy(_loggerFactory, initialDelayMillis: 100, maxBackoffMillis: 1000);
+        for (int i = 0; i < 100; i++)
+        {
+            var retryDelay = retryStrategy.DetermineWhenToRetryRequest(new Status(StatusCode.Unavailable, "unavailable"), new _GetRequest(), 0);
+            if (retryDelay == null)
+            {
+                Assert.Fail("Retry delay should not be null");
+            } else {
+                Assert.InRange(retryDelay.Value, 100, 300);
+            }
+        }
+    }
+
+    [Fact]
+    public void ExponentialBackoffRetryStrategy_SecondAttemptShouldDoubleBaseDelayWithJitter()
+    {
+        var retryStrategy = new ExponentialBackoffRetryStrategy(_loggerFactory, initialDelayMillis: 100, maxBackoffMillis: 1000);
+        for (int i = 0; i < 100; i++)
+        {
+            var retryDelay = retryStrategy.DetermineWhenToRetryRequest(new Status(StatusCode.Unavailable, "unavailable"), new _GetRequest(), 1);
+            if (retryDelay == null)
+            {
+                Assert.Fail("Retry delay should not be null");
+            } else {
+                Assert.InRange(retryDelay.Value, 200, 600);
+            }
+        }
+    }
+
+    [Fact]
+    public void ExponentialBackoffRetryStrategy_ShouldNotExceedLimitWhenMaxBackoffReached()
+    {
+        var retryStrategy = new ExponentialBackoffRetryStrategy(_loggerFactory, initialDelayMillis: 100, maxBackoffMillis: 500);
+        var retryDelay = retryStrategy.DetermineWhenToRetryRequest(new Status(StatusCode.Unavailable, "unavailable"), new _GetRequest(), 100);
+        if (retryDelay == null)
+        {
+            Assert.Fail("Retry delay should not be null");
+        } else {
+            Assert.InRange(retryDelay.Value, 500, 1500);
+        }
+    }
+
+    [Fact]
+    public void ExponentialBackoffRetryStrategy_FullOutage_ShouldRetryMultipleTimesUntilClientTimeout()
+    {
+        var retryStrategy = new ExponentialBackoffRetryStrategy(_loggerFactory, initialDelayMillis: 100, maxBackoffMillis: 2000);
+        var middlewareArgs = new MomentoLocalMiddlewareArgs {
+            ReturnError = MomentoErrorCode.SERVER_UNAVAILABLE.ToStringValue(),
+            ErrorRpcList = new List<string> { MomentoRpcMethod.Get.ToMomentoLocalMetadataString() },
+        };
+        var testProps = new MomentoLocalCacheAndCacheClient(_authProvider, _loggerFactory, _cacheConfig, middlewareArgs, retryStrategy);
+        testProps.CacheClient.GetAsync(testProps.CacheName, "key").Wait();
+        var retryCount = testProps.TestMetricsCollector.GetTotalRetryCount(testProps.CacheName, MomentoRpcMethod.Get);
+        Assert.InRange(retryCount, 2, 5);
+        var averageRetryDelay = testProps.TestMetricsCollector.GetAverageTimeBetweenRetries(testProps.CacheName, MomentoRpcMethod.Get);
+        Assert.InRange(averageRetryDelay, 100, 2000);
+    }
+
+    [Fact]
+    public void ExponentialBackoffRetryStrategy_TemporaryOutage()
+    {
+      var retryStrategy = new ExponentialBackoffRetryStrategy(_loggerFactory, initialDelayMillis: 100, maxBackoffMillis: 2000);
+        var middlewareArgs = new MomentoLocalMiddlewareArgs {
+            ReturnError = MomentoErrorCode.SERVER_UNAVAILABLE.ToStringValue(),
+            ErrorRpcList = new List<string> { MomentoRpcMethod.Get.ToMomentoLocalMetadataString() },
+            ErrorCount = 2,
+        };
+        var testProps = new MomentoLocalCacheAndCacheClient(_authProvider, _loggerFactory, _cacheConfig, middlewareArgs, retryStrategy);
+        testProps.CacheClient.GetAsync(testProps.CacheName, "key").Wait();
+        Assert.Equal(2, testProps.TestMetricsCollector.GetTotalRetryCount(testProps.CacheName, MomentoRpcMethod.Get));
+        var averageRetryDelay = testProps.TestMetricsCollector.GetAverageTimeBetweenRetries(testProps.CacheName, MomentoRpcMethod.Get);
+        Assert.InRange(averageRetryDelay, 100, 600);
+    }
+}

--- a/tests/Integration/Momento.Sdk.Tests/Retry/ExponentialBackoffRetryStrategyTest.cs
+++ b/tests/Integration/Momento.Sdk.Tests/Retry/ExponentialBackoffRetryStrategyTest.cs
@@ -14,7 +14,7 @@ public class ExponentialBackoffRetryStrategyTests
     private readonly ICredentialProvider _authProvider;
     private readonly ILoggerFactory _loggerFactory;
     private readonly IConfiguration _cacheConfig;
-    private readonly TimeSpan CLIENT_TIMEOUT_MILLIS = TimeSpan.FromMilliseconds(3000);
+    private readonly TimeSpan CLIENT_TIMEOUT = TimeSpan.FromMilliseconds(3000);
 
     public ExponentialBackoffRetryStrategyTests()
     {
@@ -30,7 +30,7 @@ public class ExponentialBackoffRetryStrategyTests
             builder.AddFilter("Grpc.Net.Client", LogLevel.Error);
             builder.SetMinimumLevel(LogLevel.Information);
         });
-        _cacheConfig = Configurations.Laptop.Latest(_loggerFactory).WithClientTimeout(CLIENT_TIMEOUT_MILLIS);
+        _cacheConfig = Configurations.Laptop.Latest(_loggerFactory).WithClientTimeout(CLIENT_TIMEOUT);
     }
 
     [Fact]
@@ -45,7 +45,11 @@ public class ExponentialBackoffRetryStrategyTests
     [Fact]
     public void ExponentialBackoffRetryStrategy_FirstAttemptReturnsInitialDelayWithJitter()
     {
-        var retryStrategy = new ExponentialBackoffRetryStrategy(_loggerFactory, initialDelayMillis: 100, maxBackoffMillis: 1000);
+        var retryStrategy = new ExponentialBackoffRetryStrategy(
+            _loggerFactory, 
+            initialDelay: TimeSpan.FromMilliseconds(100), 
+            maxBackoff: TimeSpan.FromMilliseconds(1000)
+        );
         for (int i = 0; i < 100; i++)
         {
             var retryDelay = retryStrategy.DetermineWhenToRetryRequest(new Status(StatusCode.Unavailable, "unavailable"), new _GetRequest(), 0);
@@ -61,7 +65,11 @@ public class ExponentialBackoffRetryStrategyTests
     [Fact]
     public void ExponentialBackoffRetryStrategy_SecondAttemptShouldDoubleBaseDelayWithJitter()
     {
-        var retryStrategy = new ExponentialBackoffRetryStrategy(_loggerFactory, initialDelayMillis: 100, maxBackoffMillis: 1000);
+        var retryStrategy = new ExponentialBackoffRetryStrategy(
+            _loggerFactory, 
+            initialDelay: TimeSpan.FromMilliseconds(100), 
+            maxBackoff: TimeSpan.FromMilliseconds(1000)
+        );
         for (int i = 0; i < 100; i++)
         {
             var retryDelay = retryStrategy.DetermineWhenToRetryRequest(new Status(StatusCode.Unavailable, "unavailable"), new _GetRequest(), 1);
@@ -77,7 +85,11 @@ public class ExponentialBackoffRetryStrategyTests
     [Fact]
     public void ExponentialBackoffRetryStrategy_ShouldNotExceedLimitWhenMaxBackoffReached()
     {
-        var retryStrategy = new ExponentialBackoffRetryStrategy(_loggerFactory, initialDelayMillis: 100, maxBackoffMillis: 500);
+        var retryStrategy = new ExponentialBackoffRetryStrategy(
+            _loggerFactory, 
+            initialDelay: TimeSpan.FromMilliseconds(100), 
+            maxBackoff: TimeSpan.FromMilliseconds(500)
+        );
         var retryDelay = retryStrategy.DetermineWhenToRetryRequest(new Status(StatusCode.Unavailable, "unavailable"), new _GetRequest(), 100);
         if (retryDelay == null)
         {
@@ -90,7 +102,11 @@ public class ExponentialBackoffRetryStrategyTests
     [Fact]
     public void ExponentialBackoffRetryStrategy_FullOutage_ShouldRetryMultipleTimesUntilClientTimeout()
     {
-        var retryStrategy = new ExponentialBackoffRetryStrategy(_loggerFactory, initialDelayMillis: 100, maxBackoffMillis: 2000);
+        var retryStrategy = new ExponentialBackoffRetryStrategy(
+            _loggerFactory, 
+            initialDelay: TimeSpan.FromMilliseconds(100), 
+            maxBackoff: TimeSpan.FromMilliseconds(2000)
+        );
         var middlewareArgs = new MomentoLocalMiddlewareArgs {
             ReturnError = MomentoErrorCode.SERVER_UNAVAILABLE.ToStringValue(),
             ErrorRpcList = new List<string> { MomentoRpcMethod.Get.ToMomentoLocalMetadataString() },
@@ -106,7 +122,11 @@ public class ExponentialBackoffRetryStrategyTests
     [Fact]
     public void ExponentialBackoffRetryStrategy_TemporaryOutage()
     {
-      var retryStrategy = new ExponentialBackoffRetryStrategy(_loggerFactory, initialDelayMillis: 100, maxBackoffMillis: 2000);
+        var retryStrategy = new ExponentialBackoffRetryStrategy(
+            _loggerFactory, 
+            initialDelay: TimeSpan.FromMilliseconds(100), 
+            maxBackoff: TimeSpan.FromMilliseconds(2000)
+        );
         var middlewareArgs = new MomentoLocalMiddlewareArgs {
             ReturnError = MomentoErrorCode.SERVER_UNAVAILABLE.ToStringValue(),
             ErrorRpcList = new List<string> { MomentoRpcMethod.Get.ToMomentoLocalMetadataString() },

--- a/tests/Integration/Momento.Sdk.Tests/Retry/FixedCountRetryStrategyTest.cs
+++ b/tests/Integration/Momento.Sdk.Tests/Retry/FixedCountRetryStrategyTest.cs
@@ -49,6 +49,8 @@ public class FixedCountRetryStrategyTests
         var testProps = new MomentoLocalCacheAndCacheClient(_authProvider, _loggerFactory, _cacheConfig, middlewareArgs, new FixedCountRetryStrategy(_loggerFactory, maxAttempts));
         testProps.CacheClient.GetAsync(testProps.CacheName, "key").Wait();
         Assert.Equal(maxAttempts, testProps.TestMetricsCollector.GetTotalRetryCount(testProps.CacheName, MomentoRpcMethod.Get));
+        var averageTimeBetweenRetries = testProps.TestMetricsCollector.GetAverageTimeBetweenRetries(testProps.CacheName, MomentoRpcMethod.Get);
+        Assert.InRange(averageTimeBetweenRetries, 0, 10); // should be a negligible amount of time between retries
     }
 
     [Fact]
@@ -62,5 +64,7 @@ public class FixedCountRetryStrategyTests
         var testProps = new MomentoLocalCacheAndCacheClient(_authProvider, _loggerFactory, _cacheConfig, middlewareArgs, new FixedCountRetryStrategy(_loggerFactory, 3));
         testProps.CacheClient.GetAsync(testProps.CacheName, "key").Wait();
         Assert.Equal(2, testProps.TestMetricsCollector.GetTotalRetryCount(testProps.CacheName, MomentoRpcMethod.Get));
+        var averageTimeBetweenRetries = testProps.TestMetricsCollector.GetAverageTimeBetweenRetries(testProps.CacheName, MomentoRpcMethod.Get);
+        Assert.InRange(averageTimeBetweenRetries, 0, 10); // should be a negligible amount of time between retries
     }
 }

--- a/tests/Integration/Momento.Sdk.Tests/Retry/utils/MomentoLocalMiddleware.cs
+++ b/tests/Integration/Momento.Sdk.Tests/Retry/utils/MomentoLocalMiddleware.cs
@@ -103,7 +103,7 @@ public class MomentoLocalMiddleware : IMiddleware
         // Request name appears as "Momento.Protos.CacheClient._GetRequest" so we need to extract the last part.
         var requestName = request.GetType().ToString().Split('.').Last();
 
-        // Then convert to the approrpriate enum
+        // Then convert to the appropriate enum
         var rpcMethod = MomentoRpcMethodExtensions.FromString(requestName);
         TestMetricsCollector.AddTimestamp(cacheName, rpcMethod, DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
 

--- a/tests/Integration/Momento.Sdk.Tests/Retry/utils/MomentoLocalMiddleware.cs
+++ b/tests/Integration/Momento.Sdk.Tests/Retry/utils/MomentoLocalMiddleware.cs
@@ -105,7 +105,7 @@ public class MomentoLocalMiddleware : IMiddleware
 
         // Then convert to the approrpriate enum
         var rpcMethod = MomentoRpcMethodExtensions.FromString(requestName);
-        TestMetricsCollector.AddTimestamp(cacheName, rpcMethod, 1);
+        TestMetricsCollector.AddTimestamp(cacheName, rpcMethod, DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
 
         var nextState = await continuation(request, callOptionsWithHeaders);
         return new MiddlewareResponseState<TResponse>(


### PR DESCRIPTION
Work towards https://github.com/momentohq/dev-eco-issue-tracker/issues/1195

Adds ExponentialBackoffRetryStrategy and tests based on the JS, Java, and Go implementations.

Also found a bug in how the MomentoLocalMiddleware was recording timestamps (it was not, it was only recording the number 1 🤦)