### PR TITLE
chore: add topic retry tests against momento-local using internal topics config wrapper

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -133,7 +133,7 @@ jobs:
 
       - name: Start Momento Local
         run: |
-         docker run --rm -d -p 8080:8080 gomomento/momento-local
+         docker run --cap-add=NET_ADMIN -d --rm -p 8080:8080 -p 9090:9090 gomomento/momento-local --enable-test-admin
 
       - name: Run momento-local retry tests
         run: make test-retry

--- a/src/Momento.Sdk/Internal/AuthGrpcManager.cs
+++ b/src/Momento.Sdk/Internal/AuthGrpcManager.cs
@@ -29,9 +29,9 @@ internal class AuthClientWithMiddleware : IAuthClient
 {
     private readonly IList<IMiddleware> _middlewares;
     private readonly Token.TokenClient _generatedClient;
-    private readonly IList<Tuple<string, string>> _headers;
+    private readonly IList<KeyValuePair<string, string>> _headers;
 
-    public AuthClientWithMiddleware(Token.TokenClient generatedClient, IList<IMiddleware> middlewares, IList<Tuple<string, string>> headers)
+    public AuthClientWithMiddleware(Token.TokenClient generatedClient, IList<IMiddleware> middlewares, IList<KeyValuePair<string, string>> headers)
     {
         _generatedClient = generatedClient;
         _middlewares = middlewares;

--- a/src/Momento.Sdk/Internal/GrpcManager.cs
+++ b/src/Momento.Sdk/Internal/GrpcManager.cs
@@ -39,7 +39,7 @@ public class GrpcManager : IDisposable
 
     internal List<Header> headers;
 
-    internal List<Tuple<string, string>> headerTuples;
+    internal List<KeyValuePair<string, string>> headerTuples;
 
     protected CallInvoker invoker;
 
@@ -55,13 +55,13 @@ public class GrpcManager : IDisposable
     {
         this._logger = loggerFactory.CreateLogger(loggerName);
 
-        this.headerTuples = new List<Tuple<string, string>>
+        this.headerTuples = new List<KeyValuePair<string, string>>
         {
             new(Header.AuthorizationKey, authProvider.AuthToken),
             new(Header.AgentKey, version),
             new(Header.RuntimeVersionKey, runtimeVersion)
         };
-        this.headers = headerTuples.Select(tuple => new Header(name: tuple.Item1, value: tuple.Item2)).ToList();
+        this.headers = headerTuples.Select(tuple => new Header(name: tuple.Key, value: tuple.Value)).ToList();
 
         // Set all channel opens and create the grpc connection
         var channelOptions = grpcConfig.GrpcChannelOptions;

--- a/src/Momento.Sdk/Internal/TopicGrpcManager.cs
+++ b/src/Momento.Sdk/Internal/TopicGrpcManager.cs
@@ -32,10 +32,10 @@ public class PubsubClientWithMiddleware : IPubsubClient
 {
     private readonly Pubsub.PubsubClient _generatedClient;
     private readonly IList<IMiddleware> _middlewares;
-    private readonly IList<Tuple<string, string>> _headers;
+    private readonly IList<KeyValuePair<string, string>> _headers;
 
     public PubsubClientWithMiddleware(Pubsub.PubsubClient generatedClient, IList<IMiddleware> middlewares,
-        IList<Tuple<string, string>> headers)
+        IList<KeyValuePair<string, string>> headers)
     {
         _generatedClient = generatedClient;
         _middlewares = middlewares;
@@ -60,7 +60,7 @@ public class PubsubClientWithMiddleware : IPubsubClient
 
         foreach (var header in _headers)
         {
-            callHeaders.Add(header.Item1, header.Item2);
+            callHeaders.Add(header.Key, header.Value);
         }
 
         return _generatedClient.Subscribe(request, callOptions.WithHeaders(callHeaders));
@@ -80,5 +80,17 @@ public class TopicGrpcManager : GrpcManager
 
         var client = new Pubsub.PubsubClient(this.invoker);
         Client = new PubsubClientWithMiddleware(client, middlewares, this.headerTuples);
+    }
+
+    internal TopicGrpcManager(ITopicConfiguration config, ICredentialProvider authProvider, IList<KeyValuePair<string, string>> momentoLocalHeaders) : base(config.TransportStrategy.GrpcConfig, config.LoggerFactory, authProvider, authProvider.CacheEndpoint, "TopicGrpcManager")
+    {
+        var middlewares = new List<IMiddleware>
+        {
+            new HeaderMiddleware(config.LoggerFactory, this.headers),
+        };
+
+        var allHeaders = this.headerTuples.ToList().Concat(momentoLocalHeaders).ToList();
+        var client = new Pubsub.PubsubClient(this.invoker);
+        Client = new PubsubClientWithMiddleware(client, middlewares, allHeaders);
     }
 }

--- a/src/Momento.Sdk/Internal/TopicInterfaceExtensions/TopicConfigWithHeaders.cs
+++ b/src/Momento.Sdk/Internal/TopicInterfaceExtensions/TopicConfigWithHeaders.cs
@@ -1,0 +1,16 @@
+using System.Collections.Generic;
+
+namespace Momento.Sdk.Internal;
+
+/// <summary>
+/// Interface for defining a topic configuration with headers.
+/// This is currently used by the MomentoLocalTestTopicConfiguration class, which is an internal wrapper used for
+/// testing topics retry logic against momento-local.
+/// </summary>
+public interface ITopicConfigWithHeaders
+{
+    /// <summary>
+    /// List of headers to be sent with each publish or subscribe request.
+    /// </summary>
+    public IList<KeyValuePair<string, string>> Headers { get; }
+}

--- a/src/Momento.Sdk/Internal/TopicInterfaceExtensions/TopicSubscriptionConnectionStateCallbacks.cs
+++ b/src/Momento.Sdk/Internal/TopicInterfaceExtensions/TopicSubscriptionConnectionStateCallbacks.cs
@@ -1,0 +1,21 @@
+namespace Momento.Sdk.Internal;
+
+/// <summary>
+/// Interface for defining callbacks to be invoked when the subscription stream is disconnected or re-established.
+/// This is currently used by the MomentoLocalTestTopicConfiguration class, which is an internal wrapper used for
+/// testing topics retry logic against momento-local.
+/// </summary>
+public interface ITopicSubscriptionConnectionStateCallbacks
+{
+    /// <summary>
+    /// Take action when a subscription stream is disconnected.
+    /// </summary>
+    /// <returns></returns>
+    public void OnStreamDisconnected();
+
+    /// <summary>
+    /// Take action when a subscription stream is (re)established.
+    /// </summary>
+    /// <returns></returns>
+    public void onStreamEstablished();
+}

--- a/tests/Integration/Momento.Sdk.Tests/Retry/TopicClientRetryTest.cs
+++ b/tests/Integration/Momento.Sdk.Tests/Retry/TopicClientRetryTest.cs
@@ -1,0 +1,338 @@
+using Microsoft.Extensions.Logging;
+using Momento.Sdk.Auth;
+using Momento.Sdk.Config;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Momento.Sdk.Tests.Integration.Retry;
+
+public class TestAdminClient
+{
+    private readonly string _endpoint;
+    private readonly HttpClient _httpClient;
+
+    public TestAdminClient()
+    {
+        var hostname = Environment.GetEnvironmentVariable("TEST_ADMIN_HOSTNAME") ?? "127.0.0.1";
+        var port = Environment.GetEnvironmentVariable("TEST_ADMIN_PORT") ?? "9090";
+        _endpoint = $"http://{hostname}:{port}";
+        _httpClient = new HttpClient
+        {
+            Timeout = TimeSpan.FromSeconds(5)
+        };
+    }
+
+    public async Task BlockPort()
+    {
+        try
+        {
+            Console.WriteLine($"Attempting to block port at {_endpoint}/block");
+            var response = await _httpClient.GetAsync($"{_endpoint}/block");
+            response.EnsureSuccessStatusCode();
+            Console.WriteLine("Port blocked successfully");
+        }
+        catch (HttpRequestException ex)
+        {
+            Console.WriteLine($"Failed to block port: {ex.Message}");
+            throw;
+        }
+    }
+
+    public async Task UnblockPort()
+    {
+        try
+        {
+            Console.WriteLine($"Attempting to unblock port at {_endpoint}/unblock");
+            var response = await _httpClient.GetAsync($"{_endpoint}/unblock");
+            response.EnsureSuccessStatusCode();
+            Console.WriteLine("Port unblocked successfully");
+        }
+        catch (HttpRequestException ex)
+        {
+            Console.WriteLine($"Failed to unblock port: {ex.Message}");
+            throw;
+        }
+    }
+}
+
+public class HeartbeatTimestampCollector
+{
+    private readonly List<DateTime> _timestamps;
+    private readonly TimeSpan _timeout;
+
+    public HeartbeatTimestampCollector(TimeSpan timeout)
+    {
+        _timestamps = new();
+        _timeout = timeout;
+    }
+
+    public void AddTimestamp(DateTime timestamp)
+    {
+        _timestamps.Add(timestamp);
+    }
+
+    public int GetCountOfTimestamps()
+    {
+        return _timestamps.Count;
+    }
+
+    public int GetCountOfTimeouts()
+    {
+        // Count number of times timestamps were more than timeout seconds apart
+        var count = 0;
+        for (var i = 0; i < _timestamps.Count - 1; i++)
+        {
+            if (_timestamps[i + 1] - _timestamps[i] > _timeout)
+            {
+                count++;
+            }
+        }
+        return count;
+    }
+}
+
+[Collection("Retry")]
+public class TopicClientRetryTests
+{
+    private readonly ICredentialProvider _authProvider;
+    private readonly ILoggerFactory _loggerFactory;
+    private readonly IConfiguration _cacheConfig;
+    private readonly ITopicConfiguration _topicConfig;
+
+    public TopicClientRetryTests()
+    {
+        _authProvider = new MomentoLocalProvider();
+        _loggerFactory = LoggerFactory.Create(builder =>
+        {
+            builder.AddSimpleConsole(options =>
+            {
+                options.IncludeScopes = true;
+                options.SingleLine = true;
+                options.TimestampFormat = "hh:mm:ss ";
+            });
+            builder.AddFilter("Grpc.Net.Client", LogLevel.Error);
+            builder.SetMinimumLevel(LogLevel.Information);
+        });
+        _cacheConfig = Configurations.Laptop.Latest(_loggerFactory);
+        _topicConfig = TopicConfigurations.Laptop.latest(_loggerFactory);
+    }
+
+    [Fact]
+    public async Task SubscriptionResumesAfterKeepalivesStopThenResume()
+    {
+        // SocketsHttpHandlerOptions sets default keepalive ping timeout to 1 second
+        // and keepalive ping delay to 5 seconds, so we should block keepalives for 
+        // at least that amount of time to make sure keepalives are stopped.
+        // And make sure to let the subscription be active for some time after the
+        // timeout period to allow confirmation of heartbeats and keepalives.
+
+        var testProps = new MomentoLocalCacheAndTopicClient(_authProvider, _loggerFactory, _cacheConfig, _topicConfig, null);
+        var testAdmin = new TestAdminClient();
+        var heartbeatTimeoutSeconds = 8;
+        var heartbeatTimeout = TimeSpan.FromSeconds(heartbeatTimeoutSeconds);
+        var heartbeatCounter = new HeartbeatTimestampCollector(heartbeatTimeout);
+        var cts = new CancellationTokenSource();
+        cts.CancelAfter(20_000);
+
+        var subscribeResponse = await testProps.TopicClient.SubscribeAsync(testProps.CacheName, "topic");
+        var subscriptionTask = Task.Run(async () =>
+        {
+            switch (subscribeResponse)
+            {
+                case TopicSubscribeResponse.Subscription subscription:
+                    try
+                    {
+                        var cancellableSubscription = subscription.WithCancellationForAllEvents(cts.Token);
+                        await foreach (var topicEvent in cancellableSubscription)
+                        {
+                            switch (topicEvent)
+                            {
+                                case TopicSystemEvent.Heartbeat:
+                                    heartbeatCounter.AddTimestamp(DateTime.Now);
+                                    break;
+                                case TopicMessage.Error error:
+                                    Assert.Fail("Received error message from topic: {error.ToString()}");
+                                    break;
+                                default:
+                                    break;
+                            }
+                        }
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        // Expected when the test times out
+                    }
+                    catch (IOException)
+                    {
+                        // Expected when connection is reset
+                    }
+                    finally
+                    {
+                        subscription.Dispose();
+                    }
+                    break;
+                default:
+                    Assert.Fail("Expected subscription response, got error: " + subscribeResponse.ToString());
+                    cts.Cancel();
+                    break;
+            }
+        });
+
+        // After 3 seconds, stop the keepalives, wait for the timeout period, 
+        // then restore connection and resume keepalives
+        await Task.Delay(3000);
+        await testAdmin.BlockPort();
+        await Task.Delay(heartbeatTimeout);
+        await testAdmin.UnblockPort();
+
+        // Wait for the subscription task to complete
+        await subscriptionTask;
+
+        Assert.InRange(heartbeatCounter.GetCountOfTimestamps(), heartbeatTimeoutSeconds / 2, heartbeatTimeoutSeconds);
+        Assert.Equal(1, heartbeatCounter.GetCountOfTimeouts());
+        Assert.True(testProps.TestTopicConfig.StreamDisconnectedCounter >= 1);
+        Assert.True(testProps.TestTopicConfig.StreamEstablishedCounter >= 2);
+    }
+
+    [Fact]
+    public async Task SubscriptionReconnectsAfterRecoverableError()
+    {
+        var momentoLocalArgs = new MomentoLocalMiddlewareArgs
+        {
+            StreamError = MomentoErrorCode.SERVER_UNAVAILABLE.ToStringValue(),
+            StreamErrorRpcList = new List<string> { MomentoRpcMethod.TopicSubscribe.ToMomentoLocalMetadataString() },
+            StreamErrorMessageLimit = 3 // Receive an error after every 2 heartbeats
+        };
+        var testProps = new MomentoLocalCacheAndTopicClient(_authProvider, _loggerFactory, _cacheConfig, _topicConfig, momentoLocalArgs);
+
+        var heartbeatTimeout = TimeSpan.FromSeconds(3);
+        var heartbeatCounter = new HeartbeatTimestampCollector(heartbeatTimeout);
+
+        var cts = new CancellationTokenSource();
+        cts.CancelAfter(10_000);
+
+        var subscribeResponse = await testProps.TopicClient.SubscribeAsync(testProps.CacheName, "topic");
+        switch (subscribeResponse)
+        {
+            case TopicSubscribeResponse.Subscription subscription:
+                try
+                {
+                    var cancellableSubscription = subscription.WithCancellationForAllEvents(cts.Token);
+                    await foreach (var topicEvent in cancellableSubscription)
+                    {
+                        switch (topicEvent)
+                        {
+                            case TopicSystemEvent.Heartbeat:
+                                heartbeatCounter.AddTimestamp(DateTime.Now);
+                                break;
+                            case TopicMessage.Error error:
+                                Assert.Fail("Received error message from topic: {error.ToString()}");
+                                break;
+                            default:
+                                break;
+                        }
+                    }
+                }
+                catch (OperationCanceledException)
+                {
+                    // Expected when the test times out
+                }
+                finally
+                {
+                    subscription.Dispose();
+                }
+                break;
+            default:
+                Assert.Fail("Expected subscription response, got error: " + subscribeResponse.ToString());
+                cts.Cancel();
+                break;
+        }
+
+        // 1 timeout and 1 disconnect for the resubscribe period
+        Assert.Equal(1, heartbeatCounter.GetCountOfTimeouts());
+        Assert.Equal(1, testProps.TestTopicConfig.StreamDisconnectedCounter);
+
+        // Counts heartbeats before and after the resubscribe period
+        Assert.InRange(heartbeatCounter.GetCountOfTimestamps(), 2, 8);
+
+        // 1 for the initial connection, 1 for the resubscribe, others for attempted reconnects
+        Console.WriteLine($"StreamEstablishedCounter: {testProps.TestTopicConfig.StreamEstablishedCounter}");
+        Assert.True(testProps.TestTopicConfig.StreamEstablishedCounter >= 2);
+    }
+
+    [Fact]
+    public async Task SubscriptionDoesNotReconnectAfterUnrecoverableError()
+    {
+        var momentoLocalArgs = new MomentoLocalMiddlewareArgs
+        {
+            StreamError = MomentoErrorCode.AUTHENTICATION_ERROR.ToStringValue(),
+            StreamErrorRpcList = new List<string> { MomentoRpcMethod.TopicSubscribe.ToMomentoLocalMetadataString() },
+            StreamErrorMessageLimit = 3 // Receive an error after every 2 heartbeats
+        };
+        var testProps = new MomentoLocalCacheAndTopicClient(_authProvider, _loggerFactory, _cacheConfig, _topicConfig, momentoLocalArgs);
+
+        var heartbeatTimeout = TimeSpan.FromSeconds(3);
+        var heartbeatCounter = new HeartbeatTimestampCollector(heartbeatTimeout);
+
+        var cts = new CancellationTokenSource();
+        cts.CancelAfter(10_000);
+
+        var subscribeResponse = await testProps.TopicClient.SubscribeAsync(testProps.CacheName, "topic");
+        switch (subscribeResponse)
+        {
+            case TopicSubscribeResponse.Subscription subscription:
+                try
+                {
+                    var cancellableSubscription = subscription.WithCancellationForAllEvents(cts.Token);
+                    await foreach (var topicEvent in cancellableSubscription)
+                    {
+                        switch (topicEvent)
+                        {
+                            case TopicSystemEvent.Heartbeat:
+                                heartbeatCounter.AddTimestamp(DateTime.Now);
+                                break;
+                            case TopicMessage.Error error:
+                                Assert.Equal(MomentoErrorCode.AUTHENTICATION_ERROR, error.ErrorCode);
+                                break;
+                            default:
+                                break;
+                        }
+                    }
+                }
+                catch (OperationCanceledException)
+                {
+                    // Expected when the test times out
+                }
+                finally
+                {
+                    subscription.Dispose();
+                }
+                break;
+            default:
+                Assert.Fail("Expected subscription response, got error: " + subscribeResponse.ToString());
+                cts.Cancel();
+                break;
+        }
+
+        // After the error, no heartbeats should be received, so no timeout period
+        Assert.Equal(0, heartbeatCounter.GetCountOfTimeouts());
+
+        // Count of heartbeats before the error
+        Assert.InRange(heartbeatCounter.GetCountOfTimestamps(), 1, 3);
+
+        // No reconnects should have succeeded, but should have made the initial connection and attempted reconnects
+        Assert.True(testProps.TestTopicConfig.StreamEstablishedCounter >= 1);
+        Assert.Equal(1, testProps.TestTopicConfig.StreamDisconnectedCounter);
+    }
+
+    [Fact]
+    public void PublishDoesNotRetryOnAnyError()
+    {
+        var testProps = new MomentoLocalCacheAndTopicClient(_authProvider, _loggerFactory, _cacheConfig, _topicConfig, null);
+        testProps.CacheClient.IncrementAsync(testProps.CacheName, "key").Wait();
+        Assert.Equal(0, testProps.TestMetricsCollector.GetTotalRetryCount(testProps.CacheName, MomentoRpcMethod.Increment));
+    }
+}

--- a/tests/Integration/Momento.Sdk.Tests/Retry/utils/MomentoLocalTestTopicConfiguration.cs
+++ b/tests/Integration/Momento.Sdk.Tests/Retry/utils/MomentoLocalTestTopicConfiguration.cs
@@ -1,0 +1,92 @@
+using Microsoft.Extensions.Logging;
+using Momento.Sdk.Config;
+using Momento.Sdk.Config.Transport;
+using Momento.Sdk.Internal;
+using System.Collections.Generic;
+
+namespace Momento.Sdk.Tests.Integration.Retry;
+
+public class MomentoLocalTopicConfiguration : ITopicConfiguration, ITopicSubscriptionConnectionStateCallbacks, ITopicConfigWithHeaders
+{
+    public string RequestId { get; set; } = Utils.NewGuidString();
+    private readonly MomentoLocalMiddlewareArgs? _args;
+    public IList<KeyValuePair<string, string>> Headers { get; }
+    public int StreamDisconnectedCounter = 0;
+    public int StreamEstablishedCounter = 0;
+    public ILoggerFactory LoggerFactory { get; }
+    public ITopicTransportStrategy TransportStrategy { get; }
+
+    public MomentoLocalTopicConfiguration(ILoggerFactory loggerFactory, ITopicTransportStrategy transportStrategy, MomentoLocalMiddlewareArgs? args)
+    {
+        _args = args;
+        Headers = this.CreateHeaders();
+        LoggerFactory = loggerFactory;
+        TransportStrategy = transportStrategy;
+    }
+
+    private IList<KeyValuePair<string, string>> CreateHeaders()
+    {
+        var headerMappings = new Dictionary<string, string?>
+        {
+            { "request-id", RequestId },
+            { "return-error", _args?.ReturnError },
+            { "error-rpcs", ConvertToMetadataList(_args?.ErrorRpcList) },
+            { "error-count", _args?.ErrorCount?.ToString() },
+            { "delay-rpcs", ConvertToMetadataList(_args?.DelayRpcList) },
+            { "delay-ms", _args?.DelayMillis?.ToString() },
+            { "delay-count", _args?.DelayCount?.ToString() },
+            { "stream-error-rpcs", ConvertToMetadataList(_args?.StreamErrorRpcList) },
+            { "stream-error", _args?.StreamError },
+            { "stream-error-message-limit", _args?.StreamErrorMessageLimit?.ToString() }
+        };
+
+        // Instantiate the KeyValuePair list item only if the value is not null.
+        var headers = new List<KeyValuePair<string, string>>();
+        foreach (var pair in headerMappings)
+        {
+            string key = pair.Key;
+            string? value = pair.Value;
+            {
+                if (value != null && value.Length > 0)
+                {
+                    headers.Add(new KeyValuePair<string, string>(key, value.ToString()));
+                }
+            }
+        }
+        return headers;
+    }
+
+    private string? ConvertToMetadataList(IList<string>? values)
+    {
+        if (values == null || values.Count == 0)
+        {
+            return null;
+        }
+        return string.Join(" ", values);
+    }
+
+    public void OnStreamDisconnected()
+    {
+        StreamDisconnectedCounter++;
+    }
+    public void onStreamEstablished()
+    {
+        StreamEstablishedCounter++;
+    }
+
+    public ITopicConfiguration WithTransportStrategy(ITopicTransportStrategy transportStrategy)
+    {
+        return new MomentoLocalTopicConfiguration(LoggerFactory, transportStrategy, _args);
+    }
+
+    public ITopicConfiguration WithClientTimeout(TimeSpan clientTimeout)
+    {
+        return new MomentoLocalTopicConfiguration(
+            loggerFactory: LoggerFactory,
+            transportStrategy: TransportStrategy.WithClientTimeout(clientTimeout),
+            args: _args
+        );
+    }
+}
+
+

--- a/tests/Integration/Momento.Sdk.Tests/Retry/utils/RetryTestUtils.cs
+++ b/tests/Integration/Momento.Sdk.Tests/Retry/utils/RetryTestUtils.cs
@@ -23,3 +23,22 @@ public class MomentoLocalCacheAndCacheClient
         CacheClient.CreateCacheAsync(CacheName).Wait();
     }
 }
+
+public class MomentoLocalCacheAndTopicClient
+{
+    public ICacheClient CacheClient { get; }
+    public ITopicClient TopicClient { get; }
+    public string CacheName { get; }
+    public TestRetryMetricsCollector TestMetricsCollector { get; }
+    public MomentoLocalTopicConfiguration TestTopicConfig { get; }
+
+    public MomentoLocalCacheAndTopicClient(ICredentialProvider authProvider, ILoggerFactory loggerFactory, IConfiguration cacheConfig, ITopicConfiguration topicConfig, MomentoLocalMiddlewareArgs? args)
+    {
+        TestTopicConfig = new MomentoLocalTopicConfiguration(loggerFactory, topicConfig.TransportStrategy, args);
+        TestMetricsCollector = new TestRetryMetricsCollector();
+        CacheClient = new CacheClient(cacheConfig, authProvider, TimeSpan.FromSeconds(60));
+        CacheName = Utils.NewGuidString();
+        CacheClient.CreateCacheAsync(CacheName).Wait();
+        TopicClient = new TopicClient(TestTopicConfig, authProvider);
+    }
+}


### PR DESCRIPTION
Closes https://github.com/momentohq/dev-eco-issue-tracker/issues/1189

`MomentoLocalTopicConfiguration` is a test-specific wrapper around `ITopicConfiguration`. It uses new interfaces defined in the new `Internal/TopicInterfaceExtensions` folder to be able to add momento-local headers and subscription connection state callbacks. It's used by the new topic retry tests defined in `TopicClientRetryTest.cs`.

This way, we can add/revise topics retry tests against momento-local without making any public-facing changes.

Other edits in this PR:

- Updated docker command in CI workflow file to be able to run the test admin client used by the topic retry tests.
- Carried over the `Tuple<string, string>` to `KeyValuePair<string, string>` change Michael had recommended on a previous PR.

Assuming this is merged, will rebase [Rishti's PR](https://github.com/momentohq/client-sdk-dotnet/pull/608) on this afterwards.