### PR TITLE
feat: add TopicClient middleware and topics tests against momento-local

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -124,7 +124,7 @@ jobs:
 
       - name: Start Momento Local
         run: |
-          docker run --cap-add=NET_ADMIN -d --rm -p 8080:8080 -p 9090:9090 --enable-test-admin
+          docker run --cap-add=NET_ADMIN -d --rm -p 8080:8080 -p 9090:9090 gomomento/momento-local --enable-test-admin
 
       - name: Run momento-local retry tests
         run: make test-retry

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -124,7 +124,7 @@ jobs:
 
       - name: Start Momento Local
         run: |
-         docker run --rm -d -p 8080:8080 gomomento/momento-local
+          docker run --cap-add=NET_ADMIN -d --rm -p 8080:8080 -p 9090:9090 --enable-test-admin
 
       - name: Run momento-local retry tests
         run: make test-retry

--- a/src/Momento.Sdk/Config/ITopicConfiguration.cs
+++ b/src/Momento.Sdk/Config/ITopicConfiguration.cs
@@ -1,6 +1,8 @@
 using System;
 using Microsoft.Extensions.Logging;
 using Momento.Sdk.Config.Transport;
+using System.Collections.Generic;
+using Momento.Sdk.Config.Middleware;
 
 namespace Momento.Sdk.Config;
 
@@ -14,6 +16,8 @@ public interface ITopicConfiguration
     public ILoggerFactory LoggerFactory { get; }
     /// <inheritdoc cref="Momento.Sdk.Config.Transport.ITransportStrategy" />
     public ITopicTransportStrategy TransportStrategy { get; }
+    /// <inheritdoc cref="Momento.Sdk.Config.Middleware.IMiddleware" />
+    public IList<IMiddleware> Middlewares { get; }
 
     /// <summary>
     /// Creates a new instance of the Configuration object, updated to use the specified transport strategy.
@@ -29,4 +33,17 @@ public interface ITopicConfiguration
     /// <param name="clientTimeout">The amount of time to wait before cancelling the request.</param>
     /// <returns>TopicConfiguration object with client timeout provided</returns>
     public ITopicConfiguration WithClientTimeout(TimeSpan clientTimeout);
+    /// <summary>
+    /// Creates a new instance of the Configuration object, updated to use the specified middlewares.
+    /// </summary>
+    /// <param name="middlewares">The Middleware interface allows the TopicConfiguration to provide a higher-order function that wraps all requests.</param>
+    /// <returns>TopicConfiguration object with custom middlewares provided</returns>
+    public ITopicConfiguration WithMiddlewares(IList<IMiddleware> middlewares);
+
+    /// <summary>
+    /// Add the specified middlewares to an existing instance of Configuration object in addition to already specified middlewares.
+    /// </summary>
+    /// <param name="additionalMiddlewares">The Middleware interface allows the TopicConfiguration to provide a higher-order function that wraps all requests.</param>
+    /// <returns>TopicConfiguration object with custom middlewares provided</returns>
+    public TopicConfiguration WithAdditionalMiddlewares(IList<IMiddleware> additionalMiddlewares);
 }

--- a/src/Momento.Sdk/Config/Middleware/ExperimentalMetricsMiddleware.cs
+++ b/src/Momento.Sdk/Config/Middleware/ExperimentalMetricsMiddleware.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Grpc.Core;
@@ -136,5 +137,10 @@ namespace Momento.Sdk.Config.Middleware
             return nextState;
         }
 
+        /// <inheritdoc/>
+        public IList<Tuple<string, string>> AddStreamRequestHeaders()
+        {
+            return new List<Tuple<string, string>>();
+        }
     }
 }

--- a/src/Momento.Sdk/Config/Middleware/IMiddleware.cs
+++ b/src/Momento.Sdk/Config/Middleware/IMiddleware.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Grpc.Core;
 using Grpc.Core.Interceptors;
@@ -37,6 +39,11 @@ public record struct MiddlewareResponseState<TResponse>(
 public interface IMiddleware
 {
     /// <summary>
+    /// Add headers to gRPC stream requests since middlewares are incompatible with gRPC streams.
+    /// </summary>
+    public IList<Tuple<string, string>> AddStreamRequestHeaders();
+
+    /// <summary>
     /// Called as a wrapper around each request; can be used to time the request and collect metrics etc.
     /// </summary>
     /// <typeparam name="TRequest"></typeparam>
@@ -51,5 +58,4 @@ public interface IMiddleware
         CallOptions callOptions,
         Func<TRequest, CallOptions, Task<MiddlewareResponseState<TResponse>>> continuation
     ) where TRequest : class where TResponse : class;
-
 }

--- a/src/Momento.Sdk/Config/Middleware/LoggingMiddleware.cs
+++ b/src/Momento.Sdk/Config/Middleware/LoggingMiddleware.cs
@@ -3,6 +3,7 @@ using Grpc.Core;
 using System.Threading.Tasks;
 using Grpc.Core.Interceptors;
 using Microsoft.Extensions.Logging;
+using System.Collections.Generic;
 
 namespace Momento.Sdk.Config.Middleware
 {
@@ -21,6 +22,12 @@ namespace Momento.Sdk.Config.Middleware
         public LoggingMiddleware(ILoggerFactory loggerFactory)
         {
             _logger = loggerFactory.CreateLogger<LoggingMiddleware>();
+        }
+
+        /// <inheritdoc/>
+        public IList<Tuple<string, string>> AddStreamRequestHeaders()
+        {
+            return new List<Tuple<string, string>>();
         }
 
         /// <inheritdoc/>

--- a/src/Momento.Sdk/Config/Middleware/PassThroughMiddleware.cs
+++ b/src/Momento.Sdk/Config/Middleware/PassThroughMiddleware.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Grpc.Core;
 using Grpc.Core.Interceptors;
@@ -35,4 +36,9 @@ public class PassThroughMiddleware : IMiddleware
         return continuation(request, callOptions);
     }
 
+    /// <inheritdoc/>
+    public IList<Tuple<string, string>> AddStreamRequestHeaders()
+    {
+        return new List<Tuple<string, string>>();
+    }
 }

--- a/src/Momento.Sdk/Config/TopicConfiguration.cs
+++ b/src/Momento.Sdk/Config/TopicConfiguration.cs
@@ -1,5 +1,8 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using Microsoft.Extensions.Logging;
+using Momento.Sdk.Config.Middleware;
 using Momento.Sdk.Config.Transport;
 
 namespace Momento.Sdk.Config;
@@ -12,22 +15,36 @@ public class TopicConfiguration : ITopicConfiguration
 
     /// <inheritdoc />
     public ITopicTransportStrategy TransportStrategy { get; }
+    /// <inheritdoc />
+    public IList<IMiddleware> Middlewares { get; }
+    /// <inheritdoc />
+    public IList<Tuple<string, string>> SubscribeHeaders { get; }
 
     /// <summary>
-    /// Create a new instance of a Topic Configuration object with provided arguments: <see cref="Momento.Sdk.Config.ITopicConfiguration.TransportStrategy"/>, and <see cref="Momento.Sdk.Config.ITopicConfiguration.LoggerFactory"/>
+    /// Create a new instance of a Topic Configuration object with provided arguments: <see cref="Momento.Sdk.Config.ITopicConfiguration.TransportStrategy"/>, <see cref="Momento.Sdk.Config.ITopicConfiguration.LoggerFactory"/>, and <see cref="Momento.Sdk.Config.ITopicConfiguration.Middlewares"/>
     /// </summary>
     /// <param name="transportStrategy">This is responsible for configuring network tunables.</param>
     /// <param name="loggerFactory">This is responsible for configuring logging.</param>
-    public TopicConfiguration(ILoggerFactory loggerFactory, ITopicTransportStrategy transportStrategy)
+    /// <param name="middlewares">The Middleware interface allows the TopicConfiguration to provide a higher-order function that wraps all requests.</param>
+    /// <param name="headers">The key-value pairs to add to the request headers.</param>
+    /// <returns>TopicConfiguration object with custom transport strategy, logger factory, and middlewares provided</returns>
+    public TopicConfiguration(ILoggerFactory loggerFactory, ITopicTransportStrategy transportStrategy, IList<IMiddleware> middlewares, IList<Tuple<string, string>> headers)
     {
         LoggerFactory = loggerFactory;
         TransportStrategy = transportStrategy;
+        Middlewares = middlewares;
+        SubscribeHeaders = headers;
+    }
+
+    /// <inheritdoc cref="Momento.Sdk.Config.IConfiguration" />
+    public TopicConfiguration(ILoggerFactory loggerFactory, ITopicTransportStrategy transportStrategy): this(loggerFactory, transportStrategy, new List<IMiddleware>(), new List<Tuple<string, string>>())
+    {
     }
 
     /// <inheritdoc />
     public ITopicConfiguration WithTransportStrategy(ITopicTransportStrategy transportStrategy)
     {
-        return new TopicConfiguration(LoggerFactory, transportStrategy);
+        return new TopicConfiguration(LoggerFactory, transportStrategy, Middlewares, SubscribeHeaders);
     }
 
     /// <inheritdoc/>
@@ -35,8 +52,22 @@ public class TopicConfiguration : ITopicConfiguration
     {
         return new TopicConfiguration(
             loggerFactory: LoggerFactory,
-            transportStrategy: TransportStrategy.WithClientTimeout(clientTimeout)
+            transportStrategy: TransportStrategy.WithClientTimeout(clientTimeout),
+            middlewares: Middlewares,
+            headers: SubscribeHeaders
         );
+    }
+
+    /// <inheritdoc />
+    public ITopicConfiguration WithMiddlewares(IList<IMiddleware> middlewares)
+    {
+        return new TopicConfiguration(LoggerFactory, TransportStrategy, middlewares, SubscribeHeaders);
+    }
+
+    /// <inheritdoc />
+    public TopicConfiguration WithAdditionalMiddlewares(IList<IMiddleware> additionalMiddlewares)
+    {
+        return new TopicConfiguration(LoggerFactory, TransportStrategy, Middlewares.Concat(additionalMiddlewares).ToList(), SubscribeHeaders);
     }
 
     /// <inheritdoc />

--- a/src/Momento.Sdk/Internal/Middleware/HeaderMiddleware.cs
+++ b/src/Momento.Sdk/Internal/Middleware/HeaderMiddleware.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Grpc.Core;
@@ -91,6 +92,12 @@ namespace Momento.Sdk.Internal.Middleware
                 GetStatus: nextState.GetStatus,
                 GetTrailers: nextState.GetTrailers
             );
+        }
+
+        /// <inheritdoc/>
+        public IList<Tuple<string, string>> AddStreamRequestHeaders()
+        {
+            return _headers.Select(header => new Tuple<string, string>(header.Name, header.Value)).ToList();
         }
 
         public override bool Equals(object obj)

--- a/src/Momento.Sdk/Internal/Middleware/MaxConcurrentRequestsMiddleware.cs
+++ b/src/Momento.Sdk/Internal/Middleware/MaxConcurrentRequestsMiddleware.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
 using System.Threading.Tasks;
@@ -88,6 +89,12 @@ namespace Momento.Sdk.Internal.Middleware
         public override int GetHashCode()
         {
             return base.GetHashCode();
+        }
+
+        /// <inheritdoc/>
+        public IList<Tuple<string, string>> AddStreamRequestHeaders()
+        {
+            return new List<Tuple<string, string>>();
         }
     }
 }

--- a/src/Momento.Sdk/Internal/Middleware/RetryMiddleware.cs
+++ b/src/Momento.Sdk/Internal/Middleware/RetryMiddleware.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Grpc.Core;
 using Microsoft.Extensions.Logging;
@@ -103,6 +104,12 @@ namespace Momento.Sdk.Config.Retry
         public override int GetHashCode()
         {
             return base.GetHashCode();
+        }
+
+        /// <inheritdoc/>
+        public IList<Tuple<string, string>> AddStreamRequestHeaders()
+        {
+            return new List<Tuple<string, string>>();
         }
     }
 }

--- a/tests/Integration/Momento.Sdk.Tests/Retry/MomentoLocalMiddlewareTest.cs
+++ b/tests/Integration/Momento.Sdk.Tests/Retry/MomentoLocalMiddlewareTest.cs
@@ -128,7 +128,10 @@ public class MomentoLocalMiddlewareTests
             ReturnError = MomentoErrorCode.INTERNAL_SERVER_ERROR.ToStringValue(),
             ErrorRpcList = new List<string> { MomentoRpcMethod.Get.ToMomentoLocalMetadataString() },
             ErrorCount = 1,
-            DelayRpcList = new List<string> { MomentoRpcMethod.Set.ToMomentoLocalMetadataString() },
+            DelayRpcList = new List<string> { 
+                MomentoRpcMethod.Set.ToMomentoLocalMetadataString(), 
+                MomentoRpcMethod.Get.ToMomentoLocalMetadataString() 
+            },
             DelayMillis = 100,
             DelayCount = 1,
             StreamErrorRpcList = new List<string> { MomentoRpcMethod.TopicSubscribe.ToMomentoLocalMetadataString() },
@@ -156,7 +159,7 @@ public class MomentoLocalMiddlewareTests
         Assert.Equal(MomentoErrorCode.INTERNAL_SERVER_ERROR.ToStringValue(), trailers.Get("return-error")?.Value);
         Assert.Equal(args.ErrorRpcList[0], trailers.Get("error-rpcs")?.Value);
         Assert.Equal("1", trailers.Get("error-count")?.Value);
-        Assert.Equal(args.DelayRpcList[0], trailers.Get("delay-rpcs")?.Value);
+        Assert.Equal(args.DelayRpcList[0] + " " + args.DelayRpcList[1], trailers.Get("delay-rpcs")?.Value);
         Assert.Equal("100", trailers.Get("delay-ms")?.Value);
         Assert.Equal("1", trailers.Get("delay-count")?.Value);
         Assert.Equal(args.StreamErrorRpcList[0], trailers.Get("stream-error-rpcs")?.Value);

--- a/tests/Integration/Momento.Sdk.Tests/Retry/TopicClientRetryTest.cs
+++ b/tests/Integration/Momento.Sdk.Tests/Retry/TopicClientRetryTest.cs
@@ -1,0 +1,311 @@
+using System.Collections.Generic;
+using Microsoft.Extensions.Logging;
+using Momento.Sdk.Auth;
+using Momento.Sdk.Config;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Net.Http;
+using System.IO;
+
+namespace Momento.Sdk.Tests.Integration.Retry;
+
+public class TestAdminClient
+{
+    private readonly string _endpoint;
+    private readonly HttpClient _httpClient;
+
+    public TestAdminClient()
+    {
+        var hostname = Environment.GetEnvironmentVariable("TEST_ADMIN_HOSTNAME") ?? "127.0.0.1";
+        var port = Environment.GetEnvironmentVariable("TEST_ADMIN_PORT") ?? "9090";
+        _endpoint = $"http://{hostname}:{port}";
+        _httpClient = new HttpClient
+        {
+            Timeout = TimeSpan.FromSeconds(5)
+        };
+    }
+
+    public async Task BlockPort()
+    {
+        try
+        {
+            Console.WriteLine($"Attempting to block port at {_endpoint}/block");
+            var response = await _httpClient.GetAsync($"{_endpoint}/block");
+            response.EnsureSuccessStatusCode();
+            Console.WriteLine("Port blocked successfully");
+        }
+        catch (HttpRequestException ex)
+        {
+            Console.WriteLine($"Failed to block port: {ex.Message}");
+            throw;
+        }
+    }
+
+    public async Task UnblockPort()
+    {
+        try
+        {
+            Console.WriteLine($"Attempting to unblock port at {_endpoint}/unblock");
+            var response = await _httpClient.GetAsync($"{_endpoint}/unblock");
+            response.EnsureSuccessStatusCode();
+            Console.WriteLine("Port unblocked successfully");
+        }
+        catch (HttpRequestException ex)
+        {
+            Console.WriteLine($"Failed to unblock port: {ex.Message}");
+            throw;
+        }
+    }
+}
+
+public class HeartbeatTimestampCollector
+{
+    private readonly List<DateTime> _timestamps;
+    private readonly TimeSpan _timeout;
+
+    public HeartbeatTimestampCollector(TimeSpan timeout)
+    {
+        _timestamps = new();
+        _timeout = timeout;
+    }
+
+    public void AddTimestamp(DateTime timestamp)
+    {
+        _timestamps.Add(timestamp);
+    }
+
+    public int GetCountOfTimestamps()
+    {
+        return _timestamps.Count;
+    }
+
+    public int GetCountOfTimeouts()
+    {
+        // Count number of times timestamps were more than timeout seconds apart
+        var count = 0;
+        for (var i = 0; i < _timestamps.Count - 1; i++)
+        {
+            if (_timestamps[i + 1] - _timestamps[i] > _timeout)
+            {
+                count++;
+            }
+        }
+        return count;
+    }
+}
+
+[Collection("Retry")]
+public class TopicClientRetryTests
+{
+    private readonly ICredentialProvider _authProvider;
+    private readonly ILoggerFactory _loggerFactory;
+    private readonly IConfiguration _cacheConfig;
+    private readonly ITopicConfiguration _topicConfig;
+
+    public TopicClientRetryTests()
+    {
+        _authProvider = new MomentoLocalProvider();
+        _loggerFactory = LoggerFactory.Create(builder =>
+        {
+            builder.AddSimpleConsole(options =>
+            {
+                options.IncludeScopes = true;
+                options.SingleLine = true;
+                options.TimestampFormat = "hh:mm:ss ";
+            });
+            builder.AddFilter("Grpc.Net.Client", LogLevel.Error);
+            builder.SetMinimumLevel(LogLevel.Information);
+        });
+        _cacheConfig = Configurations.Laptop.Latest(_loggerFactory);
+        _topicConfig = TopicConfigurations.Laptop.latest(_loggerFactory);
+    }
+
+    [Fact]
+    public async Task SubscriptionResumesAfterKeepalivesStopThenResume()
+    {
+        var testProps = new MomentoLocalCacheAndTopicClient(_authProvider, _loggerFactory, _cacheConfig, _topicConfig, null);
+        var testAdmin = new TestAdminClient();
+        var heartbeatTimeout = TimeSpan.FromSeconds(3);
+        var heartbeatCounter = new HeartbeatTimestampCollector(heartbeatTimeout);
+        var cts = new CancellationTokenSource();
+        cts.CancelAfter(10_000);
+
+        var subscribeResponse = await testProps.TopicClient.SubscribeAsync(testProps.CacheName, "topic");
+        var subscriptionTask = Task.Run(async () =>
+        {
+            switch (subscribeResponse) 
+            {
+                case TopicSubscribeResponse.Subscription subscription:
+                    try
+                    {
+                        var cancellableSubscription = subscription.WithCancellationForAllEvents(cts.Token);
+                        await foreach (var topicEvent in cancellableSubscription)
+                        {
+                            switch (topicEvent)
+                            {
+                                case TopicSystemEvent.Heartbeat:
+                                    heartbeatCounter.AddTimestamp(DateTime.Now);
+                                    break;
+                                case TopicMessage.Error error:
+                                    Assert.Fail("Received error message from topic: {error.ToString()}");
+                                    break;
+                                default:
+                                    break;
+                            }
+                        }
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        // Expected when the test times out
+                    }
+                    catch (IOException)
+                    {
+                        // Expected when connection is reset
+                    }
+                    finally
+                    {
+                        subscription.Dispose();
+                    }
+                    break;
+                default:
+                    Assert.Fail("Expected subscription response, got error: {subscribeResponse.ToString()}");
+                    cts.Cancel();
+                    break;
+            }
+        });
+        
+        // After 3 seconds, stop the keepalives, wait 3 seconds, then resume them
+        await Task.Delay(3000);
+        await testAdmin.BlockPort();
+        await Task.Delay(heartbeatTimeout);
+        await testAdmin.UnblockPort();
+
+        // Wait for the subscription task to complete
+        await subscriptionTask;
+
+        Assert.InRange(heartbeatCounter.GetCountOfTimestamps(), 5, 10);
+        Assert.Equal(1, heartbeatCounter.GetCountOfTimeouts());
+    }
+
+    [Fact]
+    public async Task SubscriptionReconnectsAfterRecoverableError() 
+    {
+        var momentoLocalArgs = new MomentoLocalMiddlewareArgs {
+            StreamError = MomentoErrorCode.SERVER_UNAVAILABLE.ToStringValue(),
+            StreamErrorRpcList = new List<string> { MomentoRpcMethod.TopicSubscribe.ToMomentoLocalMetadataString() },
+            StreamErrorMessageLimit = 3 // Receive an error after every 2 heartbeats
+        };
+        var testProps = new MomentoLocalCacheAndTopicClient(_authProvider, _loggerFactory, _cacheConfig, _topicConfig, momentoLocalArgs);
+
+        var heartbeatTimeout = TimeSpan.FromSeconds(3);
+        var heartbeatCounter = new HeartbeatTimestampCollector(heartbeatTimeout);
+        
+        var cts = new CancellationTokenSource();
+        cts.CancelAfter(10_000);
+
+        var subscribeResponse = await testProps.TopicClient.SubscribeAsync(testProps.CacheName, "topic");
+        switch (subscribeResponse) 
+        {
+            case TopicSubscribeResponse.Subscription subscription:
+                try
+                {
+                    var cancellableSubscription = subscription.WithCancellationForAllEvents(cts.Token);
+                    await foreach (var topicEvent in cancellableSubscription)
+                    {
+                        switch (topicEvent)
+                        {
+                            case TopicSystemEvent.Heartbeat:
+                                heartbeatCounter.AddTimestamp(DateTime.Now);
+                                break;
+                            case TopicMessage.Error error:
+                                Assert.Fail("Received error message from topic: {error.ToString()}");
+                                break;
+                            default:
+                                break;
+                        }
+                    }
+                }
+                catch (OperationCanceledException)
+                {
+                    // Expected when the test times out
+                }
+                finally
+                {
+                    subscription.Dispose();
+                }
+                break;
+            default:
+                Assert.Fail("Expected subscription response, got error: {subscribeResponse.ToString()}");
+                cts.Cancel();
+                break;
+        }
+        
+        Assert.Equal(1, heartbeatCounter.GetCountOfTimeouts()); // 1 timeout for the resubscribe period
+        Assert.InRange(heartbeatCounter.GetCountOfTimestamps(), 2, 8); // counts heartbeats before and after the resubscribe period
+    }
+
+    [Fact]
+    public async Task SubscriptionDoesNotReconnectAfterUnrecoverableError() 
+    {
+        var momentoLocalArgs = new MomentoLocalMiddlewareArgs {
+            StreamError = MomentoErrorCode.AUTHENTICATION_ERROR.ToStringValue(),
+            StreamErrorRpcList = new List<string> { MomentoRpcMethod.TopicSubscribe.ToMomentoLocalMetadataString() },
+            StreamErrorMessageLimit = 3 // Receive an error after every 2 heartbeats
+        };
+        var testProps = new MomentoLocalCacheAndTopicClient(_authProvider, _loggerFactory, _cacheConfig, _topicConfig, momentoLocalArgs);
+
+        var heartbeatTimeout = TimeSpan.FromSeconds(3);
+        var heartbeatCounter = new HeartbeatTimestampCollector(heartbeatTimeout);
+        
+        var cts = new CancellationTokenSource();
+        cts.CancelAfter(10_000);
+
+        var subscribeResponse = await testProps.TopicClient.SubscribeAsync(testProps.CacheName, "topic");
+        switch (subscribeResponse) 
+        {
+            case TopicSubscribeResponse.Subscription subscription:
+                try
+                {
+                    var cancellableSubscription = subscription.WithCancellationForAllEvents(cts.Token);
+                    await foreach (var topicEvent in cancellableSubscription)
+                    {
+                        switch (topicEvent)
+                        {
+                            case TopicSystemEvent.Heartbeat:
+                                heartbeatCounter.AddTimestamp(DateTime.Now);
+                                break;
+                            case TopicMessage.Error error:
+                                Assert.Equal(MomentoErrorCode.AUTHENTICATION_ERROR, error.ErrorCode);
+                                break;
+                            default:
+                                break;
+                        }
+                    }
+                }
+                catch (OperationCanceledException)
+                {
+                    // Expected when the test times out
+                }
+                finally
+                {
+                    subscription.Dispose();
+                }
+                break;
+            default:
+                Assert.Fail("Expected subscription response, got error: {subscribeResponse.ToString()}");
+                cts.Cancel();
+                break;
+        }
+        
+        Assert.Equal(0, heartbeatCounter.GetCountOfTimeouts()); // After the error, no heartbeats should be received, so no timeout period
+        Assert.InRange(heartbeatCounter.GetCountOfTimestamps(), 1, 3); // Count of heartbeats before the error
+    }
+
+    [Fact]
+    public void PublishDoesNotRetryOnAnyError() 
+    {
+        var testProps = new MomentoLocalCacheAndTopicClient(_authProvider, _loggerFactory, _cacheConfig, _topicConfig, null);
+        testProps.CacheClient.IncrementAsync(testProps.CacheName, "key").Wait();
+        Assert.Equal(0, testProps.TestMetricsCollector.GetTotalRetryCount(testProps.CacheName, MomentoRpcMethod.Increment));
+    }
+}

--- a/tests/Integration/Momento.Sdk.Tests/Retry/utils/MomentoLocalMiddleware.cs
+++ b/tests/Integration/Momento.Sdk.Tests/Retry/utils/MomentoLocalMiddleware.cs
@@ -103,7 +103,12 @@ public class MomentoLocalMiddleware : IMiddleware
         var headers = callOptionsWithHeaders.Headers!;
         foreach (var header in ConvertArgsToHeaders())
         {
-            headers.Add(header);
+            // Check if the header already exists. If it does, we don't want to add it again
+            // as it causes momento-local to not recognize the header.
+            if (headers.GetValue(header.Key) == null)
+            {
+                headers.Add(header);
+            }
         }
 
         // Get the cache name from the metadata that should already exist on the request.

--- a/tests/Integration/Momento.Sdk.Tests/Retry/utils/RetryTestUtils.cs
+++ b/tests/Integration/Momento.Sdk.Tests/Retry/utils/RetryTestUtils.cs
@@ -23,3 +23,22 @@ public class MomentoLocalCacheAndCacheClient
         CacheClient.CreateCacheAsync(CacheName).Wait();
     }
 }
+
+public class MomentoLocalCacheAndTopicClient
+{
+    public ICacheClient CacheClient { get; }
+    public ITopicClient TopicClient { get; }
+    public string CacheName { get; }
+    public TestRetryMetricsCollector TestMetricsCollector { get; }
+
+    public MomentoLocalCacheAndTopicClient(ICredentialProvider authProvider, ILoggerFactory loggerFactory, IConfiguration cacheConfig, ITopicConfiguration topicConfig, MomentoLocalMiddlewareArgs? args)
+    {
+        var middleware = new MomentoLocalMiddleware(loggerFactory, args);
+        TestMetricsCollector = middleware.TestMetricsCollector;
+        CacheClient = new CacheClient(cacheConfig, authProvider, TimeSpan.FromSeconds(60));
+        CacheName = Utils.NewGuidString();
+        CacheClient.CreateCacheAsync(CacheName).Wait();
+        var tConfig = topicConfig.WithAdditionalMiddlewares(new List<IMiddleware>() { middleware });
+        TopicClient = new TopicClient(tConfig, authProvider);
+    }
+}


### PR DESCRIPTION
Closes https://github.com/momentohq/dev-eco-issue-tracker/issues/1189

Adds middleware to the TopicClient config and internals (stream connections provide only an option for adding headers).
Adds topic client retry tests for exercising subscription reconnect logic ([JS reference](https://github.com/momentohq/client-sdk-javascript/blob/main/packages/client-sdk-nodejs/test/integration/retry/topic-client-retry.test.ts)).

Would really appreciate feedback on a couple of points:

1. Topics retry tests: subscriptions don't follow the JS/Java callback approach so there's no usage of semaphores or an `OnConnectionLost()` callback here. Not sure if there's a better way to track subscription events for tests.
2. Not sure if the outlined approach is the most idiomatic. Maybe an IStreamMiddleware interface could split out the stream headers part? But if the current design seems good enough, we can also proceed with what's here.