### PR TITLE
feat: add ITopicMiddleware and implement it for momento-local topics tests

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -133,7 +133,7 @@ jobs:
 
       - name: Start Momento Local
         run: |
-         docker run --rm -d -p 8080:8080 gomomento/momento-local
+         docker run --cap-add=NET_ADMIN -d --rm -p 8080:8080 -p 9090:9090 gomomento/momento-local --enable-test-admin
 
       - name: Run momento-local retry tests
         run: make test-retry

--- a/src/Momento.Sdk/Config/ITopicConfiguration.cs
+++ b/src/Momento.Sdk/Config/ITopicConfiguration.cs
@@ -16,7 +16,7 @@ public interface ITopicConfiguration
     public ILoggerFactory LoggerFactory { get; }
     /// <inheritdoc cref="Momento.Sdk.Config.Transport.ITransportStrategy" />
     public ITopicTransportStrategy TransportStrategy { get; }
-    /// TODO
+    /// <inheritdoc cref="Momento.Sdk.Config.Middleware.ITopicMiddleware" />
     public IList<ITopicMiddleware> Middlewares { get; }
 
     /// <summary>
@@ -34,9 +34,18 @@ public interface ITopicConfiguration
     /// <returns>TopicConfiguration object with client timeout provided</returns>
     public ITopicConfiguration WithClientTimeout(TimeSpan clientTimeout);
 
-    /// TODO
-    public ITopicConfiguration WithMiddlewares(IList<ITopicMiddleware> middleware);
+    /// <summary>
+    /// Replace the middlewares on an existing instance of TopicConfiguration object with
+    /// the provided middlewares.
+    /// </summary>
+    /// <param name="middlewares">The list of middlewares to be used.</param>
+    public ITopicConfiguration WithMiddlewares(IList<ITopicMiddleware> middlewares);
 
-    /// TODO
+    /// <summary>
+    /// Add the specified middleware to an existing instance of TopicConfiguration object as an addition to
+    /// the existing middlewares.
+    /// </summary>
+    /// <param name="middleware">The middleware to be used.</param>
+    /// <returns>TopicConfiguration object with middleware provided</returns>
     public ITopicConfiguration AddMiddleware(ITopicMiddleware middleware);
 }

--- a/src/Momento.Sdk/Config/ITopicConfiguration.cs
+++ b/src/Momento.Sdk/Config/ITopicConfiguration.cs
@@ -39,7 +39,7 @@ public interface ITopicConfiguration
     /// the provided middlewares.
     /// </summary>
     /// <param name="middlewares">The list of middlewares to be used.</param>
-    public ITopicConfiguration WithMiddlewares(IList<ITopicMiddleware> middlewares);
+    public ITopicConfiguration WithMiddlewares(IEnumerable<ITopicMiddleware> middlewares);
 
     /// <summary>
     /// Add the specified middleware to an existing instance of TopicConfiguration object as an addition to

--- a/src/Momento.Sdk/Config/ITopicConfiguration.cs
+++ b/src/Momento.Sdk/Config/ITopicConfiguration.cs
@@ -1,6 +1,8 @@
 using Microsoft.Extensions.Logging;
+using Momento.Sdk.Config.Middleware;
 using Momento.Sdk.Config.Transport;
 using System;
+using System.Collections.Generic;
 
 namespace Momento.Sdk.Config;
 
@@ -14,6 +16,8 @@ public interface ITopicConfiguration
     public ILoggerFactory LoggerFactory { get; }
     /// <inheritdoc cref="Momento.Sdk.Config.Transport.ITransportStrategy" />
     public ITopicTransportStrategy TransportStrategy { get; }
+    /// TODO
+    public IList<ITopicMiddleware> Middlewares { get; }
 
     /// <summary>
     /// Creates a new instance of the Configuration object, updated to use the specified transport strategy.
@@ -29,4 +33,10 @@ public interface ITopicConfiguration
     /// <param name="clientTimeout">The amount of time to wait before cancelling the request.</param>
     /// <returns>TopicConfiguration object with client timeout provided</returns>
     public ITopicConfiguration WithClientTimeout(TimeSpan clientTimeout);
+
+    /// TODO
+    public ITopicConfiguration WithMiddlewares(IList<ITopicMiddleware> middleware);
+
+    /// TODO
+    public ITopicConfiguration AddMiddleware(ITopicMiddleware middleware);
 }

--- a/src/Momento.Sdk/Config/Middleware/ITopicMiddleware.cs
+++ b/src/Momento.Sdk/Config/Middleware/ITopicMiddleware.cs
@@ -4,24 +4,24 @@ using System.Collections.Generic;
 namespace Momento.Sdk.Config.Middleware;
 
 /// <summary>
-/// TODO
+/// Interface for TopicClient middleware.
 /// </summary>
 public interface ITopicMiddleware
 {
     /// <summary>
-    /// TODO
+    /// Add arbitrary headers to each request.
     /// </summary>
     /// <returns></returns>
     public IList<Tuple<string, string>> WithHeaders();
 
     /// <summary>
-    /// TODO
+    /// Take action when a subscription stream is disconnected.
     /// </summary>
     /// <returns></returns>
     public void OnStreamDisconnected();
 
     /// <summary>
-    /// TODO
+    /// Take action when a subscription stream is (re)established.
     /// </summary>
     /// <returns></returns>
     public void onStreamEstablished();

--- a/src/Momento.Sdk/Config/Middleware/ITopicMiddleware.cs
+++ b/src/Momento.Sdk/Config/Middleware/ITopicMiddleware.cs
@@ -9,10 +9,10 @@ namespace Momento.Sdk.Config.Middleware;
 public interface ITopicMiddleware
 {
     /// <summary>
-    /// Add arbitrary headers to each request.
+    /// Arbitrary headers to each request.
     /// </summary>
     /// <returns></returns>
-    public IList<Tuple<string, string>> WithHeaders();
+    public IEnumerable<KeyValuePair<string, string>> Headers { get; }
 
     /// <summary>
     /// Take action when a subscription stream is disconnected.

--- a/src/Momento.Sdk/Config/Middleware/ITopicMiddleware.cs
+++ b/src/Momento.Sdk/Config/Middleware/ITopicMiddleware.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Collections.Generic;
+
+namespace Momento.Sdk.Config.Middleware;
+
+/// <summary>
+/// TODO
+/// </summary>
+public interface ITopicMiddleware
+{
+    /// <summary>
+    /// TODO
+    /// </summary>
+    /// <returns></returns>
+    public IList<Tuple<string, string>> WithHeaders();
+
+    /// <summary>
+    /// TODO
+    /// </summary>
+    /// <returns></returns>
+    public void OnStreamDisconnected();
+
+    /// <summary>
+    /// TODO
+    /// </summary>
+    /// <returns></returns>
+    public void onStreamEstablished();
+}

--- a/src/Momento.Sdk/Config/TopicConfiguration.cs
+++ b/src/Momento.Sdk/Config/TopicConfiguration.cs
@@ -3,6 +3,7 @@ using Momento.Sdk.Config.Middleware;
 using Momento.Sdk.Config.Transport;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Momento.Sdk.Config;
 
@@ -53,12 +54,12 @@ public class TopicConfiguration : ITopicConfiguration
     /// </summary>
     /// <param name="middlewares"></param>
     /// <returns></returns>
-    public ITopicConfiguration WithMiddlewares(IList<ITopicMiddleware> middlewares)
+    public ITopicConfiguration WithMiddlewares(IEnumerable<ITopicMiddleware> middlewares)
     {
         return new TopicConfiguration(
             loggerFactory: LoggerFactory,
             transportStrategy: TransportStrategy,
-            middlewares: middlewares
+            middlewares: middlewares.ToList()
         );
     }
 
@@ -69,11 +70,12 @@ public class TopicConfiguration : ITopicConfiguration
     /// <returns></returns>
     public ITopicConfiguration AddMiddleware(ITopicMiddleware middleware)
     {
-        Middlewares.Add(middleware);
+        var newMiddlewares = new List<ITopicMiddleware>(Middlewares);
+        newMiddlewares.Add(middleware);
         return new TopicConfiguration(
             loggerFactory: LoggerFactory,
             transportStrategy: TransportStrategy,
-            middlewares: Middlewares
+            middlewares: newMiddlewares
         );
     }
 

--- a/src/Momento.Sdk/Internal/AuthGrpcManager.cs
+++ b/src/Momento.Sdk/Internal/AuthGrpcManager.cs
@@ -29,9 +29,9 @@ internal class AuthClientWithMiddleware : IAuthClient
 {
     private readonly IList<IMiddleware> _middlewares;
     private readonly Token.TokenClient _generatedClient;
-    private readonly IList<Tuple<string, string>> _headers;
+    private readonly IList<KeyValuePair<string, string>> _headers;
 
-    public AuthClientWithMiddleware(Token.TokenClient generatedClient, IList<IMiddleware> middlewares, IList<Tuple<string, string>> headers)
+    public AuthClientWithMiddleware(Token.TokenClient generatedClient, IList<IMiddleware> middlewares, IList<KeyValuePair<string, string>> headers)
     {
         _generatedClient = generatedClient;
         _middlewares = middlewares;

--- a/src/Momento.Sdk/Internal/GrpcManager.cs
+++ b/src/Momento.Sdk/Internal/GrpcManager.cs
@@ -39,7 +39,7 @@ public class GrpcManager : IDisposable
 
     internal List<Header> headers;
 
-    internal List<Tuple<string, string>> headerTuples;
+    internal List<KeyValuePair<string, string>> headerTuples;
 
     protected CallInvoker invoker;
 
@@ -55,13 +55,13 @@ public class GrpcManager : IDisposable
     {
         this._logger = loggerFactory.CreateLogger(loggerName);
 
-        this.headerTuples = new List<Tuple<string, string>>
+        this.headerTuples = new List<KeyValuePair<string, string>>
         {
             new(Header.AuthorizationKey, authProvider.AuthToken),
             new(Header.AgentKey, version),
             new(Header.RuntimeVersionKey, runtimeVersion)
         };
-        this.headers = headerTuples.Select(tuple => new Header(name: tuple.Item1, value: tuple.Item2)).ToList();
+        this.headers = headerTuples.Select(tuple => new Header(name: tuple.Key, value: tuple.Value)).ToList();
 
         // Set all channel opens and create the grpc connection
         var channelOptions = grpcConfig.GrpcChannelOptions;

--- a/tests/Integration/Momento.Sdk.Tests/Retry/TopicClientRetryTest.cs
+++ b/tests/Integration/Momento.Sdk.Tests/Retry/TopicClientRetryTest.cs
@@ -1,336 +1,336 @@
-using System.Collections.Generic;
 using Microsoft.Extensions.Logging;
 using Momento.Sdk.Auth;
 using Momento.Sdk.Config;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Net.Http;
-using System.IO;
 
 namespace Momento.Sdk.Tests.Integration.Retry;
 
 public class TestAdminClient
 {
-  private readonly string _endpoint;
-  private readonly HttpClient _httpClient;
+    private readonly string _endpoint;
+    private readonly HttpClient _httpClient;
 
-  public TestAdminClient()
-  {
-    var hostname = Environment.GetEnvironmentVariable("TEST_ADMIN_HOSTNAME") ?? "127.0.0.1";
-    var port = Environment.GetEnvironmentVariable("TEST_ADMIN_PORT") ?? "9090";
-    _endpoint = $"http://{hostname}:{port}";
-    _httpClient = new HttpClient
+    public TestAdminClient()
     {
-      Timeout = TimeSpan.FromSeconds(5)
-    };
-  }
+        var hostname = Environment.GetEnvironmentVariable("TEST_ADMIN_HOSTNAME") ?? "127.0.0.1";
+        var port = Environment.GetEnvironmentVariable("TEST_ADMIN_PORT") ?? "9090";
+        _endpoint = $"http://{hostname}:{port}";
+        _httpClient = new HttpClient
+        {
+            Timeout = TimeSpan.FromSeconds(5)
+        };
+    }
 
-  public async Task BlockPort()
-  {
-    try
+    public async Task BlockPort()
     {
-      Console.WriteLine($"Attempting to block port at {_endpoint}/block");
-      var response = await _httpClient.GetAsync($"{_endpoint}/block");
-      response.EnsureSuccessStatusCode();
-      Console.WriteLine("Port blocked successfully");
+        try
+        {
+            Console.WriteLine($"Attempting to block port at {_endpoint}/block");
+            var response = await _httpClient.GetAsync($"{_endpoint}/block");
+            response.EnsureSuccessStatusCode();
+            Console.WriteLine("Port blocked successfully");
+        }
+        catch (HttpRequestException ex)
+        {
+            Console.WriteLine($"Failed to block port: {ex.Message}");
+            throw;
+        }
     }
-    catch (HttpRequestException ex)
-    {
-      Console.WriteLine($"Failed to block port: {ex.Message}");
-      throw;
-    }
-  }
 
-  public async Task UnblockPort()
-  {
-    try
+    public async Task UnblockPort()
     {
-      Console.WriteLine($"Attempting to unblock port at {_endpoint}/unblock");
-      var response = await _httpClient.GetAsync($"{_endpoint}/unblock");
-      response.EnsureSuccessStatusCode();
-      Console.WriteLine("Port unblocked successfully");
+        try
+        {
+            Console.WriteLine($"Attempting to unblock port at {_endpoint}/unblock");
+            var response = await _httpClient.GetAsync($"{_endpoint}/unblock");
+            response.EnsureSuccessStatusCode();
+            Console.WriteLine("Port unblocked successfully");
+        }
+        catch (HttpRequestException ex)
+        {
+            Console.WriteLine($"Failed to unblock port: {ex.Message}");
+            throw;
+        }
     }
-    catch (HttpRequestException ex)
-    {
-      Console.WriteLine($"Failed to unblock port: {ex.Message}");
-      throw;
-    }
-  }
 }
 
 public class HeartbeatTimestampCollector
 {
-  private readonly List<DateTime> _timestamps;
-  private readonly TimeSpan _timeout;
+    private readonly List<DateTime> _timestamps;
+    private readonly TimeSpan _timeout;
 
-  public HeartbeatTimestampCollector(TimeSpan timeout)
-  {
-    _timestamps = new();
-    _timeout = timeout;
-  }
-
-  public void AddTimestamp(DateTime timestamp)
-  {
-    _timestamps.Add(timestamp);
-  }
-
-  public int GetCountOfTimestamps()
-  {
-    return _timestamps.Count;
-  }
-
-  public int GetCountOfTimeouts()
-  {
-    // Count number of times timestamps were more than timeout seconds apart
-    var count = 0;
-    for (var i = 0; i < _timestamps.Count - 1; i++)
+    public HeartbeatTimestampCollector(TimeSpan timeout)
     {
-      if (_timestamps[i + 1] - _timestamps[i] > _timeout)
-      {
-        count++;
-      }
+        _timestamps = new();
+        _timeout = timeout;
     }
-    return count;
-  }
+
+    public void AddTimestamp(DateTime timestamp)
+    {
+        _timestamps.Add(timestamp);
+    }
+
+    public int GetCountOfTimestamps()
+    {
+        return _timestamps.Count;
+    }
+
+    public int GetCountOfTimeouts()
+    {
+        // Count number of times timestamps were more than timeout seconds apart
+        var count = 0;
+        for (var i = 0; i < _timestamps.Count - 1; i++)
+        {
+            if (_timestamps[i + 1] - _timestamps[i] > _timeout)
+            {
+                count++;
+            }
+        }
+        return count;
+    }
 }
 
 [Collection("Retry")]
 public class TopicClientRetryTests
 {
-  private readonly ICredentialProvider _authProvider;
-  private readonly ILoggerFactory _loggerFactory;
-  private readonly IConfiguration _cacheConfig;
-  private readonly ITopicConfiguration _topicConfig;
+    private readonly ICredentialProvider _authProvider;
+    private readonly ILoggerFactory _loggerFactory;
+    private readonly IConfiguration _cacheConfig;
+    private readonly ITopicConfiguration _topicConfig;
 
-  public TopicClientRetryTests()
-  {
-    _authProvider = new MomentoLocalProvider();
-    _loggerFactory = LoggerFactory.Create(builder =>
+    public TopicClientRetryTests()
     {
-      builder.AddSimpleConsole(options =>
-          {
-            options.IncludeScopes = true;
-            options.SingleLine = true;
-            options.TimestampFormat = "hh:mm:ss ";
-          });
-      builder.AddFilter("Grpc.Net.Client", LogLevel.Error);
-      builder.SetMinimumLevel(LogLevel.Information);
-    });
-    _cacheConfig = Configurations.Laptop.Latest(_loggerFactory);
-    _topicConfig = TopicConfigurations.Laptop.latest(_loggerFactory);
-  }
-
-  [Fact]
-  public async Task SubscriptionResumesAfterKeepalivesStopThenResume()
-  {
-    // SocketsHttpHandlerOptions sets default keepalive ping timeout to 1 second
-    // and keepalive ping delay to 5 seconds, so we should block keepalives for 
-    // at least that amount of time to make sure keepalives are stopped.
-    // And make sure to let the subscription be active for some time after the
-    // timeout period to allow confirmation of heartbeats and keepalives.
-
-    var testProps = new MomentoLocalCacheAndTopicClient(_authProvider, _loggerFactory, _cacheConfig, _topicConfig, null);
-    var testAdmin = new TestAdminClient();
-    var heartbeatTimeoutSeconds = 8;
-    var heartbeatTimeout = TimeSpan.FromSeconds(heartbeatTimeoutSeconds);
-    var heartbeatCounter = new HeartbeatTimestampCollector(heartbeatTimeout);
-    var cts = new CancellationTokenSource();
-    cts.CancelAfter(20_000);
-
-    var subscribeResponse = await testProps.TopicClient.SubscribeAsync(testProps.CacheName, "topic");
-    var subscriptionTask = Task.Run(async () =>
-    {
-      switch (subscribeResponse)
-      {
-        case TopicSubscribeResponse.Subscription subscription:
-          try
-          {
-            var cancellableSubscription = subscription.WithCancellationForAllEvents(cts.Token);
-            await foreach (var topicEvent in cancellableSubscription)
+        _authProvider = new MomentoLocalProvider();
+        _loggerFactory = LoggerFactory.Create(builder =>
+        {
+            builder.AddSimpleConsole(options =>
             {
-              switch (topicEvent)
-              {
-                case TopicSystemEvent.Heartbeat:
-                  heartbeatCounter.AddTimestamp(DateTime.Now);
-                  break;
-                case TopicMessage.Error error:
-                  Assert.Fail("Received error message from topic: {error.ToString()}");
-                  break;
+                  options.IncludeScopes = true;
+                  options.SingleLine = true;
+                  options.TimestampFormat = "hh:mm:ss ";
+              });
+            builder.AddFilter("Grpc.Net.Client", LogLevel.Error);
+            builder.SetMinimumLevel(LogLevel.Information);
+        });
+        _cacheConfig = Configurations.Laptop.Latest(_loggerFactory);
+        _topicConfig = TopicConfigurations.Laptop.latest(_loggerFactory);
+    }
+
+    [Fact]
+    public async Task SubscriptionResumesAfterKeepalivesStopThenResume()
+    {
+        // SocketsHttpHandlerOptions sets default keepalive ping timeout to 1 second
+        // and keepalive ping delay to 5 seconds, so we should block keepalives for 
+        // at least that amount of time to make sure keepalives are stopped.
+        // And make sure to let the subscription be active for some time after the
+        // timeout period to allow confirmation of heartbeats and keepalives.
+
+        var testProps = new MomentoLocalCacheAndTopicClient(_authProvider, _loggerFactory, _cacheConfig, _topicConfig, null);
+        var testAdmin = new TestAdminClient();
+        var heartbeatTimeoutSeconds = 8;
+        var heartbeatTimeout = TimeSpan.FromSeconds(heartbeatTimeoutSeconds);
+        var heartbeatCounter = new HeartbeatTimestampCollector(heartbeatTimeout);
+        var cts = new CancellationTokenSource();
+        cts.CancelAfter(20_000);
+
+        var subscribeResponse = await testProps.TopicClient.SubscribeAsync(testProps.CacheName, "topic");
+        var subscriptionTask = Task.Run(async () =>
+        {
+            switch (subscribeResponse)
+            {
+                case TopicSubscribeResponse.Subscription subscription:
+                    try
+                    {
+                        var cancellableSubscription = subscription.WithCancellationForAllEvents(cts.Token);
+                        await foreach (var topicEvent in cancellableSubscription)
+                        {
+                            switch (topicEvent)
+                            {
+                                case TopicSystemEvent.Heartbeat:
+                                    heartbeatCounter.AddTimestamp(DateTime.Now);
+                                    break;
+                                case TopicMessage.Error error:
+                                    Assert.Fail("Received error message from topic: {error.ToString()}");
+                                    break;
+                                default:
+                                    break;
+                            }
+                        }
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        // Expected when the test times out
+                    }
+                    catch (IOException)
+                    {
+                        // Expected when connection is reset
+                    }
+                    finally
+                    {
+                        subscription.Dispose();
+                    }
+                    break;
                 default:
-                  break;
-              }
+                    Assert.Fail("Expected subscription response, got error: " + subscribeResponse.ToString());
+                    cts.Cancel();
+                    break;
             }
-          }
-          catch (OperationCanceledException)
-          {
-            // Expected when the test times out
-          }
-          catch (IOException)
-          {
-            // Expected when connection is reset
-          }
-          finally
-          {
-            subscription.Dispose();
-          }
-          break;
-        default:
-          Assert.Fail("Expected subscription response, got error: " + subscribeResponse.ToString());
-          cts.Cancel();
-          break;
-      }
-    });
+        });
 
-    // After 3 seconds, stop the keepalives, wait for the timeout period, then resume keepalives
-    await Task.Delay(3000);
-    await testAdmin.BlockPort();
-    await Task.Delay(heartbeatTimeout);
-    await testAdmin.UnblockPort();
+        // After 3 seconds, stop the keepalives, wait for the timeout period, then resume keepalives
+        await Task.Delay(3000);
+        await testAdmin.BlockPort();
+        await Task.Delay(heartbeatTimeout);
+        await testAdmin.UnblockPort();
 
-    // Wait for the subscription task to complete
-    await subscriptionTask;
+        // Wait for the subscription task to complete
+        await subscriptionTask;
 
-    Assert.InRange(heartbeatCounter.GetCountOfTimestamps(), heartbeatTimeoutSeconds / 2, heartbeatTimeoutSeconds);
-    Assert.Equal(1, heartbeatCounter.GetCountOfTimeouts());
-    Assert.True(testProps.Middleware.StreamDisconnectedCounter >= 1);
-    Assert.True(testProps.Middleware.StreamEstablishedCounter >= 2);
-  }
-
-  [Fact]
-  public async Task SubscriptionReconnectsAfterRecoverableError()
-  {
-    var momentoLocalArgs = new MomentoLocalMiddlewareArgs
-    {
-      StreamError = MomentoErrorCode.SERVER_UNAVAILABLE.ToStringValue(),
-      StreamErrorRpcList = new List<string> { MomentoRpcMethod.TopicSubscribe.ToMomentoLocalMetadataString() },
-      StreamErrorMessageLimit = 3 // Receive an error after every 2 heartbeats
-    };
-    var testProps = new MomentoLocalCacheAndTopicClient(_authProvider, _loggerFactory, _cacheConfig, _topicConfig, momentoLocalArgs);
-
-    var heartbeatTimeout = TimeSpan.FromSeconds(3);
-    var heartbeatCounter = new HeartbeatTimestampCollector(heartbeatTimeout);
-
-    var cts = new CancellationTokenSource();
-    cts.CancelAfter(10_000);
-
-    var subscribeResponse = await testProps.TopicClient.SubscribeAsync(testProps.CacheName, "topic");
-    switch (subscribeResponse)
-    {
-      case TopicSubscribeResponse.Subscription subscription:
-        try
-        {
-          var cancellableSubscription = subscription.WithCancellationForAllEvents(cts.Token);
-          await foreach (var topicEvent in cancellableSubscription)
-          {
-            switch (topicEvent)
-            {
-              case TopicSystemEvent.Heartbeat:
-                heartbeatCounter.AddTimestamp(DateTime.Now);
-                break;
-              case TopicMessage.Error error:
-                Assert.Fail("Received error message from topic: {error.ToString()}");
-                break;
-              default:
-                break;
-            }
-          }
-        }
-        catch (OperationCanceledException)
-        {
-          // Expected when the test times out
-        }
-        finally
-        {
-          subscription.Dispose();
-        }
-        break;
-      default:
-        Assert.Fail("Expected subscription response, got error: " + subscribeResponse.ToString());
-        cts.Cancel();
-        break;
+        Assert.InRange(heartbeatCounter.GetCountOfTimestamps(), heartbeatTimeoutSeconds / 2, heartbeatTimeoutSeconds);
+        Assert.Equal(1, heartbeatCounter.GetCountOfTimeouts());
+        Assert.True(testProps.Middleware.StreamDisconnectedCounter >= 1);
+        Assert.True(testProps.Middleware.StreamEstablishedCounter >= 2);
     }
 
-    // 1 timeout and 1 disconnect for the resubscribe period
-    Assert.Equal(1, heartbeatCounter.GetCountOfTimeouts());
-    Assert.Equal(1, testProps.Middleware.StreamDisconnectedCounter);
-
-    // Counts heartbeats before and after the resubscribe period
-    Assert.InRange(heartbeatCounter.GetCountOfTimestamps(), 2, 8);
-
-    // 1 for the initial connection, 1 for the resubscribe, others for attempted reconnects
-    Assert.True(testProps.Middleware.StreamEstablishedCounter >= 2);
-  }
-
-  [Fact]
-  public async Task SubscriptionDoesNotReconnectAfterUnrecoverableError()
-  {
-    var momentoLocalArgs = new MomentoLocalMiddlewareArgs
+    [Fact]
+    public async Task SubscriptionReconnectsAfterRecoverableError()
     {
-      StreamError = MomentoErrorCode.AUTHENTICATION_ERROR.ToStringValue(),
-      StreamErrorRpcList = new List<string> { MomentoRpcMethod.TopicSubscribe.ToMomentoLocalMetadataString() },
-      StreamErrorMessageLimit = 3 // Receive an error after every 2 heartbeats
-    };
-    var testProps = new MomentoLocalCacheAndTopicClient(_authProvider, _loggerFactory, _cacheConfig, _topicConfig, momentoLocalArgs);
-
-    var heartbeatTimeout = TimeSpan.FromSeconds(3);
-    var heartbeatCounter = new HeartbeatTimestampCollector(heartbeatTimeout);
-
-    var cts = new CancellationTokenSource();
-    cts.CancelAfter(10_000);
-
-    var subscribeResponse = await testProps.TopicClient.SubscribeAsync(testProps.CacheName, "topic");
-    switch (subscribeResponse)
-    {
-      case TopicSubscribeResponse.Subscription subscription:
-        try
+        var momentoLocalArgs = new MomentoLocalMiddlewareArgs
         {
-          var cancellableSubscription = subscription.WithCancellationForAllEvents(cts.Token);
-          await foreach (var topicEvent in cancellableSubscription)
-          {
-            switch (topicEvent)
-            {
-              case TopicSystemEvent.Heartbeat:
-                heartbeatCounter.AddTimestamp(DateTime.Now);
-                break;
-              case TopicMessage.Error error:
-                Assert.Equal(MomentoErrorCode.AUTHENTICATION_ERROR, error.ErrorCode);
-                break;
-              default:
-                break;
-            }
-          }
-        }
-        catch (OperationCanceledException)
+            StreamError = MomentoErrorCode.SERVER_UNAVAILABLE.ToStringValue(),
+            StreamErrorRpcList = new List<string> { MomentoRpcMethod.TopicSubscribe.ToMomentoLocalMetadataString() },
+            StreamErrorMessageLimit = 3 // Receive an error after every 2 heartbeats
+        };
+        var testProps = new MomentoLocalCacheAndTopicClient(_authProvider, _loggerFactory, _cacheConfig, _topicConfig, momentoLocalArgs);
+
+        var heartbeatTimeout = TimeSpan.FromSeconds(3);
+        var heartbeatCounter = new HeartbeatTimestampCollector(heartbeatTimeout);
+
+        var cts = new CancellationTokenSource();
+        cts.CancelAfter(10_000);
+
+        var subscribeResponse = await testProps.TopicClient.SubscribeAsync(testProps.CacheName, "topic");
+        switch (subscribeResponse)
         {
-          // Expected when the test times out
+            case TopicSubscribeResponse.Subscription subscription:
+                try
+                {
+                    var cancellableSubscription = subscription.WithCancellationForAllEvents(cts.Token);
+                    await foreach (var topicEvent in cancellableSubscription)
+                    {
+                        switch (topicEvent)
+                        {
+                            case TopicSystemEvent.Heartbeat:
+                                heartbeatCounter.AddTimestamp(DateTime.Now);
+                                break;
+                            case TopicMessage.Error error:
+                                Assert.Fail("Received error message from topic: {error.ToString()}");
+                                break;
+                            default:
+                                break;
+                        }
+                    }
+                }
+                catch (OperationCanceledException)
+                {
+                    // Expected when the test times out
+                }
+                finally
+                {
+                    subscription.Dispose();
+                }
+                break;
+            default:
+                Assert.Fail("Expected subscription response, got error: " + subscribeResponse.ToString());
+                cts.Cancel();
+                break;
         }
-        finally
-        {
-          subscription.Dispose();
-        }
-        break;
-      default:
-        Assert.Fail("Expected subscription response, got error: " + subscribeResponse.ToString());
-        cts.Cancel();
-        break;
+
+        // 1 timeout and 1 disconnect for the resubscribe period
+        Assert.Equal(1, heartbeatCounter.GetCountOfTimeouts());
+        Assert.Equal(1, testProps.Middleware.StreamDisconnectedCounter);
+
+        // Counts heartbeats before and after the resubscribe period
+        Assert.InRange(heartbeatCounter.GetCountOfTimestamps(), 2, 8);
+
+        // 1 for the initial connection, 1 for the resubscribe, others for attempted reconnects
+        Assert.True(testProps.Middleware.StreamEstablishedCounter >= 2);
     }
 
-    // After the error, no heartbeats should be received, so no timeout period
-    Assert.Equal(0, heartbeatCounter.GetCountOfTimeouts());
+    [Fact]
+    public async Task SubscriptionDoesNotReconnectAfterUnrecoverableError()
+    {
+        var momentoLocalArgs = new MomentoLocalMiddlewareArgs
+        {
+            StreamError = MomentoErrorCode.AUTHENTICATION_ERROR.ToStringValue(),
+            StreamErrorRpcList = new List<string> { MomentoRpcMethod.TopicSubscribe.ToMomentoLocalMetadataString() },
+            StreamErrorMessageLimit = 3 // Receive an error after every 2 heartbeats
+        };
+        var testProps = new MomentoLocalCacheAndTopicClient(_authProvider, _loggerFactory, _cacheConfig, _topicConfig, momentoLocalArgs);
 
-    // Count of heartbeats before the error
-    Assert.InRange(heartbeatCounter.GetCountOfTimestamps(), 1, 3);
+        var heartbeatTimeout = TimeSpan.FromSeconds(3);
+        var heartbeatCounter = new HeartbeatTimestampCollector(heartbeatTimeout);
 
-    // No reconnects should have succeeded, but should have made the initial connection and attempted reconnects
-    Assert.True(testProps.Middleware.StreamEstablishedCounter >= 1);
-    Assert.Equal(1, testProps.Middleware.StreamDisconnectedCounter);
-  }
+        var cts = new CancellationTokenSource();
+        cts.CancelAfter(10_000);
 
-  [Fact]
-  public void PublishDoesNotRetryOnAnyError()
-  {
-    var testProps = new MomentoLocalCacheAndTopicClient(_authProvider, _loggerFactory, _cacheConfig, _topicConfig, null);
-    testProps.CacheClient.IncrementAsync(testProps.CacheName, "key").Wait();
-    Assert.Equal(0, testProps.TestMetricsCollector.GetTotalRetryCount(testProps.CacheName, MomentoRpcMethod.Increment));
-  }
+        var subscribeResponse = await testProps.TopicClient.SubscribeAsync(testProps.CacheName, "topic");
+        switch (subscribeResponse)
+        {
+            case TopicSubscribeResponse.Subscription subscription:
+                try
+                {
+                    var cancellableSubscription = subscription.WithCancellationForAllEvents(cts.Token);
+                    await foreach (var topicEvent in cancellableSubscription)
+                    {
+                        switch (topicEvent)
+                        {
+                            case TopicSystemEvent.Heartbeat:
+                                heartbeatCounter.AddTimestamp(DateTime.Now);
+                                break;
+                            case TopicMessage.Error error:
+                                Assert.Equal(MomentoErrorCode.AUTHENTICATION_ERROR, error.ErrorCode);
+                                break;
+                            default:
+                                break;
+                        }
+                    }
+                }
+                catch (OperationCanceledException)
+                {
+                    // Expected when the test times out
+                }
+                finally
+                {
+                    subscription.Dispose();
+                }
+                break;
+            default:
+                Assert.Fail("Expected subscription response, got error: " + subscribeResponse.ToString());
+                cts.Cancel();
+                break;
+        }
+
+        // After the error, no heartbeats should be received, so no timeout period
+        Assert.Equal(0, heartbeatCounter.GetCountOfTimeouts());
+
+        // Count of heartbeats before the error
+        Assert.InRange(heartbeatCounter.GetCountOfTimestamps(), 1, 3);
+
+        // No reconnects should have succeeded, but should have made the initial connection and attempted reconnects
+        Assert.True(testProps.Middleware.StreamEstablishedCounter >= 1);
+        Assert.Equal(1, testProps.Middleware.StreamDisconnectedCounter);
+    }
+
+    [Fact]
+    public void PublishDoesNotRetryOnAnyError()
+    {
+        var testProps = new MomentoLocalCacheAndTopicClient(_authProvider, _loggerFactory, _cacheConfig, _topicConfig, null);
+        testProps.CacheClient.IncrementAsync(testProps.CacheName, "key").Wait();
+        Assert.Equal(0, testProps.TestMetricsCollector.GetTotalRetryCount(testProps.CacheName, MomentoRpcMethod.Increment));
+    }
 }

--- a/tests/Integration/Momento.Sdk.Tests/Retry/TopicClientRetryTest.cs
+++ b/tests/Integration/Momento.Sdk.Tests/Retry/TopicClientRetryTest.cs
@@ -109,10 +109,10 @@ public class TopicClientRetryTests
         {
             builder.AddSimpleConsole(options =>
             {
-                  options.IncludeScopes = true;
-                  options.SingleLine = true;
-                  options.TimestampFormat = "hh:mm:ss ";
-              });
+                options.IncludeScopes = true;
+                options.SingleLine = true;
+                options.TimestampFormat = "hh:mm:ss ";
+            });
             builder.AddFilter("Grpc.Net.Client", LogLevel.Error);
             builder.SetMinimumLevel(LogLevel.Information);
         });

--- a/tests/Integration/Momento.Sdk.Tests/Retry/TopicClientRetryTest.cs
+++ b/tests/Integration/Momento.Sdk.Tests/Retry/TopicClientRetryTest.cs
@@ -1,0 +1,336 @@
+using System.Collections.Generic;
+using Microsoft.Extensions.Logging;
+using Momento.Sdk.Auth;
+using Momento.Sdk.Config;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Net.Http;
+using System.IO;
+
+namespace Momento.Sdk.Tests.Integration.Retry;
+
+public class TestAdminClient
+{
+  private readonly string _endpoint;
+  private readonly HttpClient _httpClient;
+
+  public TestAdminClient()
+  {
+    var hostname = Environment.GetEnvironmentVariable("TEST_ADMIN_HOSTNAME") ?? "127.0.0.1";
+    var port = Environment.GetEnvironmentVariable("TEST_ADMIN_PORT") ?? "9090";
+    _endpoint = $"http://{hostname}:{port}";
+    _httpClient = new HttpClient
+    {
+      Timeout = TimeSpan.FromSeconds(5)
+    };
+  }
+
+  public async Task BlockPort()
+  {
+    try
+    {
+      Console.WriteLine($"Attempting to block port at {_endpoint}/block");
+      var response = await _httpClient.GetAsync($"{_endpoint}/block");
+      response.EnsureSuccessStatusCode();
+      Console.WriteLine("Port blocked successfully");
+    }
+    catch (HttpRequestException ex)
+    {
+      Console.WriteLine($"Failed to block port: {ex.Message}");
+      throw;
+    }
+  }
+
+  public async Task UnblockPort()
+  {
+    try
+    {
+      Console.WriteLine($"Attempting to unblock port at {_endpoint}/unblock");
+      var response = await _httpClient.GetAsync($"{_endpoint}/unblock");
+      response.EnsureSuccessStatusCode();
+      Console.WriteLine("Port unblocked successfully");
+    }
+    catch (HttpRequestException ex)
+    {
+      Console.WriteLine($"Failed to unblock port: {ex.Message}");
+      throw;
+    }
+  }
+}
+
+public class HeartbeatTimestampCollector
+{
+  private readonly List<DateTime> _timestamps;
+  private readonly TimeSpan _timeout;
+
+  public HeartbeatTimestampCollector(TimeSpan timeout)
+  {
+    _timestamps = new();
+    _timeout = timeout;
+  }
+
+  public void AddTimestamp(DateTime timestamp)
+  {
+    _timestamps.Add(timestamp);
+  }
+
+  public int GetCountOfTimestamps()
+  {
+    return _timestamps.Count;
+  }
+
+  public int GetCountOfTimeouts()
+  {
+    // Count number of times timestamps were more than timeout seconds apart
+    var count = 0;
+    for (var i = 0; i < _timestamps.Count - 1; i++)
+    {
+      if (_timestamps[i + 1] - _timestamps[i] > _timeout)
+      {
+        count++;
+      }
+    }
+    return count;
+  }
+}
+
+[Collection("Retry")]
+public class TopicClientRetryTests
+{
+  private readonly ICredentialProvider _authProvider;
+  private readonly ILoggerFactory _loggerFactory;
+  private readonly IConfiguration _cacheConfig;
+  private readonly ITopicConfiguration _topicConfig;
+
+  public TopicClientRetryTests()
+  {
+    _authProvider = new MomentoLocalProvider();
+    _loggerFactory = LoggerFactory.Create(builder =>
+    {
+      builder.AddSimpleConsole(options =>
+          {
+            options.IncludeScopes = true;
+            options.SingleLine = true;
+            options.TimestampFormat = "hh:mm:ss ";
+          });
+      builder.AddFilter("Grpc.Net.Client", LogLevel.Error);
+      builder.SetMinimumLevel(LogLevel.Information);
+    });
+    _cacheConfig = Configurations.Laptop.Latest(_loggerFactory);
+    _topicConfig = TopicConfigurations.Laptop.latest(_loggerFactory);
+  }
+
+  [Fact]
+  public async Task SubscriptionResumesAfterKeepalivesStopThenResume()
+  {
+    // SocketsHttpHandlerOptions sets default keepalive ping timeout to 1 second
+    // and keepalive ping delay to 5 seconds, so we should block keepalives for 
+    // at least that amount of time to make sure keepalives are stopped.
+    // And make sure to let the subscription be active for some time after the
+    // timeout period to allow confirmation of heartbeats and keepalives.
+
+    var testProps = new MomentoLocalCacheAndTopicClient(_authProvider, _loggerFactory, _cacheConfig, _topicConfig, null);
+    var testAdmin = new TestAdminClient();
+    var heartbeatTimeoutSeconds = 8;
+    var heartbeatTimeout = TimeSpan.FromSeconds(heartbeatTimeoutSeconds);
+    var heartbeatCounter = new HeartbeatTimestampCollector(heartbeatTimeout);
+    var cts = new CancellationTokenSource();
+    cts.CancelAfter(20_000);
+
+    var subscribeResponse = await testProps.TopicClient.SubscribeAsync(testProps.CacheName, "topic");
+    var subscriptionTask = Task.Run(async () =>
+    {
+      switch (subscribeResponse)
+      {
+        case TopicSubscribeResponse.Subscription subscription:
+          try
+          {
+            var cancellableSubscription = subscription.WithCancellationForAllEvents(cts.Token);
+            await foreach (var topicEvent in cancellableSubscription)
+            {
+              switch (topicEvent)
+              {
+                case TopicSystemEvent.Heartbeat:
+                  heartbeatCounter.AddTimestamp(DateTime.Now);
+                  break;
+                case TopicMessage.Error error:
+                  Assert.Fail("Received error message from topic: {error.ToString()}");
+                  break;
+                default:
+                  break;
+              }
+            }
+          }
+          catch (OperationCanceledException)
+          {
+            // Expected when the test times out
+          }
+          catch (IOException)
+          {
+            // Expected when connection is reset
+          }
+          finally
+          {
+            subscription.Dispose();
+          }
+          break;
+        default:
+          Assert.Fail("Expected subscription response, got error: " + subscribeResponse.ToString());
+          cts.Cancel();
+          break;
+      }
+    });
+
+    // After 3 seconds, stop the keepalives, wait for the timeout period, then resume keepalives
+    await Task.Delay(3000);
+    await testAdmin.BlockPort();
+    await Task.Delay(heartbeatTimeout);
+    await testAdmin.UnblockPort();
+
+    // Wait for the subscription task to complete
+    await subscriptionTask;
+
+    Assert.InRange(heartbeatCounter.GetCountOfTimestamps(), heartbeatTimeoutSeconds / 2, heartbeatTimeoutSeconds);
+    Assert.Equal(1, heartbeatCounter.GetCountOfTimeouts());
+    Assert.True(testProps.Middleware.StreamDisconnectedCounter >= 1);
+    Assert.True(testProps.Middleware.StreamEstablishedCounter >= 2);
+  }
+
+  [Fact]
+  public async Task SubscriptionReconnectsAfterRecoverableError()
+  {
+    var momentoLocalArgs = new MomentoLocalMiddlewareArgs
+    {
+      StreamError = MomentoErrorCode.SERVER_UNAVAILABLE.ToStringValue(),
+      StreamErrorRpcList = new List<string> { MomentoRpcMethod.TopicSubscribe.ToMomentoLocalMetadataString() },
+      StreamErrorMessageLimit = 3 // Receive an error after every 2 heartbeats
+    };
+    var testProps = new MomentoLocalCacheAndTopicClient(_authProvider, _loggerFactory, _cacheConfig, _topicConfig, momentoLocalArgs);
+
+    var heartbeatTimeout = TimeSpan.FromSeconds(3);
+    var heartbeatCounter = new HeartbeatTimestampCollector(heartbeatTimeout);
+
+    var cts = new CancellationTokenSource();
+    cts.CancelAfter(10_000);
+
+    var subscribeResponse = await testProps.TopicClient.SubscribeAsync(testProps.CacheName, "topic");
+    switch (subscribeResponse)
+    {
+      case TopicSubscribeResponse.Subscription subscription:
+        try
+        {
+          var cancellableSubscription = subscription.WithCancellationForAllEvents(cts.Token);
+          await foreach (var topicEvent in cancellableSubscription)
+          {
+            switch (topicEvent)
+            {
+              case TopicSystemEvent.Heartbeat:
+                heartbeatCounter.AddTimestamp(DateTime.Now);
+                break;
+              case TopicMessage.Error error:
+                Assert.Fail("Received error message from topic: {error.ToString()}");
+                break;
+              default:
+                break;
+            }
+          }
+        }
+        catch (OperationCanceledException)
+        {
+          // Expected when the test times out
+        }
+        finally
+        {
+          subscription.Dispose();
+        }
+        break;
+      default:
+        Assert.Fail("Expected subscription response, got error: " + subscribeResponse.ToString());
+        cts.Cancel();
+        break;
+    }
+
+    // 1 timeout and 1 disconnect for the resubscribe period
+    Assert.Equal(1, heartbeatCounter.GetCountOfTimeouts());
+    Assert.Equal(1, testProps.Middleware.StreamDisconnectedCounter);
+
+    // Counts heartbeats before and after the resubscribe period
+    Assert.InRange(heartbeatCounter.GetCountOfTimestamps(), 2, 8);
+
+    // 1 for the initial connection, 1 for the resubscribe, others for attempted reconnects
+    Assert.True(testProps.Middleware.StreamEstablishedCounter >= 2);
+  }
+
+  [Fact]
+  public async Task SubscriptionDoesNotReconnectAfterUnrecoverableError()
+  {
+    var momentoLocalArgs = new MomentoLocalMiddlewareArgs
+    {
+      StreamError = MomentoErrorCode.AUTHENTICATION_ERROR.ToStringValue(),
+      StreamErrorRpcList = new List<string> { MomentoRpcMethod.TopicSubscribe.ToMomentoLocalMetadataString() },
+      StreamErrorMessageLimit = 3 // Receive an error after every 2 heartbeats
+    };
+    var testProps = new MomentoLocalCacheAndTopicClient(_authProvider, _loggerFactory, _cacheConfig, _topicConfig, momentoLocalArgs);
+
+    var heartbeatTimeout = TimeSpan.FromSeconds(3);
+    var heartbeatCounter = new HeartbeatTimestampCollector(heartbeatTimeout);
+
+    var cts = new CancellationTokenSource();
+    cts.CancelAfter(10_000);
+
+    var subscribeResponse = await testProps.TopicClient.SubscribeAsync(testProps.CacheName, "topic");
+    switch (subscribeResponse)
+    {
+      case TopicSubscribeResponse.Subscription subscription:
+        try
+        {
+          var cancellableSubscription = subscription.WithCancellationForAllEvents(cts.Token);
+          await foreach (var topicEvent in cancellableSubscription)
+          {
+            switch (topicEvent)
+            {
+              case TopicSystemEvent.Heartbeat:
+                heartbeatCounter.AddTimestamp(DateTime.Now);
+                break;
+              case TopicMessage.Error error:
+                Assert.Equal(MomentoErrorCode.AUTHENTICATION_ERROR, error.ErrorCode);
+                break;
+              default:
+                break;
+            }
+          }
+        }
+        catch (OperationCanceledException)
+        {
+          // Expected when the test times out
+        }
+        finally
+        {
+          subscription.Dispose();
+        }
+        break;
+      default:
+        Assert.Fail("Expected subscription response, got error: " + subscribeResponse.ToString());
+        cts.Cancel();
+        break;
+    }
+
+    // After the error, no heartbeats should be received, so no timeout period
+    Assert.Equal(0, heartbeatCounter.GetCountOfTimeouts());
+
+    // Count of heartbeats before the error
+    Assert.InRange(heartbeatCounter.GetCountOfTimestamps(), 1, 3);
+
+    // No reconnects should have succeeded, but should have made the initial connection and attempted reconnects
+    Assert.True(testProps.Middleware.StreamEstablishedCounter >= 1);
+    Assert.Equal(1, testProps.Middleware.StreamDisconnectedCounter);
+  }
+
+  [Fact]
+  public void PublishDoesNotRetryOnAnyError()
+  {
+    var testProps = new MomentoLocalCacheAndTopicClient(_authProvider, _loggerFactory, _cacheConfig, _topicConfig, null);
+    testProps.CacheClient.IncrementAsync(testProps.CacheName, "key").Wait();
+    Assert.Equal(0, testProps.TestMetricsCollector.GetTotalRetryCount(testProps.CacheName, MomentoRpcMethod.Increment));
+  }
+}

--- a/tests/Integration/Momento.Sdk.Tests/Retry/utils/MomentoLocalMiddleware.cs
+++ b/tests/Integration/Momento.Sdk.Tests/Retry/utils/MomentoLocalMiddleware.cs
@@ -69,10 +69,13 @@ public class MomentoLocalMiddleware : IMiddleware, ITopicMiddleware
     public int StreamEstablishedCounter { get; set; } = 0;
     public int StreamDisconnectedCounter { get; set; } = 0;
 
+    public IEnumerable<KeyValuePair<string, string>> Headers { get; } = new List<KeyValuePair<string, string>>();
+
     public MomentoLocalMiddleware(ILoggerFactory loggerFactory, MomentoLocalMiddlewareArgs? args)
     {
         _logger = loggerFactory.CreateLogger<MomentoLocalMiddleware>();
         _args = args ?? new MomentoLocalMiddlewareArgs();
+        Headers = CreateHeaders();
     }
 
     public async Task<MiddlewareResponseState<TResponse>> WrapRequest<TRequest, TResponse>(
@@ -118,7 +121,7 @@ public class MomentoLocalMiddleware : IMiddleware, ITopicMiddleware
         );
     }
 
-    public IList<Tuple<string, string>> WithHeaders()
+    private IList<KeyValuePair<string, string>> CreateHeaders()
     {
         var headerMappings = new Dictionary<string, string?>
         {
@@ -134,7 +137,7 @@ public class MomentoLocalMiddleware : IMiddleware, ITopicMiddleware
             { "stream-error-message-limit", _args.StreamErrorMessageLimit?.ToString() }
         };
 
-        var headers = new List<Tuple<string, string>>();
+        var headers = new List<KeyValuePair<string, string>>();
         foreach (var pair in headerMappings)
         {
             string key = pair.Key;
@@ -142,7 +145,7 @@ public class MomentoLocalMiddleware : IMiddleware, ITopicMiddleware
             {
                 if (value != null)
                 {
-                    headers.Add(new Tuple<string, string>(key, value.ToString()));
+                    headers.Add(new KeyValuePair<string, string>(key, value.ToString()));
                 }
             }
         }

--- a/tests/Integration/Momento.Sdk.Tests/Retry/utils/RetryTestUtils.cs
+++ b/tests/Integration/Momento.Sdk.Tests/Retry/utils/RetryTestUtils.cs
@@ -23,3 +23,23 @@ public class MomentoLocalCacheAndCacheClient
         CacheClient.CreateCacheAsync(CacheName).Wait();
     }
 }
+
+public class MomentoLocalCacheAndTopicClient
+{
+    public ICacheClient CacheClient { get; }
+    public ITopicClient TopicClient { get; }
+    public string CacheName { get; }
+    public TestRetryMetricsCollector TestMetricsCollector { get; }
+    public MomentoLocalMiddleware Middleware { get; }
+
+    public MomentoLocalCacheAndTopicClient(ICredentialProvider authProvider, ILoggerFactory loggerFactory, IConfiguration cacheConfig, ITopicConfiguration topicConfig, MomentoLocalMiddlewareArgs? args)
+    {
+        Middleware = new MomentoLocalMiddleware(loggerFactory, args);
+        TestMetricsCollector = Middleware.TestMetricsCollector;
+        CacheClient = new CacheClient(cacheConfig, authProvider, TimeSpan.FromSeconds(60));
+        CacheName = Utils.NewGuidString();
+        CacheClient.CreateCacheAsync(CacheName).Wait();
+        var tConfig = topicConfig.AddMiddleware(Middleware);
+        TopicClient = new TopicClient(tConfig, authProvider);
+    }
+}


### PR DESCRIPTION
Closes https://github.com/momentohq/dev-eco-issue-tracker/issues/1189

Adds a new ITopicMiddleware interface to allow TopicClient to accept middlewares that can be applied to both publish and subscribe. Implemented it for MomentoLocalMiddleware and wrote new momento-local tests for topics.

Because of this [comment](https://github.com/momentohq/client-sdk-dotnet/blob/main/src/Momento.Sdk/Internal/TopicGrpcManager.cs#L53-L54) stating that the current middleware setup is incompatible with streaming calls, I made this middleware more limited in what it can change. Namely, it can really only add headers before a request is sent out. I might be limiting the capabilities here too much, let me know what y'all think!

In addition to headers, the ITopicMiddleware also allows for taking action when a stream is established or disconnected. All other topics events are accessible through an iterator-style subscription stream, but these two events were not, but was helpful for the momento-local tests, and could be helpful for other users as well, but not as important as the main topics events provided in the regular subscription iterator.