### PR TITLE
feat: add topic subscribe timeout

### DIFF
--- a/src/Momento.Sdk/Internal/ScsTopicClient.cs
+++ b/src/Momento.Sdk/Internal/ScsTopicClient.cs
@@ -119,7 +119,7 @@ internal sealed class ScsTopicClient : ScsTopicClientBase
         {
             _logger.LogTraceExecutingTopicRequest(RequestTypeTopicSubscribe, cacheName, topicName);
             subscriptionWrapper = new SubscriptionWrapper(grpcManager, cacheName, topicName,
-                resumeAtTopicSequenceNumber, resumeAtTopicSequencePage, _exceptionMapper, _logger);
+                resumeAtTopicSequenceNumber, resumeAtTopicSequencePage, topicClientOperationTimeout, _exceptionMapper, _logger);
             await subscriptionWrapper.Subscribe();
         }
         catch (Exception e)
@@ -147,9 +147,10 @@ internal sealed class ScsTopicClient : ScsTopicClientBase
         private ulong _lastSequenceNumber;
         private ulong _lastSequencePage;
         private bool _subscribed;
+        private TimeSpan _topicClientOperationTimeout;
 
         public SubscriptionWrapper(TopicGrpcManager grpcManager, string cacheName,
-            string topicName, ulong? resumeAtTopicSequenceNumber, ulong? resumeAtTopicSequencePage,
+            string topicName, ulong? resumeAtTopicSequenceNumber, ulong? resumeAtTopicSequencePage, TimeSpan topicClientOperationTimeout,
             CacheExceptionMapper exceptionMapper, ILogger logger)
         {
             _grpcManager = grpcManager;
@@ -157,6 +158,7 @@ internal sealed class ScsTopicClient : ScsTopicClientBase
             _topicName = topicName;
             _lastSequenceNumber = resumeAtTopicSequenceNumber ?? 0;
             _lastSequencePage = resumeAtTopicSequencePage ?? 0;
+            _topicClientOperationTimeout = topicClientOperationTimeout; 
             _exceptionMapper = exceptionMapper;
             _logger = logger;
         }
@@ -173,9 +175,39 @@ internal sealed class ScsTopicClient : ScsTopicClientBase
             request.SequencePage = _lastSequencePage;
 
             _logger.LogTraceExecutingTopicRequest(RequestTypeTopicSubscribe, _cacheName, _topicName);
-            var subscription = _grpcManager.Client.subscribe(request, new CallOptions());
+            
+            // Create a linked token source to support cancellation
+            using var cts = new CancellationTokenSource();
+            var subscription = _grpcManager.Client.subscribe(request, new CallOptions(cancellationToken: cts.Token));
 
-            await subscription.ResponseStream.MoveNext();
+            var moveNextTask = subscription.ResponseStream.MoveNext();
+            var timeoutTask = Task.Delay(_topicClientOperationTimeout, cts.Token);
+            var completedTask = await Task.WhenAny(moveNextTask, timeoutTask);
+
+            if (completedTask == timeoutTask) 
+            {
+                // cancel the stream
+                _logger.LogWarning("Timed out waiting for first message (heartbeat) for topic {Topic} on cache {Cache}", _topicName, _cacheName);
+                cts.Cancel(); 
+                subscription.Dispose();
+
+                throw new Exceptions.TimeoutException(
+                    $"Timed out after {_topicClientOperationTimeout.TotalSeconds} seconds waiting for first message (heartbeat) for topic {_topicName} on cache {_cacheName}",
+                    new MomentoErrorTransportDetails(
+                        new MomentoGrpcErrorDetails(
+                            StatusCode.DeadlineExceeded,
+                            "Timed out waiting for first message (heartbeat)"
+                        )
+                    )
+                );
+            }
+            
+            if (!await moveNextTask)
+            {
+                throw new InternalServerException($"Subscription stream closed unexpectedly for topic {_topicName} on cache {_cacheName}");
+            }
+            
+            
             var firstMessage = subscription.ResponseStream.Current;
             // The first message to a new subscription will always be a heartbeat.
             if (firstMessage.KindCase is not _SubscriptionItem.KindOneofCase.Heartbeat)

--- a/tests/Integration/Momento.Sdk.Tests/Retry/TopicClientRetryTest.cs
+++ b/tests/Integration/Momento.Sdk.Tests/Retry/TopicClientRetryTest.cs
@@ -6,6 +6,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Net.Http;
 using System.IO;
+using Xunit.Abstractions;
+using Xunit.Sdk;
 
 namespace Momento.Sdk.Tests.Integration.Retry;
 
@@ -148,8 +150,6 @@ public class TopicClientRetryTests
                                     break;
                                 case TopicMessage.Error error:
                                     Assert.Fail("Received error message from topic: {error.ToString()}");
-                                    break;
-                                default:
                                     break;
                             }
                         }
@@ -307,5 +307,57 @@ public class TopicClientRetryTests
         var testProps = new MomentoLocalCacheAndTopicClient(_authProvider, _loggerFactory, _cacheConfig, _topicConfig, null);
         testProps.CacheClient.IncrementAsync(testProps.CacheName, "key").Wait();
         Assert.Equal(0, testProps.TestMetricsCollector.GetTotalRetryCount(testProps.CacheName, MomentoRpcMethod.Increment));
+    }
+    
+    [Fact]
+    public async Task TopicSubscribe_ReturnsTimeoutError_IfFirstMessageNotReceivedBeforeDeadline() 
+    {
+        var momentoLocalArgs = new MomentoLocalMiddlewareArgs {
+            DelayRpcList = new List<string> { MomentoRpcMethod.TopicSubscribe.ToMomentoLocalMetadataString() },
+            DelayMillis = 2000 
+        };
+        var testProps = new MomentoLocalCacheAndTopicClient(_authProvider, _loggerFactory, _cacheConfig, _topicConfig.WithClientTimeout(TimeSpan.FromMilliseconds(500)), momentoLocalArgs);
+
+        var cts = new CancellationTokenSource();
+        cts.CancelAfter(10_000);
+        
+        var subscribeResponse = await testProps.TopicClient.SubscribeAsync(testProps.CacheName, "topic");
+        switch (subscribeResponse) 
+        {
+            case TopicSubscribeResponse.Subscription subscription:
+                try
+                {
+                    var cancellableSubscription = subscription.WithCancellationForAllEvents(cts.Token);
+                    await foreach (var topicEvent in cancellableSubscription)
+                    {
+                        switch (topicEvent)
+                        {
+                            case TopicSystemEvent.Heartbeat:
+                                break;
+                            case TopicMessage.Error error:
+                                break;
+                            default:
+                                break;
+                        }
+                    }
+                }
+                catch (OperationCanceledException)
+                {
+                    // Expected when the test times out
+                }
+                finally
+                {
+                    subscription.Dispose();
+                }
+                break;
+            case TopicSubscribeResponse.Error error:
+                Assert.Equal(MomentoErrorCode.TIMEOUT_ERROR, error.ErrorCode);
+                break;
+            default:
+                Assert.Fail("Expected subscription response, got error: {subscribeResponse.ToString()}");
+                cts.Cancel();
+                break;
+        }
+        
     }
 }


### PR DESCRIPTION
## PR Description:
- Enforces deadline on `subscribe`: Sets a deadline for receiving the first message when subscribing to a topic.

## Testing
- Adds a test case that intentionally delays the subscribe response beyond the client timeout to verify that a `DEADLINE_EXCEEDED` error (`TIMEOUT_ERROR`) is correctly returned.

## Issue
https://github.com/momentohq/dev-eco-issue-tracker/issues/1148